### PR TITLE
Optional SSM agent and PVRE reporting

### DIFF
--- a/flux/ssm-agent.yaml
+++ b/flux/ssm-agent.yaml
@@ -1,0 +1,14 @@
+apiVersion: kustomize.toolkit.fluxcd.io/v1beta1
+kind: Kustomization
+metadata:
+  name: ssm-agent
+  namespace: flux-system
+spec:
+  interval: 5m
+  sourceRef:
+    kind: GitRepository
+    name: test-infra
+  path: ./prow/ssm-agent
+  prune: true
+  targetNamespace: default
+  validation: client

--- a/infra/bin/test-ci.ts
+++ b/infra/bin/test-ci.ts
@@ -23,5 +23,6 @@ new TestCIStack(app, 'TestCIStack', {
     botPersonalAccessToken: app.node.tryGetContext('bot_pat') || process.env.BOT_PAT,
     webhookHMACToken: app.node.tryGetContext('webhook_hmac') || process.env.WEBHOOK_HMAC
   },
-  logsBucketName: app.node.tryGetContext('logs_bucket') || process.env.LOGS_BUCKET
+  logsBucketName: app.node.tryGetContext('logs_bucket') || process.env.LOGS_BUCKET,
+  pvreBucketName: app.node.tryGetContext('pvre_bucket') || process.env.PVRE_BUCKET,
 });

--- a/infra/lib/ssm.ts
+++ b/infra/lib/ssm.ts
@@ -1,0 +1,56 @@
+import * as cdk from '@aws-cdk/core';
+import * as eks from '@aws-cdk/aws-eks';
+import * as iam from '@aws-cdk/aws-iam';
+import * as ssm from '@aws-cdk/aws-ssm';
+
+export type ClusterSSMCompileProps = {
+  pvreBucketName?: string;
+}
+
+export type ClusterSSMRuntimeProps = {
+  account: string;
+  region: string;
+  cluster: eks.Cluster;
+}
+
+export type ClusterSSMProps = ClusterSSMCompileProps & ClusterSSMRuntimeProps;
+
+export class ClusterSSM extends cdk.Construct {
+  constructor(scope: cdk.Construct, id: string, props: ClusterSSMProps) {
+    super(scope, id);
+
+    // Only install if PVRE bucket is configured (optional)
+    if (!props.pvreBucketName) {
+      return;
+    }
+
+    if (!props.cluster.defaultNodegroup) {
+      throw new Error("Expected default nodegroup for SSM configuration")
+    }
+
+    props.cluster.defaultNodegroup.role.addManagedPolicy(
+      iam.ManagedPolicy.fromAwsManagedPolicyName(
+        "AmazonSSMManagedInstanceCore"
+      )
+    );
+
+    new ssm.CfnAssociation(this, 'InventoryCollection', {
+      name: "AWS-GatherSoftwareInventory",
+      associationName: `${props.account}-InventoryCollection`,
+      scheduleExpression: "rate(12 hours)",
+      targets: [
+        {
+          key: "tag:eks:cluster-name",
+          values: [props.cluster.clusterName]
+        }
+      ]
+    });
+
+    new ssm.CfnResourceDataSync(this, 'PvreReporting', {
+      bucketName: props.pvreBucketName,
+      bucketRegion: props.region,
+      syncFormat: "JsonSerDe",
+      syncName: `${props.account}-PvreReporting`
+    });
+  }
+}

--- a/infra/lib/test-ci-stack.ts
+++ b/infra/lib/test-ci-stack.ts
@@ -1,13 +1,14 @@
 import * as cdk from '@aws-cdk/core';
 import { CICluster, CIClusterCompileTimeProps } from './ci-cluster';
 import { LogBucket, LogBucketCompileProps } from './log-bucket';
+import { ClusterSSM, ClusterSSMCompileProps } from './ssm';
 import { ProwServiceAccounts } from './prow-service-accounts';
 
 export const PROW_NAMESPACE = "prow";
 export const PROW_JOB_NAMESPACE = "test-pods";
 export const EXTERNAL_DNS_NAMESPACE = "external-dns";
 
