### PR TITLE
Increase Prow node root disk size

### DIFF
--- a/infra/lib/ci-cluster.ts
+++ b/infra/lib/ci-cluster.ts
@@ -19,6 +19,7 @@ export type CIClusterProps = CIClusterCompileTimeProps & CIClusterRuntimeProps;
 
 export class CICluster extends cdk.Construct {
   readonly testCluster: eks.Cluster;
+  readonly testNodegroup: eks.Nodegroup;
   readonly cdk8sApp: cdk8s.App = new cdk8s.App();
 
   constructor(scope: cdk.Construct, id: string, props: CIClusterProps) {
@@ -26,8 +27,12 @@ export class CICluster extends cdk.Construct {
 
     this.testCluster = new eks.Cluster(scope, 'TestInfraCluster', {
       version: eks.KubernetesVersion.V1_19,
-      defaultCapacity: 2,
-      defaultCapacityInstance: ec2.InstanceType.of(ec2.InstanceClass.M5, ec2.InstanceSize.XLARGE8)
+      defaultCapacity: 0
+    })
+    this.testNodegroup = this.testCluster.addNodegroupCapacity('TestInfraNodegroup', {
+      instanceTypes: [ec2.InstanceType.of(ec2.InstanceClass.M5, ec2.InstanceSize.XLARGE8)],
+      minSize: 2,
+      diskSize: 150,
     })
 
     this.installProwRequirements(props);

--- a/infra/lib/ssm.ts
+++ b/infra/lib/ssm.ts
@@ -11,6 +11,7 @@ export type ClusterSSMRuntimeProps = {
   account: string;
   region: string;
   cluster: eks.Cluster;
+  nodes: eks.Nodegroup;
 }
 
 export type ClusterSSMProps = ClusterSSMCompileProps & ClusterSSMRuntimeProps;
@@ -24,11 +25,7 @@ export class ClusterSSM extends cdk.Construct {
       return;
     }
 
-    if (!props.cluster.defaultNodegroup) {
-      throw new Error("Expected default nodegroup for SSM configuration")
-    }
-
-    props.cluster.defaultNodegroup.role.addManagedPolicy(
+    props.nodes.role.addManagedPolicy(
       iam.ManagedPolicy.fromAwsManagedPolicyName(
         "AmazonSSMManagedInstanceCore"
       )

--- a/infra/lib/test-ci-stack.ts
+++ b/infra/lib/test-ci-stack.ts
@@ -29,7 +29,8 @@ export class TestCIStack extends cdk.Stack {
       ...props,
       account: this.account,
       region: this.region,
-      cluster: testCluster.testCluster
+      cluster: testCluster.testCluster,
+      nodes: testCluster.testNodegroup
     })
 
     const prowServiceAccounts = new ProwServiceAccounts(this, 'ProwServiceAccountsConstruct', {


### PR DESCRIPTION
Modifies the managed nodegroup disk size from the 20GB default to 150GB. Attempting to fix the `no space left on device` error seen in some Prow jobs.