### PR TITLE
Use soakconfig file for controlling soak test behavior

### DIFF
--- a/soak/Dockerfile
+++ b/soak/Dockerfile
@@ -10,11 +10,15 @@ ENV CONTROLLER_E2E_PATH ${CONTROLLER_E2E_PATH}
 
 WORKDIR /soak
 # Install dependencies for soak test environment
-RUN apk add --no-cache git bash gcc libc-dev
+RUN apk add --no-cache git bash gcc libc-dev curl \
+    && curl -L -s https://github.com/mikefarah/yq/releases/download/v4.9.6/yq_linux_amd64 --output /usr/bin/yq \
+    && chmod +x /usr/bin/yq
 
 # Copy the script to run soak tests.
 COPY run_soak_test.sh .
 RUN chmod +x run_soak_test.sh
+
+COPY default_soak_config.yaml .
 
 # Checkout the controller repository where e2e tests are present.
 # Soak test run consists of multiple runs of these e2e tests.

--- a/soak/default_soak_config.yaml
+++ b/soak/default_soak_config.yaml
@@ -1,0 +1,13 @@
+# Amount of time in minutes to execute long running soak test. Default 1 day = 1440 minutes
+durationMinutes: 1440
+# Map of pytest marker name to pytest command options
+# Soak test running container will execute pytest command for each of these markers sequentially from the e2e directory.
+# One example would be to run 'service' marker pytests followed by 'e2e_dangling_resource_cleanup'(example name) marker
+# to eliminate piling of dangling resources from e2e test runs, since soak test runner will be executing e2e tests
+# continuously for 24 hours.
+pytestMarkers:
+  # For default soak config, only run e2e tests continuously
+  service:
+    logLevel: info
+    numThreads: auto
+    dist: no

--- a/soak/helm/ack-soak-test/templates/job.yaml
+++ b/soak/helm/ack-soak-test/templates/job.yaml
@@ -18,13 +18,14 @@ spec:
       containers:
         - name: soak-test
           image: {{ .Values.soak.imageRepo }}:{{ .Values.soak.imageTag }}
+          imagePullPolicy: Always
           command: ["bash", "-c", "./run_soak_test.sh"]
           env:
             - name: LOAD_IN_CLUSTER_KUBECONFIG # This variable makes sure e2e tests run against local k8s cluster
               value: "True"
             - name: START_TIME_EPOCH_SECONDS
               value: {{ .Values.soak.startTimeEpochSeconds | quote }}
-            - name: SOAK_TEST_DURATION_MINUTES
+            - name: DEFAULT_SOAK_DURATION_MINUTES
               value: {{ .Values.soak.durationMinutes | quote }}
             - name: AWS_DEFAULT_REGION
               value: {{ .Values.awsRegion | quote }}