-export type TestCIStackProps = cdk.StackProps & LogBucketCompileProps & {
+export type TestCIStackProps = cdk.StackProps & LogBucketCompileProps & ClusterSSMCompileProps & {
   clusterConfig: CIClusterCompileTimeProps
 };
 
@@ -23,6 +24,13 @@ export class TestCIStack extends cdk.Stack {
     const testCluster = new CICluster(this, 'CIClusterConstruct', {
       ...props.clusterConfig
     });
+
+    const clusterSSM = new ClusterSSM(this, 'CIClusterSSM', {
+      ...props,
+      account: this.account,
+      region: this.region,
+      cluster: testCluster.testCluster
+    })
 
     const prowServiceAccounts = new ProwServiceAccounts(this, 'ProwServiceAccountsConstruct', {
       account: this.account,

--- a/infra/test/test-ci.test.ts
+++ b/infra/test/test-ci.test.ts
@@ -10,7 +10,8 @@ test('Empty Stack', () => {
         botPersonalAccessToken: "abc123",
         webhookHMACToken: "def456"
       },
-      logsBucketName: "my-log-bucket"
+      logsBucketName: "my-log-bucket",
+      pvreBucketName: undefined
     });
     // THEN
     expectCDK(stack).to(matchTemplate({

--- a/prow/ssm-agent/kustomization.yaml
+++ b/prow/ssm-agent/kustomization.yaml
@@ -2,7 +2,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-- prow-config.yaml
-- prow-data-plane.yaml
-- prow-jobs.yaml
-- ssm-agent.yaml
+- ssm-DaemonSet.yaml

--- a/prow/ssm-agent/ssm-DaemonSet.yaml
+++ b/prow/ssm-agent/ssm-DaemonSet.yaml
@@ -1,0 +1,38 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  labels:
+    k8s-app: ssm-installer
+  name: ssm-installer
+  namespace: default
+spec:
+  selector:
+    matchLabels:
+      k8s-app: ssm-installer
+  template:
+    metadata:
+      labels:
+        k8s-app: ssm-installer    
+    spec:
+      containers:
+      - image: amazonlinux
+        imagePullPolicy: Always
+        name: ssm
+        command: ["/bin/bash"]
+        args: ["-c","echo '* * * * * root yum install -y https://s3.amazonaws.com/ec2-downloads-windows/SSMAgent/latest/linux_amd64/amazon-ssm-agent.rpm & rm -rf /etc/cron.d/ssmstart' > /etc/cron.d/ssmstart"]
+        securityContext:
+          allowPrivilegeEscalation: true
+        volumeMounts:
+        - mountPath: /etc/cron.d
+          name: cronfile    
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+      volumes:
+      - name: cronfile
+        hostPath:
+          path: /etc/cron.d
+          type: Directory  
+      dnsPolicy: ClusterFirst
+      restartPolicy: Always
+      schedulerName: default-scheduler
+      terminationGracePeriodSeconds: 30

--- a/prow/ssm-agent/ssm-DaemonSet.yaml
+++ b/prow/ssm-agent/ssm-DaemonSet.yaml
@@ -33,6 +33,6 @@ spec:
           path: /etc/cron.d
           type: Directory  
       dnsPolicy: ClusterFirst
-      restartPolicy: Always
+      restartPolicy: OnFailure
       schedulerName: default-scheduler
       terminationGracePeriodSeconds: 30

--- a/prow/ssm-agent/ssm-DaemonSet.yaml
+++ b/prow/ssm-agent/ssm-DaemonSet.yaml
@@ -19,7 +19,7 @@ spec:
         imagePullPolicy: Always
         name: ssm
         command: ["/bin/bash"]
-        args: ["-c","echo '* * * * * root yum install -y https://s3.amazonaws.com/ec2-downloads-windows/SSMAgent/latest/linux_amd64/amazon-ssm-agent.rpm & rm -rf /etc/cron.d/ssmstart' > /etc/cron.d/ssmstart"]
+        args: ["-c","echo '* * * * * root yum install -y https://s3.amazonaws.com/ec2-downloads-windows/SSMAgent/latest/linux_amd64/amazon-ssm-agent.rpm & rm -rf /etc/cron.d/ssmstart' > /etc/cron.d/ssmstart && tail -f /dev/null"]
         securityContext:
           allowPrivilegeEscalation: true
         volumeMounts:
@@ -33,6 +33,6 @@ spec:
           path: /etc/cron.d
           type: Directory  
       dnsPolicy: ClusterFirst
-      restartPolicy: OnFailure
+      restartPolicy: Always
       schedulerName: default-scheduler
       terminationGracePeriodSeconds: 30


### PR DESCRIPTION
Installs an SSM agent installer `DaemonSet` into the cluster that ensures all nodes have an Amazon SSM agent - taken from https://docs.aws.amazon.com/prescriptive-guidance/latest/patterns/install-ssm-agent-on-amazon-eks-worker-nodes-by-using-kubernetes-daemonset.html

Creates an SSM association for all cluster instances and a respective SSM DataSync for instance inventory collection.