### PR TITLE
Migrate bootstrap resources to OOP style

### DIFF
--- a/src/acktest/bootstrapping/__init__.py
+++ b/src/acktest/bootstrapping/__init__.py
@@ -84,6 +84,18 @@ class Bootstrappable(abc.ABC):
             yield attr
 
     def _bootstrap_subresources(self):
+        """Iterates through every `Bootstrappable` field and attempts to 
+            bootstrap it for a given number of retries.
+
+        If the bootstrapping fails, it will attempt to cleanup the previous 
+        attempt's subresources and try again. After reaching the maximum number
+        of retries, it will clean up any resources that were successfully 
+        bootstrapped and then fail with a `BootstrapFailureException`.
+
+        Raises:
+            BootstrapFailureException: If bootstrapping attempts reached the 
+                maximum number of retries.
+        """
         bootstrapped = []
         for resource in self.iter_bootstrappable:
             should_cleanup = True
@@ -121,6 +133,13 @@ class Bootstrappable(abc.ABC):
         self._cleanup_resources(self.iter_bootstrappable)
 
     def _cleanup_resources(self, resources: Iterable[Bootstrappable]):
+        """Iterates through the given list of resources and attempts to clean
+            them up for a given number of retries.
+
+        Args:
+            resources (Iterable[Bootstrappable]): The resources to attempt to 
+                clean up.
+        """
         # Iterate through list in reverse order, so that resources created last
         # (with the most dependencies) are the first to be deleted
         for resource in reversed(list(resources)):

--- a/src/acktest/bootstrapping/__init__.py
+++ b/src/acktest/bootstrapping/__init__.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+import abc
+import pickle
+import logging
+
+from pathlib import Path
+from dataclasses import dataclass, fields
+from typing import Iterator
+
+@dataclass
+class ServiceBootstrapResources(abc.ABC):
+    """Represents a list of all bootstrappable resources required for a given
+    service's tests.
+    """
+    def serialize(self, output_path: Path, bootstrap_file_name: str = "bootstrap.pkl"):
+        """ Dumps the service bootstrap into a pickle file at a given path.
+
+        Args:
+            bootstrap: The bootstrap object.
+            output_path: The directory in which to dump the bootstrap pickle.
+            bootstrap_file_name: The name of the created bootstrap pickle file.
+        """
+        path =  output_path / bootstrap_file_name
+        with open(path, "wb") as stream:
+            pickle.dump(self, stream)
+        logging.info(f"Wrote bootstrap to {path}")
+
+    @classmethod
+    def deseralize(cls, config_dir: Path, bootstrap_file_name: str = "bootstrap.pkl") -> ServiceBootstrapResources:
+        """ Reads a service bootstrap from a given bootstrap pickle file.
+
+        Args:
+            config_dir: The directory in which the bootstray yaml exists.
+            bootstrap_file_name: The name of the created bootstrap yaml file.
+
+        Returns:
+            ServiceBootstrapResources: The servicebootstrap resources read from
+                the file.
+        """
+        path = config_dir / bootstrap_file_name
+        with open(path, "rb") as stream:
+            bootstrap = pickle.load(stream)
+        return bootstrap
+
+    @property
+    def bootstrappable_field_values(self) -> Iterator[BootstrappableResource]:
+        """Iterates over the values of each field that extends the 
+            `BootstrappableResource` type
+
+        Yields:
+            Iterator[BootstrappableResource]: A field value.
+        """
+        for field in fields(self):
+            if not issubclass(field.type, BootstrappableResource):
+                continue
+
+            yield getattr(self, field.name)
+
+    def bootstrap(self):
+        """Runs the `bootstrap` method for every `BootstrappableResource` 
+            subclass in the bootstrap dictionary.
+        """
+        logging.info("🛠️ Bootstrapping resources ...")
+        for resource in self.bootstrappable_field_values:
+            resource.bootstrap()
+
+    def cleanup(self):
+        """Runs the `cleanup` method for every `BootstrappableResource` 
+            subclass in the bootstrap dictionary.
+        """
+        logging.info("🧹 Cleaning up resources ...")
+        for resource in self.bootstrappable_field_values:
+            resource.cleanup()
+
+@dataclass
+class BootstrappableResource(abc.ABC):
+    """Represents a single bootstrappable resource.
+    """
+    
+    @abc.abstractmethod
+    def bootstrap(self):
+        pass
+
+    @abc.abstractmethod
+    def cleanup(self):
+        pass

--- a/src/acktest/bootstrapping/__init__.py
+++ b/src/acktest/bootstrapping/__init__.py
@@ -47,6 +47,7 @@ class Serializable:
 class Bootstrappable(abc.ABC):
     """Represents a single bootstrappable resource.
     """
+    region_override: str
     
     @abc.abstractmethod
     def bootstrap(self):
@@ -58,7 +59,7 @@ class Bootstrappable(abc.ABC):
 
     @property
     def region(self):
-        return get_region()
+        return get_region() if self.region_override is None else self.region_override
 
 @dataclass
 class Resources(Serializable, Bootstrappable):

--- a/src/acktest/bootstrapping/iam.py
+++ b/src/acktest/bootstrapping/iam.py
@@ -30,14 +30,6 @@ class Role(BootstrappableResource):
     
     def bootstrap(self):
         """Creates an IAM role with an auto-generated name.
-
-        Args:
-            name_prefix (str): The prefix for the auto-generated name.
-            principal_service (str): The service principal that is allowed to assume
-                the role.
-            policies (List[str]): A list of IAM policy ARNs that are attached to the
-                the role.
-            description (str, optional): The role description. Defaults to "".
         """
         region = get_region()
         role_name = resources.random_suffix_name(self.name_prefix, 63)

