### PR TITLE
Fix typo in `Serializable` class method

### DIFF
--- a/src/acktest/bootstrapping/__init__.py
+++ b/src/acktest/bootstrapping/__init__.py
@@ -30,7 +30,7 @@ class Serializable:
         logging.info(f"Wrote bootstrap to {path}")
 
     @classmethod
-    def deseralize(cls, config_dir: Path, bootstrap_file_name: str = "bootstrap.pkl") -> Resources:
+    def deserialize(cls, config_dir: Path, bootstrap_file_name: str = "bootstrap.pkl") -> Resources:
         """ Reads a service bootstrap from a given bootstrap pickle file.
 
         Args:


### PR DESCRIPTION
Description of changes:
Renames `deseralize` to `deserialize` in the `Serializable` class.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
