### PR TITLE
Allow postsubmitserviceaccount ecr-public:GetAuthorizationToken permissions.

### DIFF
--- a/infra/lib/prow-service-accounts.ts
+++ b/infra/lib/prow-service-accounts.ts
@@ -72,6 +72,13 @@ export class ProwServiceAccounts extends cdk.Construct {
       ],
     });
 
+    const postEcrPublicAllResourcePolicy = new iam.PolicyStatement({
+      actions: ["ecr-public:GetAuthorizationToken"],
+      resources: [
+        "*",
+      ],
+    });
+
     const postStsPolicy = new iam.PolicyStatement({
       actions: ["sts:GetServiceBearerToken"],
       resources: [
@@ -116,6 +123,7 @@ export class ProwServiceAccounts extends cdk.Construct {
     });
     this.postsubmitJobServiceAccount.addToPrincipalPolicy(postBucketAccessPolicy);
     this.postsubmitJobServiceAccount.addToPrincipalPolicy(postEcrPublicPolicy);
+    this.postsubmitJobServiceAccount.addToPrincipalPolicy(postEcrPublicAllResourcePolicy);
     this.postsubmitJobServiceAccount.addToPrincipalPolicy(postStsPolicy);
     new cdk.CfnOutput(scope, 'PostSubmitServiceAccountRoleOutput', {
       value: this.postsubmitJobServiceAccount.role.roleName,


### PR DESCRIPTION
Allow postsubmitserviceaccount ecr-public:GetAuthorizationToken permissions.

Earlier ecr-public Get* permissions were given on restricted resource set.
However ecr-public:GetAuthorizationToken permissions are required for * resource.

This PR adds those permissions.