--- a/src/acktest/bootstrapping/iam.py
+++ b/src/acktest/bootstrapping/iam.py
@@ -67,7 +67,6 @@ class Role(Bootstrappable):
         # resulting in failure that role is not present. So adding a delay
         # to allow for the role to become available
         time.sleep(ROLE_CREATE_WAIT_IN_SECONDS)
-        logging.info(f"Created role {resource_arn}")
 
         self.arn = resource_arn
 
@@ -89,5 +88,3 @@ class Role(Bootstrappable):
                 RoleName=role_name, InstanceProfileName=each["InstanceProfileName"]
             )
         self.iam_client.delete_role(RoleName=role_name)
-
-        logging.info(f"Deleted role {role_name}")

--- a/src/acktest/bootstrapping/iam.py
+++ b/src/acktest/bootstrapping/iam.py
@@ -1,0 +1,102 @@
+import boto3
+import logging
+import json
+import re
+import time
+
+from dataclasses import dataclass, field
+from typing import List
+
+from . import BootstrappableResource
+from .. import resources
+from ..aws.identity import get_region
+
+# Regex to match the role name from a role ARN
+ROLE_ARN_REGEX = r"^arn:aws:iam::\d{12}:(?:root|user|role\/([A-Za-z0-9-]+))$"
+
+# Time to wait (in seconds) after a role is created
+ROLE_CREATE_WAIT_IN_SECONDS = 3
+
+@dataclass
+class Role(BootstrappableResource):
+    # Inputs
+    name_prefix: str
+    principal_service: str
+    policies: List[str]
+    description: str = ""
+
+    # Outputs
+    arn: str = field(default="", init=False)
+    
+    def bootstrap(self):
+        """Creates an IAM role with an auto-generated name.
+
+        Args:
+            name_prefix (str): The prefix for the auto-generated name.
+            principal_service (str): The service principal that is allowed to assume
+                the role.
+            policies (List[str]): A list of IAM policy ARNs that are attached to the
+                the role.
+            description (str, optional): The role description. Defaults to "".
+        """
+        region = get_region()
+        role_name = resources.random_suffix_name(self.name_prefix, 63)
+        iam = boto3.client("iam", region_name=region)
+
+        iam.create_role(
+            RoleName=role_name,
+            AssumeRolePolicyDocument=json.dumps(
+                {
+                    "Version": "2012-10-17",
+                    "Statement": [
+                        {
+                            "Effect": "Allow",
+                            "Principal": {"Service": self.principal_service},
+                            "Action": "sts:AssumeRole",
+                        }
+                    ],
+                }
+            ),
+            Description=self.description,
+        )
+
+        for policy in self.policies:
+            iam.attach_role_policy(
+                RoleName=role_name,
+                PolicyArn=policy,
+            )
+
+        iam_resource = iam.get_role(RoleName=role_name)
+        resource_arn = iam_resource["Role"]["Arn"]
+
+        # There appears to be a delay in role availability after role creation
+        # resulting in failure that role is not present. So adding a delay
+        # to allow for the role to become available
+        time.sleep(ROLE_CREATE_WAIT_IN_SECONDS)
+        logging.info(f"Created role {resource_arn}")
+
+        self.arn = resource_arn
+
+    def cleanup(self):
+        """Deletes an IAM role.
+        """
+        region = get_region()
+        iam = boto3.client("iam", region_name=region)
+
+        role_name = re.match(ROLE_ARN_REGEX, self.arn).group(1)
+        managedPolicy = iam.list_attached_role_policies(RoleName=role_name)
+        for each in managedPolicy["AttachedPolicies"]:
+            iam.detach_role_policy(RoleName=role_name, PolicyArn=each["PolicyArn"])
+
+        inlinePolicy = iam.list_role_policies(RoleName=role_name)
+        for each in inlinePolicy["PolicyNames"]:
+            iam.delete_role_policy(RoleName=role_name, PolicyName=each)
+
+        instanceProfiles = iam.list_instance_profiles_for_role(RoleName=role_name)
+        for each in instanceProfiles["InstanceProfiles"]:
+            iam.remove_role_from_instance_profile(
+                RoleName=role_name, InstanceProfileName=each["InstanceProfileName"]
+            )
+        iam.delete_role(RoleName=role_name)
+
+        logging.info(f"Deleted role {role_name}")

--- a/src/acktest/bootstrapping/s3.py
+++ b/src/acktest/bootstrapping/s3.py
@@ -1,0 +1,51 @@
+import boto3
+import logging
+import json
+import re
+import time
+
+from dataclasses import dataclass, field
+from typing import List
+
+from . import BootstrappableResource
+from .. import resources
+from ..aws.identity import get_region, get_account_id
+
+@dataclass
+class Bucket(BootstrappableResource):
+    # Inputs
+    name_prefix: str
+
+    # Outputs
+    name: str = field(init=False)
+    
+    def bootstrap(self):
+        """Creates an S3 bucket with an auto-generated name.
+
+        Args:
+            name_prefix (str): The prefix for the auto-generated name.
+        """
+        region = get_region()
+        self.name = resources.random_suffix_name(self.name_prefix, 63)
+
+        s3 = boto3.client("s3", region_name=region)
+        if region == "us-east-1":
+            s3.create_bucket(Bucket=self.name)
+        else:
+            s3.create_bucket(
+                Bucket=self.name, CreateBucketConfiguration={"LocationConstraint": region}
+            )
+
+        logging.info(f"Created bucket {self.name}")
+
+    def cleanup(self):
+        """Deletes an S3 bucket.
+        """
+        region = get_region()
+        s3_resource = boto3.resource("s3", region_name=region)
+
+        bucket = s3_resource.Bucket(self.name)
+        bucket.objects.all().delete()
+        bucket.delete()
+
+        logging.info(f"Deleted data bucket {self.name}")

