### PR TITLE
Add PR number to commit title

### DIFF
--- a/prow/config/Chart.yaml
+++ b/prow/config/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: prow-config
 description: Configuration for the ACK Prow cluster
 type: application
-version: 0.1.2
+version: 0.1.3
 appVersion: "1.16.0"

--- a/prow/config/templates/config-ConfigMap.yaml
+++ b/prow/config/templates/config-ConfigMap.yaml
@@ -88,7 +88,7 @@ data:
           body: >-
               {{ "{{ .Body }}" }}
           title: >-
-              {{ "{{ .Title }}" }}
+              {{ "{{ .Title }} (#{{ .Number }})" }}
       merge_method:
         "{{ .Values.github.organisation }}": "squash"
       queries:


### PR DESCRIPTION
Adds the PR number into the commit title (to mirror Github's default squash commit title message)

e.g. `Add PR number to commit title (#29)`
- Incremented prow config number to push through latest changes