### PR TITLE
Add pytest to requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 boto3==1.16.40
 kubernetes==12.0.1
 PyYAML==5.4
+pytest-xdist==2.2.0


### PR DESCRIPTION
Adding `pytest-xdist` to the `test-infra` requirements removes the need to add it to each service controller's individual requirements file, and allows us to standardise on the version used by the `./run-tests.sh` script.