### PR TITLE
Do not use 'tput' command to get number of columns in terminal.

### DIFF
--- a/scripts/lib/common.sh
+++ b/scripts/lib/common.sh
@@ -79,15 +79,17 @@ perform_buildah_and_helm_login() {
 }
 
 # get_num_columns returns the number of column on the terminal where script is
-# being executed
+# being executed. Currently 80 is returned as output which is consistent with
+# other ACK bash scripts. Ex: wrapper.sh.
+#
+# NOTE(vijtrip2): Tried to use "tput cols" to get number of columns in the
+# terminal dynamically but the prow-job container does not work correctly for
+# 'tput' command.
+# It is hard to reproduce the issue because ACK prow-job images works correctly
+# for 'tput' but Prow wraps ACK prow-job images to produce a new image and uses
+# it to execute the prowjob.
 get_num_columns() {
-  local __cmd="tput cols"
-  # if the TERM variable is not set, default to xterm
-  if [[ -z $TERM ]]; then
-    __cmd="tput -T xterm cols"
-  fi
-  local __num_cols=$(eval "$__cmd")
-  echo "$__num_cols"
+  echo "80"
 }
 
 # print_line_separation prints a line of "=" symbol on the terminal executing


### PR DESCRIPTION
Do not use 'tput' command to get number of columns in terminal. Use static value of 80.

* setting `TERM` env variable or using `tput -T` did not help resolve the error `tput: No value for $TERM and no -T specified`. [Latest prow logs](https://prow.ack.aws.dev/log?job=sagemaker-release-test&id=1427414581856178176)  
* When trying to reproduce the issue using image 'public.ecr.aws/m5q3e4b2/prow:prow-integration-0.0.3', the issue is not reproducible. The mentioned image has $TERM as 'xterm' and `tput -T xterm cols` also works
* I am very sure that Prow does not use the above image directly to execute the prow-jobs, but instead uses a different image to load all the repos and prow decorations. I am also confident that the issue of running `tput` is arising from that image.
* I am currently not spending any more time on it, static value of 80 should work fine and is consistent with other bash scripts in ACK prow jobs.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.