### PR TITLE
Squash all PRs in Prow by default

### DIFF
--- a/prow/config/Chart.yaml
+++ b/prow/config/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: prow-config
 description: Configuration for the ACK Prow cluster
 type: application
-version: 0.1.1
+version: 0.1.2
 appVersion: "1.16.0"

--- a/prow/config/templates/config-ConfigMap.yaml
+++ b/prow/config/templates/config-ConfigMap.yaml
@@ -83,8 +83,14 @@ data:
             sidecar: {{ .Values.utility_images.sidecar }}
 
     tide:
+      merge_commit_template:
+        "{{ .Values.github.organisation }}":
+          body: >-
+              {{ "{{ .Title }}" }}
+          title: >-
+              {{ "{{ .Body }}" }}
       merge_method:
-        "*": "squash"
+        "{{ .Values.github.organisation }}": "squash"
       queries:
       - labels:
         - lgtm


### PR DESCRIPTION
Fixes the config to specify to squash all ACK repository PRs