### PR TITLE
Add new Docker image for auto generating controllers using prow.

### DIFF
--- a/prow/jobs/images/Dockerfile.auto-generate-controller
+++ b/prow/jobs/images/Dockerfile.auto-generate-controller
@@ -1,0 +1,41 @@
+FROM debian:buster-slim AS base
+
+ARG GOPROXY=https://proxy.golang.org|direct
+ENV GOPROXY=${GOPROXY}
+
+ARG GO_VERSION=1.15
+ENV GO_VERSION=${GO_VERSION}
+
+ENV GOPATH=/home/prow/go \
+    GO111MODULE=on \
+    PATH=/home/prow/go/bin:/usr/local/go/bin:${PATH}
+
+RUN echo "Installing packages ..." \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends\
+        build-essential \
+        ca-certificates \
+        make \
+        curl \
+        git \
+        gnupg2 \
+        software-properties-common \
+        lsb-release \
+        wget \
+        jq \
+        uuid-runtime \
+        apt-transport-https \
+        unzip
+
+RUN echo "Installing Go ..." \
+    && export GO_TARBALL="go${GO_VERSION}.linux-amd64.tar.gz"\
+    && curl -fsSL "https://storage.googleapis.com/golang/${GO_TARBALL}" --output "${GO_TARBALL}" \
+    && tar xzf "${GO_TARBALL}" -C /usr/local \
+    && rm "${GO_TARBALL}"\
+    && mkdir -p "${GOPATH}/bin"
+
+RUN echo "Installing GitHub cli ..." \
+    && curl -fsSL "https://cli.github.com/packages/githubcli-archive-keyring.gpg" | gpg --dearmor -o /usr/share/keyrings/githubcli-archive-keyring.gpg \
+    && echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | tee /etc/apt/sources.list.d/github-cli.list > /dev/null \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends gh

--- a/prow/jobs/images/build-images.sh
+++ b/prow/jobs/images/build-images.sh
@@ -26,6 +26,7 @@ QUIET=${QUIET:-"false"}
 
 docker build -f "$IMAGE_DIR/Dockerfile.deploy" --quiet=$QUIET -t "prow/deploy" "${IMAGE_DIR}"
 docker build -f "$IMAGE_DIR/Dockerfile.docs" --quiet=$QUIET -t "prow/docs" "${IMAGE_DIR}"
+docker build -f "$IMAGE_DIR/Dockerfile.auto-generate-controller" --quiet=$QUIET -t "prow/auto-generate-controller" "${IMAGE_DIR}"
 docker build -f "$IMAGE_DIR/Dockerfile.soak" --quiet=$QUIET --build-arg DEPLOY_BASE_TAG="prow/deploy" -t "prow/soak" "${IMAGE_DIR}"
 
 export TEST_BASE_TAG=$(echo "prow/test-$(uuidgen | cut -c1-8)" | tr '[:upper:]' '[:lower:]')

--- a/prow/jobs/images/push-image.sh
+++ b/prow/jobs/images/push-image.sh
@@ -16,7 +16,8 @@ Usage:
 Pushes all of the tagged 'prow/*' images into a public ECR repository. Use
 DOCKER_REPOSITORY to specify the ECR repository URI. Use VERSION to set the 
 SemVer value in the image tag.
-Valid IMAGE_TYPE are "deploy", "docs", "soak", "integration" and "unit"
+Valid IMAGE_TYPE are "deploy", "docs", "soak", "integration", "auto-generate-controller"
+and "unit"
 
 Example:
 $(basename "$0") integration


### PR DESCRIPTION
Issue #, if available: https://github.com/aws-controllers-k8s/community/issues/908

Description of changes:
* Add a new "auto-generate-controller" Docker image that will be used as base image in prow cluster.
* Some lines are more than 80 chars in Dockerfile and splitting them into multiple lines did not work because path was getting separated.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
