### PR TITLE
Add iam:GetPolicy permission to presubmit service account

### DIFF
--- a/infra/lib/prow-service-accounts.ts
+++ b/infra/lib/prow-service-accounts.ts
@@ -42,6 +42,12 @@ export class ProwServiceAccounts extends cdk.Construct {
       resources: ["*"]
     });
 
+    // Used to validate recommended-policy-arn in service controllers repository
+    const preGetPolicyPolicy = new iam.PolicyStatement({
+      actions: ["iam:GetPolicy"],
+      resources: ["*"]
+    });
+
     const preBucketAccessPolicy = new iam.PolicyStatement({
       actions: ["s3:Get*", "s3:List*", "s3:Put*", "s3:DeleteObject"],
       resources: [
@@ -154,6 +160,7 @@ export class ProwServiceAccounts extends cdk.Construct {
     });
 
     this.presubmitJobServiceAccount.addToPrincipalPolicy(preAssumeRolePolicy);
+    this.presubmitJobServiceAccount.addToPrincipalPolicy(preGetPolicyPolicy);
     this.presubmitJobServiceAccount.addToPrincipalPolicy(preBucketAccessPolicy);
     this.presubmitJobServiceAccount.addToPrincipalPolicy(preParamStoreAccessPolicy);
     this.presubmitJobServiceAccount.addToPrincipalPolicy(preECRPublicReadOnlyPolicy)


### PR DESCRIPTION
Description of changes:
* Add iam:GetPolicy permission to presubmit service account
* this permission is needed for testing recommended-policy-arn

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