--- a/src/acktest/bootstrapping/s3.py
+++ b/src/acktest/bootstrapping/s3.py
@@ -21,9 +21,6 @@ class Bucket(BootstrappableResource):
     
     def bootstrap(self):
         """Creates an S3 bucket with an auto-generated name.
-
-        Args:
-            name_prefix (str): The prefix for the auto-generated name.
         """
         region = get_region()
         self.name = resources.random_suffix_name(self.name_prefix, 63)
@@ -48,4 +45,4 @@ class Bucket(BootstrappableResource):
         bucket.objects.all().delete()
         bucket.delete()
 
-        logging.info(f"Deleted data bucket {self.name}")
+        logging.info(f"Deleted bucket {self.name}")

--- a/src/acktest/bootstrapping/s3.py
+++ b/src/acktest/bootstrapping/s3.py
@@ -35,13 +35,9 @@ class Bucket(Bootstrappable):
                 Bucket=self.name, CreateBucketConfiguration={"LocationConstraint": self.region}
             )
 
-        logging.info(f"Created bucket {self.name}")
-
     def cleanup(self):
         """Deletes an S3 bucket.
         """
         bucket = self.s3_resource.Bucket(self.name)
         bucket.objects.all().delete()
         bucket.delete()
-
-        logging.info(f"Deleted bucket {self.name}")

--- a/src/acktest/bootstrapping/vpc.py
+++ b/src/acktest/bootstrapping/vpc.py
@@ -103,7 +103,7 @@ class VPC(Bootstrappable):
         vpc = self.ec2_resource.Vpc(self.vpc_id)
 
         for subnet in self.public_subnet_ids + self.private_subnet_ids:
-            ec2.delete_subnet(SubnetId=subnet)
+            self.ec2_client.delete_subnet(SubnetId=subnet)
 
             logging.info(f"Deleted subnet {self.name}")
 

