### PR TITLE
Update `boto3` version to `1.18.50`

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-boto3==1.18.28
+boto3==1.18.50
 kubernetes==12.0.1
 PyYAML==5.4
 pytest-xdist==2.2.0


### PR DESCRIPTION
Description of changes:
Update the `boto3` requirement to `1.18.50` to support the new `opensearchservice` service endpoint.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
