### PR TITLE
Downgrade PyYAML version 5.4 -> 5.3.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 boto3==1.16.40
 kubernetes==12.0.1
-PyYAML==5.4
+PyYAML==5.3.1


### PR DESCRIPTION
PyYAML 5.4 was attempting to use Cython to install the PyYAML Python bindings. This was causing reproducible build issues in our e2e test containers (which run alpine)