--- a/src/acktest/bootstrapping/vpc.py
+++ b/src/acktest/bootstrapping/vpc.py
@@ -1,0 +1,175 @@
+from typing import List, Union
+import boto3
+import logging
+
+from dataclasses import dataclass, field
+
+from . import BootstrappableResource
+from .. import resources
+from ..aws.identity import get_region
+
+# Subnets inside the default VPC CIDR block will be of form 10.0.*.0/24
+VPC_CIDR_BLOCK = "10.0.0.0/16"
+
+
+@dataclass
+class VPC(BootstrappableResource):
+    # Inputs
+    name_prefix: Union[str, None] = field(default=None)
+    public_subnets: int = 2
+    private_subnets: int = 0
+
+    vpc_cidr_block: str = field(default=VPC_CIDR_BLOCK)
+    public_subnet_cidr_blocks: Union[List[str], None] = field(default=None)
+    private_subnet_cidr_blocks: Union[List[str], None] = field(default=None)
+
+    # Outputs
+    name: Union[str, None] = field(default=None, init=False)
+    vpc_id: str = field(init=False)
+
+    internet_gateway_id: str = field(init=False)
+    public_route_table_id: str = field(init=False)
+    private_route_table_id: str = field(init=False)
+    public_subnet_ids: List[str] = field(init=False, default_factory=list)
+    private_subnet_ids: List[str] = field(init=False, default_factory=list)
+    
+    def bootstrap(self):
+        """Creates a VPC with an auto-generated name and any number of public
+           and private subnets.
+        """
+        region = get_region()
+        ec2_client = boto3.client("ec2", region_name=region)
+        ec2_resource = boto3.resource("ec2", region_name=region)
+
+        vpc = ec2_client.create_vpc(CidrBlock=self.vpc_cidr_block)
+
+        self.vpc_id = vpc['Vpc']['VpcId']
+        logging.info(f"Created VPC {self.vpc_id}")
+
+        if self.name_prefix is not None:
+            self.name = resources.random_suffix_name(self.name_prefix, 63)
+            ec2_client.create_tags(Resources=[self.vpc_id], Tags=[{'Key': 'Name', 'Value': self.name}])
+
+        vpc = ec2_resource.Vpc(self.vpc_id)
+        vpc.wait_until_available()
+
+        self._create_internet_gateway()
+        public_route_table = self._create_public_route_table()
+        self.public_route_table_id = public_route_table.id
+
+        subnet_count = 0
+        for i in range(self.public_subnets):
+            if self.public_subnet_cidr_blocks is None:
+                cidr_block = f"10.0.{subnet_count}.0/24"
+            else:
+                cidr_block = self.public_subnet_cidr_blocks[i]
+            subnet = vpc.create_subnet(CidrBlock=cidr_block)
+            self.public_subnet_ids.append(subnet.id)
+
+            ec2_client.associate_route_table(RouteTableId=public_route_table.id, SubnetId=subnet.id)
+
+            logging.info(f"Created public subnet {subnet.id}")
+            subnet_count += 1
+
+        if self.private_subnets == 0:
+            return
+
+        private_route_table = self._create_private_route_table()
+        self.private_route_table_id = private_route_table.id
+
+        for i in range(self.private_subnets):
+            if self.private_subnet_cidr_blocks is None:
+                cidr_block = f"10.0.{subnet_count}.0/24"
+            else:
+                cidr_block = self.private_subnet_cidr_blocks[i]
+            subnet = vpc.create_subnet(CidrBlock=cidr_block)
+            self.private_subnet_ids.append(subnet.id)
+
+            ec2_client.associate_route_table(RouteTableId=private_route_table.id, SubnetId=subnet.id)
+
+            logging.info(f"Created private subnet {subnet.id}")
+            subnet_count += 1
+
+    def cleanup(self):
+        """Deletes a VPC.
+        """
+        region = get_region()
+        ec2 = boto3.client("ec2", region_name=region)
+        ec2_resource = boto3.resource("ec2", region_name=region)
+
+        vpc = ec2_resource.Vpc(self.vpc_id)
+
+        for subnet in self.public_subnet_ids + self.private_subnet_ids:
+            ec2.delete_subnet(SubnetId=subnet)
+
+            logging.info(f"Deleted subnet {self.name}")
+
+        ec2.delete_route_table(RouteTableId=self.private_route_table_id)
+        ec2.delete_route_table(RouteTableId=self.public_route_table_id)
+
+        vpc.detach_internet_gateway(InternetGatewayId=self.internet_gateway_id)
+        ec2.delete_internet_gateway(InternetGatewayId=self.internet_gateway_id)
+
+        vpc.delete()
+
+        logging.info(f"Deleted VPC {self.name}")
+
+    @property
+    def route_tables(self):
+        region = get_region()
+        ec2 = boto3.resource("ec2", region_name=region)
+
+        return ec2.route_tables.filter(Filters=[{'Name': 'vpc-id', 'Values': [self.vpc_id]}])
+
+    def _get_public_route_table(self):
+        """Gets the public route table in the VPC if it exists, else None.
+        """
+        for route_table in self.route_tables:
+            for ra in route_table.routes_attribute:
+                if ra.get('DestinationCidrBlock') == '0.0.0.0/0' and ra.get('GatewayId') is not None:
+                    return ra
+        return None
+
+    def _get_private_route_table(self):
+        """Gets the private route table in the VPC if it exists, else None.
+        """
+        for route_table in self.route_tables:
+            for ra in route_table.routes_attribute:
+                if ra.get('DestinationCidrBlock') == '0.0.0.0/0' and ra.get('GatewayId') is None:
+                    return ra
+        return None
+
+    def _create_internet_gateway(self):
+        """Creates a private route table for the VPC.
+        """
+        region = get_region()
+        ec2_resource = boto3.resource("ec2", region_name=region)
+        vpc = ec2_resource.Vpc(self.vpc_id)
+
+        internet_gateway = ec2_resource.create_internet_gateway()
+        vpc.attach_internet_gateway(InternetGatewayId=internet_gateway.id)
+
+        self.internet_gateway_id = internet_gateway.id
+
+    def _create_public_route_table(self):
+        """Creates a private route table for the VPC.
+        """
+        region = get_region()
+        ec2_resource = boto3.resource("ec2", region_name=region)
+        vpc = ec2_resource.Vpc(self.vpc_id)
+
+        route_table = vpc.create_route_table()
+        route_table.create_route(DestinationCidrBlock='0.0.0.0/0', GatewayId=self.internet_gateway_id)
+
+        return route_table
+    
+    def _create_private_route_table(self):
+        """Creates a private route table for the VPC.
+        """
+        region = get_region()
+        ec2 = boto3.resource("ec2", region_name=region)
+        vpc = ec2.Vpc(self.vpc_id)
+
+        route_table = vpc.create_route_table()
+
+        return route_table

--- a/src/acktest/bootstrapping/vpc.py
+++ b/src/acktest/bootstrapping/vpc.py
@@ -2,10 +2,9 @@ from typing import List, Union
 import boto3
 import logging
 
-from boto3.session import Session
 from dataclasses import dataclass, field
 
-from . import BootstrappableResource
+from . import Bootstrappable
 from .. import resources
 from ..aws.identity import get_region
 
@@ -14,7 +13,7 @@ VPC_CIDR_BLOCK = "10.0.0.0/16"
 
 
 @dataclass
-class VPC(BootstrappableResource):
+class VPC(Bootstrappable):
     # Inputs
     name_prefix: Union[str, None] = field(default=None)
     public_subnets: int = 2
@@ -34,24 +33,29 @@ class VPC(BootstrappableResource):
     public_subnet_ids: List[str] = field(init=False, default_factory=list)
     private_subnet_ids: List[str] = field(init=False, default_factory=list)
     
+    @property
+    def ec2_client(self):
+        return boto3.client("ec2", region_name=self.region)
+
+    @property
+    def ec2_resource(self):
+        return boto3.resource("ec2", region_name=self.region)
+
+
     def bootstrap(self):
         """Creates a VPC with an auto-generated name and any number of public
            and private subnets.
         """
-        region = get_region()
-        ec2_client = boto3.client("ec2", region_name=region)
-        ec2_resource = boto3.resource("ec2", region_name=region)
-
-        vpc = ec2_client.create_vpc(CidrBlock=self.vpc_cidr_block)
+        vpc = self.ec2_client.create_vpc(CidrBlock=self.vpc_cidr_block)
 
         self.vpc_id = vpc['Vpc']['VpcId']
         logging.info(f"Created VPC {self.vpc_id}")
 
         if self.name_prefix is not None:
             self.name = resources.random_suffix_name(self.name_prefix, 63)
-            ec2_client.create_tags(Resources=[self.vpc_id], Tags=[{'Key': 'Name', 'Value': self.name}])
+            self.ec2_client.create_tags(Resources=[self.vpc_id], Tags=[{'Key': 'Name', 'Value': self.name}])
 
