### PR TITLE
Fix merge commit body and title positions

### DIFF
--- a/prow/config/templates/config-ConfigMap.yaml
+++ b/prow/config/templates/config-ConfigMap.yaml
@@ -86,9 +86,9 @@ data:
       merge_commit_template:
         "{{ .Values.github.organisation }}":
           body: >-
-              {{ "{{ .Title }}" }}
-          title: >-
               {{ "{{ .Body }}" }}
+          title: >-
+              {{ "{{ .Title }}" }}
       merge_method:
         "{{ .Values.github.organisation }}": "squash"
       queries:


### PR DESCRIPTION
Accidentally swapped body and title positions in the original PR. This was pushing the first line of the description into the title of the squash commit. See https://github.com/aws-controllers-k8s/dev-tools/commit/46d5909a1d4003d2930d20f2befbe941af2c32a9