### PR TITLE
[doc-update] ack-bot should have admin access on GitHub repo

### DIFF
--- a/docs/onboarding.md
+++ b/docs/onboarding.md
@@ -22,7 +22,9 @@ Github repository.
 [ack-bot]: https://github.com/ack-bot
 
 > **Note for Core Contributors:** Accept the invitation on behalf of the bot 
-account and change the bot to `Maintainer` role.
+account and change the bot to `Admin` role.  Admin role is required for successful
+prow job trigger functionality. Prow job trigger requires call to `ListCollaborators`
+API which is allowed only for a GitHub repository Admin.
 
 ## 2. Create an ACK test role
 


### PR DESCRIPTION
Description of changes:

[doc-update] ack-bot should have admin access on GitHub repo
* Prow job trigger requires call to `ListCollaborators` API which is allowed only for a GitHub repository Admin.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