-        vpc = ec2_resource.Vpc(self.vpc_id)
+        vpc = self.ec2_resource.Vpc(self.vpc_id)
         vpc.wait_until_available()
 
         self._create_internet_gateway()
@@ -69,7 +73,7 @@ class VPC(BootstrappableResource):
             subnet = vpc.create_subnet(CidrBlock=cidr_block, AvailabilityZone=region_azs[subnet_count % len(region_azs)])
             self.public_subnet_ids.append(subnet.id)
 
-            ec2_client.associate_route_table(RouteTableId=public_route_table.id, SubnetId=subnet.id)
+            self.ec2_client.associate_route_table(RouteTableId=public_route_table.id, SubnetId=subnet.id)
 
             logging.info(f"Created public subnet {subnet.id}")
             subnet_count += 1
@@ -88,7 +92,7 @@ class VPC(BootstrappableResource):
             subnet = vpc.create_subnet(CidrBlock=cidr_block, AvailabilityZone=region_azs[subnet_count % len(region_azs)])
             self.private_subnet_ids.append(subnet.id)
 
-            ec2_client.associate_route_table(RouteTableId=private_route_table.id, SubnetId=subnet.id)
+            self.ec2_client.associate_route_table(RouteTableId=private_route_table.id, SubnetId=subnet.id)
 
             logging.info(f"Created private subnet {subnet.id}")
             subnet_count += 1
@@ -96,40 +100,30 @@ class VPC(BootstrappableResource):
     def cleanup(self):
         """Deletes a VPC.
         """
-        region = get_region()
-        ec2 = boto3.client("ec2", region_name=region)
-        ec2_resource = boto3.resource("ec2", region_name=region)
-
-        vpc = ec2_resource.Vpc(self.vpc_id)
+        vpc = self.ec2_resource.Vpc(self.vpc_id)
 
         for subnet in self.public_subnet_ids + self.private_subnet_ids:
             ec2.delete_subnet(SubnetId=subnet)
 
             logging.info(f"Deleted subnet {self.name}")
 
-        ec2.delete_route_table(RouteTableId=self.private_route_table_id)
-        ec2.delete_route_table(RouteTableId=self.public_route_table_id)
+        self.ec2_client.delete_route_table(RouteTableId=self.private_route_table_id)
+        self.ec2_client.delete_route_table(RouteTableId=self.public_route_table_id)
 
         vpc.detach_internet_gateway(InternetGatewayId=self.internet_gateway_id)
-        ec2.delete_internet_gateway(InternetGatewayId=self.internet_gateway_id)
+        self.ec2_client.delete_internet_gateway(InternetGatewayId=self.internet_gateway_id)
 
         vpc.delete()
 
         logging.info(f"Deleted VPC {self.name}")
 
     def get_availability_zone_names(self):
-        region = get_region()
-        ec2 = boto3.client("ec2", region_name=region)
-
-        zones = ec2.describe_availability_zones()
+        zones = self.ec2_client.describe_availability_zones()
         return list(map(lambda x: x['ZoneName'], zones['AvailabilityZones']))
 
     @property
     def route_tables(self):
