### PR TITLE
docs: update dev docs URL

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -64,7 +64,7 @@ any 'help wanted' issues is a great place to start.
 
 [See the documentation][dev-docs] for detailed development information.
 
-[dev-docs]: https://aws.github.io/aws-controllers-k8s/dev-docs/overview/
+[dev-docs]: https://aws-controllers-k8s.github.io/community/dev-docs/overview/
 
 ## Code of Conduct
 


### PR DESCRIPTION
Fixed old url to new domain (https://aws-controllers-k8s.github.io)