### PR TITLE
Fix Prometheus rules and allowlist

### DIFF
--- a/flux/prometheus.yaml
+++ b/flux/prometheus.yaml
@@ -136,7 +136,7 @@ spec:
           # {namespace="...",pod="...",node="...",pod_ip="1.2.3.4",phase="...",org="...",repo="...",type="...",name="...",id="<UUID>"} [bytes]
           - record: prow:job:resource_requests_memory_bytes
             expr: |
-              sum by (namespace, pod, node, pod_ip) (kube_pod_container_resource_requests_memory_bytes{container="test"}) *
+              sum by (namespace, pod, node, pod_ip) (kube_pod_container_resource_requests{resource="memory",container="test"}) *
                 on(namespace, pod)
                 group_left(org, repo, type, name, id, node, pod_ip, phase)
                 prow:job
@@ -144,7 +144,7 @@ spec:
           # {namespace="...",pod="...",node="...",pod_ip="1.2.3.4",phase="...",org="...",repo="...",type="...",name="...",id="<UUID>"} [bytes]
           - record: prow:job:resource_limits_memory_bytes
             expr: |
-              sum by (namespace, pod, node, pod_ip) (kube_pod_container_resource_limits_memory_bytes{container="test"}) *
+              sum by (namespace, pod, node, pod_ip) (kube_pod_container_resource_limits{resource="memory",container="test"}) *
                 on(namespace, pod)
                 group_left(org, repo, type, name, id, node, pod_ip, phase)
                 prow:job
@@ -160,7 +160,7 @@ spec:
           # {namespace="...",pod="...",node="...",pod_ip="1.2.3.4",phase="...",org="...",repo="...",type="...",name="...",id="<UUID>"} [cores]
           - record: prow:job:resource_requests_cpu_cores
             expr: |
-              sum by (namespace, pod, node, pod_ip) (kube_pod_container_resource_requests_cpu_cores{container="test"}) *
+              sum by (namespace, pod, node, pod_ip) (kube_pod_container_resource_requests{resource="cpu",container="test"}) *
                 on(namespace, pod)
                 group_left(org, repo, type, name, id, node, pod_ip, phase)
                 prow:job
@@ -168,7 +168,7 @@ spec:
           # {namespace="...",pod="...",node="...",pod_ip="1.2.3.4",phase="...",org="...",repo="...",type="...",name="...",id="<UUID>"} [cores]
           - record: prow:job:resource_limits_cpu_cores
             expr: |
-              sum by (namespace, pod, node, pod_ip) (kube_pod_container_resource_limits_cpu_cores{container="test"}) *
+              sum by (namespace, pod, node, pod_ip) (kube_pod_container_resource_limits{resource="cpu",container="test"}) *
                 on(namespace, pod)
                 group_left(org, repo, type, name, id, node, pod_ip, phase)
                 prow:job
@@ -176,12 +176,12 @@ spec:
           # {node="..."} [cores]
           - record: prow:node:cpu_capacity_cores
             expr: |
-              sum by (node) (kube_node_status_capacity_cpu_cores{node=~"worker-.*"})
+              sum by (node) (kube_node_status_capacity{resource="cpu"})
           # total memory available on *worker* nodes
           # {node="..."} [bytes]
           - record: prow:node:memory_capacity_bytes
             expr: |
-              sum by (node) (kube_node_status_capacity_memory_bytes{node=~"worker-.*"})
+              sum by (node) (kube_node_status_capacity{resource="memory"})
   chart:
     spec:
       chart: kube-prometheus-stack

--- a/flux/prometheus.yaml
+++ b/flux/prometheus.yaml
@@ -19,7 +19,7 @@ spec:
     createNamespace: true
   values:
     kube-state-metrics:
-      metricLabelsAllowlist: pods=[app,label_prow_k8s_io_id,label_prow_k8s_io_refs_repo,label_prow_k8s_io_type,label_prow_k8s_io_job,label_prow_k8s_io_refs_org]
+      metricLabelsAllowlist: pods=[app,prow.k8s.io/id,prow.k8s.io/refs.repo,prow.k8s.io/type,prow.k8s.io/job,prow.k8s.io/refs.org]
     prometheus:
       prometheusSpec:
         additionalScrapeConfigs:


### PR DESCRIPTION
Description of changes:
The original document where I found the Prow dashboards and rules was for a much older version of `kube-state-metrics`. Some of the metrics it references in the rules have since been replaced by ones with different names. I have updated the names of these metrics, and fixed the syntax in the metrics allow list.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
