### PR TITLE
Use xterm as default TERM variable.

### DIFF
--- a/scripts/lib/common.sh
+++ b/scripts/lib/common.sh
@@ -81,6 +81,8 @@ perform_buildah_and_helm_login() {
 # get_num_columns returns the number of column on the terminal where script is
 # being executed
 get_num_columns() {
+  # if the TERM variable is not set, default to xterm
+  export TERM=${TERM:-"xterm"}
   local __num_cols=$(tput cols)
   echo "$__num_cols"
 }

--- a/scripts/test-helm.sh
+++ b/scripts/test-helm.sh
@@ -135,6 +135,9 @@ then
   print_line_separation
   echo "$CONTROLLER_LOGS" | grep "ERROR"
   print_line_separation
+  # TODO(vijat@): Remove following INFO message upon completion of
+  #  https://github.com/aws-controllers-k8s/community/issues/885
+  echo "test-helm.sh] [INFO] Make sure to execute code-generator/scripts/build-controller-release.sh to update the helm artifacts ..."
   echo "test-helm.sh] [ERROR] Exiting ..."
   exit 1
 fi


### PR DESCRIPTION
Issue: https://github.com/aws-controllers-k8s/community/issues/885

Use xterm as default TERM variable to get rid of following error in prow job logs `No value for $TERM and no -T specified`

```
➜  test-infra git:(xterm) make kind-test
checking AWS credentials ... ok.
loading the images into the cluster ... ok.
=============================================================================================================================================================================================================================================checking AWS credentials ... ok.
test-helm.sh] Starting Helm Artifacts Test
test-helm.sh] installing the Helm Chart ack-ecr-controller in namespace ack-system-test-helm ... ok.
test-helm.sh] waiting 10 seconds for ecr controller to start ... ok
test-helm.sh] ACK ecr controller pod name is ack-system-test-helm/ack-ecr-controller-84c7fcf88-clmfm
test-helm.sh] Verifying that pod status is in Running state ... ok.
test-helm.sh] Verifying that there are no ERROR in controller logs ... ok.
test-helm.sh] uninstalling the Helm Chart ack-ecr-controller in namespace ack-system-test-helm ... ok.
test-helm.sh] removing ecr crds installed by Helm ... ok.
test-helm.sh] deleting ack-system-test-helm namespace ... ok.
test-helm.sh] Helm Artifacts Test Finished Successfully
=============================================================================================================================================================================================================================================Skipping e2e tests because ENABLE_E2E_TESTS is not true. Current value is : false

```


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.