### PR TITLE
Create namespace for Prometheus Helm chart

### DIFF
--- a/flux/prometheus.yaml
+++ b/flux/prometheus.yaml
@@ -15,6 +15,8 @@ metadata:
 spec:
   interval: 5m
   targetNamespace: prometheus
+  install:
+    createNamespace: true
   values:
     kube-state-metrics:
       metricLabelsAllowlist: pods=[app,label_prow_k8s_io_id,label_prow_k8s_io_refs_repo,label_prow_k8s_io_type,label_prow_k8s_io_job,label_prow_k8s_io_refs_org]


### PR DESCRIPTION
Description of changes:
Create the namespace when installing the Prometheus Helm chart

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