-        region = get_region()
-        ec2 = boto3.resource("ec2", region_name=region)
-
-        return ec2.route_tables.filter(Filters=[{'Name': 'vpc-id', 'Values': [self.vpc_id]}])
+        return self.ec2_resource.route_tables.filter(Filters=[{'Name': 'vpc-id', 'Values': [self.vpc_id]}])
 
     def _get_public_route_table(self):
         """Gets the public route table in the VPC if it exists, else None.
@@ -152,11 +146,9 @@ class VPC(BootstrappableResource):
     def _create_internet_gateway(self):
         """Creates a private route table for the VPC.
         """
-        region = get_region()
-        ec2_resource = boto3.resource("ec2", region_name=region)
-        vpc = ec2_resource.Vpc(self.vpc_id)
+        vpc = self.ec2_resource.Vpc(self.vpc_id)
 
-        internet_gateway = ec2_resource.create_internet_gateway()
+        internet_gateway = self.ec2_resource.create_internet_gateway()
         vpc.attach_internet_gateway(InternetGatewayId=internet_gateway.id)
 
         self.internet_gateway_id = internet_gateway.id
@@ -164,9 +156,7 @@ class VPC(BootstrappableResource):
     def _create_public_route_table(self):
         """Creates a private route table for the VPC.
         """
-        region = get_region()
-        ec2_resource = boto3.resource("ec2", region_name=region)
-        vpc = ec2_resource.Vpc(self.vpc_id)
+        vpc = self.ec2_resource.Vpc(self.vpc_id)
 
         route_table = vpc.create_route_table()
         route_table.create_route(DestinationCidrBlock='0.0.0.0/0', GatewayId=self.internet_gateway_id)
@@ -176,9 +166,7 @@ class VPC(BootstrappableResource):
     def _create_private_route_table(self):
         """Creates a private route table for the VPC.
         """
-        region = get_region()
-        ec2 = boto3.resource("ec2", region_name=region)
-        vpc = ec2.Vpc(self.vpc_id)
+        vpc = self.ec2_resource.Vpc(self.vpc_id)
 
         route_table = vpc.create_route_table()
 

--- a/src/acktest/bootstrapping/vpc.py
+++ b/src/acktest/bootstrapping/vpc.py
@@ -1,38 +1,22 @@
 from typing import List, Union
 import boto3
-import logging
 
 from dataclasses import dataclass, field
 
-from . import Bootstrappable
+from . import BootstrapFailureException, Bootstrappable
 from .. import resources
-from ..aws.identity import get_region
 
 # Subnets inside the default VPC CIDR block will be of form 10.0.*.0/24
 VPC_CIDR_BLOCK = "10.0.0.0/16"
 
-
 @dataclass
-class VPC(Bootstrappable):
+class InternetGateway(Bootstrappable):
     # Inputs
-    name_prefix: Union[str, None] = field(default=None)
-    public_subnets: int = 2
-    private_subnets: int = 0
-
-    vpc_cidr_block: str = field(default=VPC_CIDR_BLOCK)
-    public_subnet_cidr_blocks: Union[List[str], None] = field(default=None)
-    private_subnet_cidr_blocks: Union[List[str], None] = field(default=None)
+    vpc_id: str
 
     # Outputs
-    name: Union[str, None] = field(default=None, init=False)
-    vpc_id: str = field(init=False)
-
     internet_gateway_id: str = field(init=False)
-    public_route_table_id: str = field(init=False)
-    private_route_table_id: str = field(init=False)
-    public_subnet_ids: List[str] = field(init=False, default_factory=list)
-    private_subnet_ids: List[str] = field(init=False, default_factory=list)
-    
+
     @property
     def ec2_client(self):
         return boto3.client("ec2", region_name=self.region)
@@ -41,110 +25,8 @@ class VPC(Bootstrappable):
     def ec2_resource(self):
         return boto3.resource("ec2", region_name=self.region)
 
-
     def bootstrap(self):
-        """Creates a VPC with an auto-generated name and any number of public
-           and private subnets.
-        """
-        vpc = self.ec2_client.create_vpc(CidrBlock=self.vpc_cidr_block)
-
-        self.vpc_id = vpc['Vpc']['VpcId']
-        logging.info(f"Created VPC {self.vpc_id}")
-
-        if self.name_prefix is not None:
-            self.name = resources.random_suffix_name(self.name_prefix, 63)
-            self.ec2_client.create_tags(Resources=[self.vpc_id], Tags=[{'Key': 'Name', 'Value': self.name}])
-
-        vpc = self.ec2_resource.Vpc(self.vpc_id)
-        vpc.wait_until_available()
-
-        self._create_internet_gateway()
-        public_route_table = self._create_public_route_table()
-        self.public_route_table_id = public_route_table.id
-
-        region_azs = self.get_availability_zone_names()
-
-        subnet_count = 0
-        for i in range(self.public_subnets):
-            if self.public_subnet_cidr_blocks is None:
-                cidr_block = f"10.0.{subnet_count}.0/24"
-            else:
-                cidr_block = self.public_subnet_cidr_blocks[i]
-            subnet = vpc.create_subnet(CidrBlock=cidr_block, AvailabilityZone=region_azs[subnet_count % len(region_azs)])
-            self.public_subnet_ids.append(subnet.id)
-
-            self.ec2_client.associate_route_table(RouteTableId=public_route_table.id, SubnetId=subnet.id)
-
-            logging.info(f"Created public subnet {subnet.id}")
-            subnet_count += 1
-
-        if self.private_subnets == 0:
-            return
-
-        private_route_table = self._create_private_route_table()
-        self.private_route_table_id = private_route_table.id
-
-        for i in range(self.private_subnets):
-            if self.private_subnet_cidr_blocks is None:
-                cidr_block = f"10.0.{subnet_count}.0/24"
-            else:
-                cidr_block = self.private_subnet_cidr_blocks[i]
-            subnet = vpc.create_subnet(CidrBlock=cidr_block, AvailabilityZone=region_azs[subnet_count % len(region_azs)])
-            self.private_subnet_ids.append(subnet.id)
-
-            self.ec2_client.associate_route_table(RouteTableId=private_route_table.id, SubnetId=subnet.id)
-
-            logging.info(f"Created private subnet {subnet.id}")
-            subnet_count += 1
-
-    def cleanup(self):
-        """Deletes a VPC.
-        """
-        vpc = self.ec2_resource.Vpc(self.vpc_id)
-
-        for subnet in self.public_subnet_ids + self.private_subnet_ids:
-            self.ec2_client.delete_subnet(SubnetId=subnet)
-
-            logging.info(f"Deleted subnet {self.name}")
-
-        self.ec2_client.delete_route_table(RouteTableId=self.private_route_table_id)
-        self.ec2_client.delete_route_table(RouteTableId=self.public_route_table_id)
-
-        vpc.detach_internet_gateway(InternetGatewayId=self.internet_gateway_id)
-        self.ec2_client.delete_internet_gateway(InternetGatewayId=self.internet_gateway_id)
-
-        vpc.delete()
-
-        logging.info(f"Deleted VPC {self.name}")
-
-    def get_availability_zone_names(self):
-        zones = self.ec2_client.describe_availability_zones()
-        return list(map(lambda x: x['ZoneName'], zones['AvailabilityZones']))
-
-    @property
-    def route_tables(self):
-        return self.ec2_resource.route_tables.filter(Filters=[{'Name': 'vpc-id', 'Values': [self.vpc_id]}])
-
-    def _get_public_route_table(self):
-        """Gets the public route table in the VPC if it exists, else None.
-        """
-        for route_table in self.route_tables:
-            for ra in route_table.routes_attribute:
-                if ra.get('DestinationCidrBlock') == '0.0.0.0/0' and ra.get('GatewayId') is not None:
-                    return ra
-        return None
-
-    def _get_private_route_table(self):
-        """Gets the private route table in the VPC if it exists, else None.
-        """
-        for route_table in self.route_tables:
-            for ra in route_table.routes_attribute:
-                if ra.get('DestinationCidrBlock') == '0.0.0.0/0' and ra.get('GatewayId') is None:
-                    return ra
-        return None
-
-    def _create_internet_gateway(self):
-        """Creates a private route table for the VPC.
+        """Creates an internet gateway.
         """
         vpc = self.ec2_resource.Vpc(self.vpc_id)
 
