### PR TITLE
Pass `PYTEST_LOG_LEVEL` through to e2e container

### DIFF
--- a/scripts/build-run-test-dockerfile.sh
+++ b/scripts/build-run-test-dockerfile.sh
@@ -50,6 +50,7 @@ docker run --rm -t \
     -v $THIS_DIR:/root/tests:z \
     -e SERVICE_CONTROLLER_E2E_TEST_PATH="." \
     -e RUN_PYTEST_LOCALLY="true" \
+    -e PYTEST_LOG_LEVEL \
     -e AWS_DEFAULT_REGION="${AWS_DEFAULT_REGION:-"us-west-2"}" \
     -e AWS_ACCESS_KEY_ID \
     -e AWS_SECRET_ACCESS_KEY \

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -10,7 +10,7 @@ ROOT_DIR="$SCRIPTS_DIR/.."
 # set environment variables
 SKIP_PYTHON_TESTS=${SKIP_PYTHON_TESTS:-"false"}
 RUN_PYTEST_LOCALLY=${RUN_PYTEST_LOCALLY:-"false"}
-PYTEST_LOG_LEVEL="${PYTEST_LOG_LEVEL:-"INFO"}"
+PYTEST_LOG_LEVEL=$(echo "${PYTEST_LOG_LEVEL:-"info"}" | tr '[:upper:]' '[:lower:]')
 
 USAGE="
 Usage:
@@ -28,7 +28,7 @@ Environment variables:
                             inside Docker (<true|false>)
                             Default: false
   PYTEST_LOG_LEVEL:         Set to any Python logging level for the Python tests.
-                            Default: INFO
+                            Default: info
 "
 
 if [ $# -ne 1 ]; then
@@ -79,7 +79,8 @@ elif [[ "$RUN_PYTEST_LOCALLY" == "true" ]]; then
     python service_bootstrap.py
     set +e
 
-    pytest -n auto --dist loadfile --log-cli-level "${PYTEST_LOG_LEVEL}" .
+    pytest -n auto --dist loadfile -o log_cli=true \
+      --log-cli-level "${PYTEST_LOG_LEVEL}" --log-level "${PYTEST_LOG_LEVEL}" .
     test_exit_code=$?
 
     python service_cleanup.py


### PR DESCRIPTION
Fixes https://github.com/aws-controllers-k8s/community/issues/791

Ensures the `pytest` command correctly registers the desired `PYTEST_LOG_LEVEL` in local mode and from within the e2e container.