### PR TITLE
include ACK runtime version in auto-generated controller branch

### DIFF
--- a/cd/auto-generate/auto-generate-controllers.sh
+++ b/cd/auto-generate/auto-generate-controllers.sh
@@ -34,9 +34,6 @@ TEST_INFRA_DIR=$CD_DIR/..
 WORKSPACE_DIR=$TEST_INFRA_DIR/..
 CODEGEN_DIR=$WORKSPACE_DIR/code-generator
 
-DEFAULT_PR_SOURCE_BRANCH="ack-bot/runtime"
-PR_SOURCE_BRANCH=${PR_SOURCE_BRANCH:-$DEFAULT_PR_SOURCE_BRANCH}
-
 DEFAULT_PR_TARGET_BRANCH="main"
 PR_TARGET_BRANCH=${PR_TARGET_BRANCH:-$DEFAULT_PR_TARGET_BRANCH}
 
@@ -74,6 +71,9 @@ if [[ -z $ACK_RUNTIME_VERSION ]]; then
 else
   echo "auto-generate-controllers.sh][INFO] ACK runtime version for new controllers will be $ACK_RUNTIME_VERSION"
 fi
+
+DEFAULT_PR_SOURCE_BRANCH="ack-bot/runtime-$ACK_RUNTIME_VERSION"
+PR_SOURCE_BRANCH=${PR_SOURCE_BRANCH:-$DEFAULT_PR_SOURCE_BRANCH}
 
 # find all the directories whose name ends with 'controller'
 pushd "$WORKSPACE_DIR" >/dev/null


### PR DESCRIPTION
Description of changes:
a) Choosing the dependabot approach for generating GitHub branch name with auto-generated controllers.
b) Having the same branch name caused this [issue](https://github.com/aws-controllers-k8s/ec2-controller/pull/9#discussion_r708492058)

There were two approaches to solve problem mentioned in (b)
1. Look for any open PR for branch "ack-bot/runtime" and update that PR title and body with latest runtime version. There will be only one PR open at anytime for ACK runtime library.
2. Approach used by [Dependabot](https://github.com/dependabot/dependabot-core/branches/all). Create separate PR and branch for package-version. PROs are that separate PR and changes for each runtime version. Only Con is cleanup of old branches which can done in future with a periodic job.

Hence I chose the approach which is consistent with dependabot for upgrading ACK runtime dependency.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
