### PR TITLE
remove old bind-mount from dockerized test launch

### DIFF
--- a/scripts/build-run-test-dockerfile.sh
+++ b/scripts/build-run-test-dockerfile.sh
@@ -47,7 +47,6 @@ docker run --rm -t \
     --network="host" \
     -v $KUBECONFIG_LOCATION:/root/.kube/config:z \
     -v $HOME/.aws/credentials:/root/.aws/credentials:z \
-    -v $THIS_DIR:/root/tests:z \
     -e SERVICE_CONTROLLER_E2E_TEST_PATH="." \
     -e RUN_PYTEST_LOCALLY="true" \
     -e PYTEST_LOG_LEVEL \


### PR DESCRIPTION
When moving the kind-build-test script infrastructure from community
repo to test-infra, we brought over the scripts as they worked with the
previous monorepo. Recall that the previous monorepo had all the e2e
tests in a single `test/e2e/{$SERVICE}` directory. Previously, when
launching the docker image containing the e2e tests, we needed to
bind-mount the `test/e2e/{$SERVICE}` directory as `/root/test` in the
testing container:

```
-v $THIS_DIR:/root/tests:z
```

This is not necessary anymore after we split out the service controller
repositories and now have e2e tests in each service controller
repository. The following environment variable in the
`build-run-test-dockerfile.sh` script accomplishes the same thing:

```
    -e SERVICE_CONTROLLER_E2E_TEST_PATH="."
```

The old reference to a non-existing `$THIS_DIR` variable was causing
failures in the kind build test resulting in
aws-controllers-k8s/community#817. Removing this line fixes the issue.

Fixes aws-controllers-k8s/community#817