@@ -153,21 +35,178 @@ class VPC(Bootstrappable):
 
         self.internet_gateway_id = internet_gateway.id
 
-    def _create_public_route_table(self):
-        """Creates a private route table for the VPC.
+    def cleanup(self):
+        """Deletes an internet gateway.
         """
         vpc = self.ec2_resource.Vpc(self.vpc_id)
 
-        route_table = vpc.create_route_table()
-        route_table.create_route(DestinationCidrBlock='0.0.0.0/0', GatewayId=self.internet_gateway_id)
+        vpc.detach_internet_gateway(InternetGatewayId=self.internet_gateway_id)
+        self.ec2_client.delete_internet_gateway(InternetGatewayId=self.internet_gateway_id)
 
-        return route_table
-    
-    def _create_private_route_table(self):
-        """Creates a private route table for the VPC.
+@dataclass
+class RouteTable(Bootstrappable):
+    # Inputs
+    vpc_id: str
+    is_public: bool = False
+
+    # Subresources
+    internet_gateway: InternetGateway = field(init=False, default=None)
+
+    # Outputs
+    route_table_id: str = field(init=False)
+
+    def __post_init__(self):
+        if self.is_public:
+            self.internet_gateway = InternetGateway(self.vpc_id)
+
+    @property
+    def ec2_client(self):
+        return boto3.client("ec2", region_name=self.region)
+
+    @property
+    def ec2_resource(self):
+        return boto3.resource("ec2", region_name=self.region)
+
+    def bootstrap(self):
+        """Creates a route table.
         """
+        super().bootstrap()
+
         vpc = self.ec2_resource.Vpc(self.vpc_id)
 
         route_table = vpc.create_route_table()
+        self.route_table_id = route_table.id
 
-        return route_table
+        if self.is_public:
+            route_table.create_route(DestinationCidrBlock='0.0.0.0/0', GatewayId=self.internet_gateway.internet_gateway_id)
+
+    def cleanup(self):
+        """Deletes a route table.
+        """
+        super().cleanup()
+        
+        self.ec2_client.delete_route_table(RouteTableId=self.route_table_id)
+
+@dataclass
+class Subnets(Bootstrappable):
+    # Inputs
+    vpc_id: str
+    cidr_blocks: List[str]
+    is_public: bool = True
+    num_subnets: int = 1
+
+    # Subresources
+    route_table: RouteTable = field(init=False, default=None)
+
+    # Outputs
+    subnet_ids: List[str] = field(init=False, default_factory=lambda: [])
+
+    def __post_init__(self):
+        self.route_table = RouteTable(self.vpc_id, is_public=self.is_public)
+
+    @property
+    def ec2_client(self):
+        return boto3.client("ec2", region_name=self.region)
+
+    @property
+    def ec2_resource(self):
+        return boto3.resource("ec2", region_name=self.region)
+
+    def bootstrap(self):
+        """Creates subnets.
+        """
+        super().bootstrap()
+
+        vpc = self.ec2_resource.Vpc(self.vpc_id)
+        region_azs = self.get_availability_zone_names()
+
+        for i in range(self.num_subnets):
+            subnet = vpc.create_subnet(CidrBlock=self.cidr_blocks[i], AvailabilityZone=region_azs[i % len(region_azs)])
+            self.subnet_ids.append(subnet.id)
+
+            self.ec2_client.associate_route_table(RouteTableId=self.route_table.route_table_id, SubnetId=subnet.id)
+
+    def cleanup(self):
+        """Deletes the subnets.
+        """
+        # You must delete the subnet before you can delete any of its dependencies
+        for subnet in self.subnet_ids:
+            self.ec2_client.delete_subnet(SubnetId=subnet)
+
+        super().cleanup()
+
+    def get_availability_zone_names(self):
+        zones = self.ec2_client.describe_availability_zones()
+        return list(map(lambda x: x['ZoneName'], zones['AvailabilityZones']))
+
+@dataclass
+class VPC(Bootstrappable):
+    # Inputs
+    name_prefix: Union[str, None] = field(default=None)
+    num_public_subnet: int = 2
+    num_private_subnet: int = 0
+
+    vpc_cidr_block: str = field(default=VPC_CIDR_BLOCK)
+    public_subnet_cidr_blocks: Union[List[str], None] = field(default=None)
+    private_subnet_cidr_blocks: Union[List[str], None] = field(default=None)
+
+    # Subresources
+    public_subnets: Subnets = field(init=False, default=None)
+    private_subnets: Subnets = field(init=False, default=None)
+
+    # Outputs
+    name: Union[str, None] = field(default=None, init=False)
+    vpc_id: str = field(init=False)
+
+    def __post_init__(self):
+        # Create CIDR blocks if none specified
+        if self.public_subnet_cidr_blocks is None:
+            self.public_subnet_cidr_blocks = [f"10.0.{r}.0/24" for r in range(self.num_public_subnet)]
+
+        if self.private_subnet_cidr_blocks is None:
+            self.private_subnet_cidr_blocks = [f"10.0.{r}.0/24" for r in range(self.num_public_subnet, self.num_private_subnet + self.num_public_subnet)]
+
+    @property
+    def ec2_client(self):
+        return boto3.client("ec2", region_name=self.region)
+
+    @property
+    def ec2_resource(self):
+        return boto3.resource("ec2", region_name=self.region)
+
+    def bootstrap(self):
+        """Creates a VPC with an auto-generated name and any number of public
+           and private subnets.
+        """
+        vpc = self.ec2_client.create_vpc(CidrBlock=self.vpc_cidr_block)
+
+        self.vpc_id = vpc['Vpc']['VpcId']
+
+        vpc = self.ec2_resource.Vpc(self.vpc_id)
+        vpc.wait_until_available()
+
+        if self.name_prefix is not None:
+            self.name = resources.random_suffix_name(self.name_prefix, 63)
+            self.ec2_client.create_tags(Resources=[self.vpc_id], Tags=[{'Key': 'Name', 'Value': self.name}])
+
+        if self.num_private_subnet > 0:
+            self.private_subnets = Subnets(self.vpc_id, self.private_subnet_cidr_blocks, is_public=False, num_subnets=self.num_private_subnet)
+        if self.num_public_subnet > 0:
+            self.public_subnets = Subnets(self.vpc_id, self.public_subnet_cidr_blocks, is_public=True, num_subnets=self.num_public_subnet)
+
+        # Because we require the VPC to be generated before generating other
+        # resources, if the subresources fail while bootstrapping, we need to
+        # make sure to clean up the VPC before raising the error
+        try:
+            super().bootstrap()
+        except BootstrapFailureException as ex:
+            vpc.delete()
+            raise ex
+
+    def cleanup(self):
+        """Deletes a VPC.
+        """
+        super().cleanup()
+
+        vpc = self.ec2_resource.Vpc(self.vpc_id)
+        vpc.delete()

