### PR TITLE
improve logging for condition wait

### DIFF
--- a/src/acktest/k8s/resource.py
+++ b/src/acktest/k8s/resource.py
@@ -328,6 +328,7 @@ def wait_on_condition(reference: CustomResourceReference,
         logging.error(f"Resource {reference} does not have a condition of type {condition_name}.")
     else:
         logging.error(f"Wait for condition {condition_name} to reach status {desired_condition_status} timed out")
+    logging.info(f"Resource state:\n{get_resource(reference)}")  # log resource state upon failure
     return False
 
 def get_resource_condition(reference: CustomResourceReference, condition_name: str):


### PR DESCRIPTION
Often, a condition wait will fail during a test run and it's not straightforward to figure out why. Logging the resource state can help. For example, this could reveal that the wait for `ResourceSynced` to turn `True` failed due to a terminal condition.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