--- a/soak/prow/README.md
+++ b/soak/prow/README.md
@@ -114,3 +114,8 @@ triggered.
       # For ACK core contributors
       aws ssm put-parameter --name "/ack/prow/soak/irsa/$SERVICE" --type String --value <provided-value> 
       ```
+
+6. By default, the soak-runner uses the [default configuration](https://github.com/aws-controllers-k8s/test-infra/blob/main/soak/default_soak_config.yaml)
+   i.e. run e2e tests continuously for 24 hours. To provide custom behavior for soak tests, create a file in service-controller
+   repository at "test/e2e/soak_config.yaml". Take a look at [default configuration](https://github.com/aws-controllers-k8s/test-infra/blob/main/soak/default_soak_config.yaml)
+   for sample configuration.

--- a/soak/run_soak_test.sh
+++ b/soak/run_soak_test.sh
@@ -2,9 +2,17 @@
 
 set -eo pipefail
 
-PYTEST_LOG_LEVEL=$(echo "${PYTEST_LOG_LEVEL:-"info"}" | tr '[:upper:]' '[:lower:]')
-PYTEST_NUM_THREADS=${PYTEST_NUM_THREADS:-"auto"}
-SOAK_TEST_DURATION_MINUTES="${SOAK_TEST_DURATION_MINUTES:-90}"
+DEFAULT_SOAK_CONFIG_PATH="$(pwd)/default_soak_config.yaml"
+CONTROLLER_SOAK_CONFIG_PATH="$CONTROLLER_E2E_PATH/soak_config.yaml"
+DEFAULT_SOAK_DURATION_MINUTES=${DEFAULT_SOAK_DURATION_MINUTES:-"1440"}
+
+if [[ -f "$CONTROLLER_SOAK_CONFIG_PATH" ]]; then
+	SOAK_CONFIG_PATH=$CONTROLLER_SOAK_CONFIG_PATH
+else
+	SOAK_CONFIG_PATH=$DEFAULT_SOAK_CONFIG_PATH
+fi
+
+echo "Using soak configuration stored at $SOAK_CONFIG_PATH"
 
 USAGE="
 Usage:
@@ -12,29 +20,35 @@ Usage:
 
 Environment variables:
   START_TIME_EPOCH_SECONDS:   Start time of soak test run in seconds from epoch.
-  SOAK_TEST_DURATION_MINUTES: Number of minutes to run soak test. Default: 90 minutes
   CONTROLLER_E2E_PATH:        Path where e2e tests reside for ack service controller.
-  PYTEST_LOG_LEVEL:           Set to any Python logging level for the Python tests.
-                              Default: info
+  DEFAULT_SOAK_DURATION_MINUTES: Default duration of soak test execution in minutes.
 "
 
+SOAK_DURATION_MINUTES=$(yq eval ".durationMinutes // \"$DEFAULT_SOAK_DURATION_MINUTES\"" $SOAK_CONFIG_PATH) #default: $DEFAULT_SOAK_DURATION_MINUTES
 echo "[INFO] Starting the soak test run."
 echo "[INFO] START_TIME_EPOCH_SECONDS is $START_TIME_EPOCH_SECONDS"
-((END_TIME_EPOCH_SECONDS= "$START_TIME_EPOCH_SECONDS" + "$SOAK_TEST_DURATION_MINUTES"*60))
+((END_TIME_EPOCH_SECONDS= "$START_TIME_EPOCH_SECONDS" + "$SOAK_DURATION_MINUTES"*60))
 echo "[INFO] END_TIME_EPOCH_SECONDS is $END_TIME_EPOCH_SECONDS"
 
 pushd "${CONTROLLER_E2E_PATH}" 1>/dev/null
 # Treat e2e directory as a module to run bootstrap as scripts
 export PYTHONPATH=..
 python service_bootstrap.py
+set +e
+ALL_PYTEST_MARKERS=$(yq eval '.pytestMarkers|keys|.[]' $SOAK_CONFIG_PATH)
 #If current time is less than $END_TIME_EPOCH_SECONDS, keep executing the e2e tests.
 while [ $(date +%s) -le $END_TIME_EPOCH_SECONDS ]
 do
   echo "[INFO] Current time is $(date +%s%3N) and end time is $END_TIME_EPOCH_SECONDS in epoch seconds. Executing e2e tests..."
-  set +e
-  pytest -n $PYTEST_NUM_THREADS --dist loadfile -o log_cli=true \
-      --log-cli-level "${PYTEST_LOG_LEVEL}" --log-level "${PYTEST_LOG_LEVEL}" .
+  for marker in `echo $ALL_PYTEST_MARKERS`
+  do
+	  log_level=$(yq eval ".pytestMarkers.$marker.logLevel // \"info\"" $SOAK_CONFIG_PATH) #default: info
+	  num_threads=$(yq eval ".pytestMarkers.$marker.numThreads // \"auto\"" $SOAK_CONFIG_PATH) #default: auto
+	  dist=$(yq eval ".pytestMarkers.$marker.dist // \"no\"" $SOAK_CONFIG_PATH) # default: no
+	  pytest -m $marker -n $num_threads --dist $dist -o log_cli=true --log-cli-level $log_level --log-level $log_level .
+  done
 done
+
 python service_cleanup.py
 set -eo pipefail
 popd 1> /dev/null


### PR DESCRIPTION
issue https://github.com/aws-controllers-k8s/community/issues/832
* Updating soak-runner image to include 'yq' tool and 'default_soak_config.yaml' file
* Adding a 'default_soak_config.yaml' file to provide default soak test behavior. (24 hours continuous e2e tests)
* Always pull soak-runner image in soak-cluster because this image is built and updated by prow on every soak run.
* Add instructions for service teams to configure custom soak behavior
* Execute pytest with marker option for providing custom behavior.