--- a/src/acktest/resources.py
+++ b/src/acktest/resources.py
@@ -20,10 +20,12 @@ import string
 import random
 import yaml
 import logging
+import pickle
 from pathlib import Path
 from typing import Any, Dict
 
 from .aws import identity
+from .bootstrapping import BootstrappableResource
 
 def default_placeholder_values():
     """ Default placeholder values for loading any resource file.
@@ -57,33 +59,3 @@ def random_suffix_name(resource_name: str, max_length: int,
     rand = "".join(random.choice(string.ascii_lowercase + string.digits)
                    for _ in range(rand_length))
     return f"{resource_name}{delimiter}{rand}"
-
-
-def write_bootstrap_config(bootstrap: dict, output_path: Path, bootstrap_file_name: str = "bootstrap.yaml"):
-    """ Dumps the bootstrap object into a YAML file at a given path.
-
-    Args:
-        bootstrap: The bootstrap object.
-        output_path: The directory in which to dump the bootstrap yaml.
-        bootstrap_file_name: The name of the created bootstrap yaml file.
-    """
-    path =  output_path / bootstrap_file_name
-    logging.info(f"Wrote bootstrap to {path}")
-    with open(path, "w") as stream:
-        yaml.safe_dump(bootstrap, stream)
-
-
-def read_bootstrap_config(config_dir: Path, bootstrap_file_name: str = "bootstrap.yaml") -> dict:
-    """ Reads a bootstrap dictionary from a given bootstrap file.
-
-    Args:
-        config_dir: The directory in which the bootstray yaml exists.
-        bootstrap_file_name: The name of the created bootstrap yaml file.
-
-    Returns:
-        dict: The bootstrap dictionary read from the file.
-    """
-    path = config_dir / bootstrap_file_name
-    with open(path, "r") as stream:
-        bootstrap = yaml.safe_load(stream)
-    return bootstrap

--- a/src/acktest/resources.py
+++ b/src/acktest/resources.py
@@ -19,13 +19,10 @@ and contain YAML files used as templates for creating test fixtures.
 import string
 import random
 import yaml
-import logging
-import pickle
 from pathlib import Path
 from typing import Any, Dict
 
 from .aws import identity
-from .bootstrapping import BootstrappableResource
 
 def default_placeholder_values():
     """ Default placeholder values for loading any resource file.


### PR DESCRIPTION
This pull request modifies how bootstrap resource creation and cleanup is handled, migrating from an imperative style to an object oriented style. Resources are now represented as an implementation of a base `BootstrappableResource` abstract type that declares only that it can be "boostrapped" and "cleaned up". Service teams should then override the `ServiceBootstrapResources` class, adding additional members for each bootstrappable resource. The `ServiceBootstrapResources` class handles serialization/deserialization (now into `pickle` instead of YAML) and calling the respective `bootstrap` and `cleanup` method for each member.

Services teams are encouraged to add additional `BootstrappleResource` types to the `test-infra` repository. Teams are also welcome to extend any `BootstrappleResource`, adding more fields or operations, in their own repositories if they require interactions specific to their service.

⚠️ This breaks backwards compatibility:
- `write_bootstrap_config` and `read_bootstrap_config` are now deprecated in favour of `BootstrappleResource` `serialize` and `deserialize` methods

Example of bootstrapping, now:
```python
resources = TestBootstrapResources(
    TestRole=Role("test-role", "eks.amazonaws.com", ["arn:aws:iam::aws:policy/AmazonEKSClusterPolicy"]),
    TestVPC=VPC(name_prefix="test-vpc", public_subnets=2, private_subnets=2)
)
resources.bootstrap()
resources.serialize(bootstrap_directory)
```

Example of cleanup, now:
```python
resources = ServiceBootstrapResources.deseralize(bootstrap_directory)
resources.cleanup()
```