### PR TITLE
Parallelize e2e runs on the test-level

### DIFF
--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -84,7 +84,7 @@ elif [[ "$RUN_PYTEST_LOCALLY" == "true" ]]; then
     python service_bootstrap.py
     set +e
 
-    pytest -n $PYTEST_NUM_THREADS --dist loadfile -o log_cli=true \
+    pytest -n $PYTEST_NUM_THREADS --dist no -o log_cli=true \
       --log-cli-level "${PYTEST_LOG_LEVEL}" --log-level "${PYTEST_LOG_LEVEL}" .
     test_exit_code=$?
 


### PR DESCRIPTION
Currently each thread executes a single test file (`--dist loadfile`). In the case of the ElastiCache controller, tests are organized by resource. Since the Replication Group resource contains the most tests and the longest-running tests, both the actual tests and the teardown are prone to fail due to credential expiration during Prow runs. Using the option `--dist no` should mitigate this issue, which other controllers may eventually run into as well.