### PR TITLE
adding .idea and .DS_Store to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -108,6 +108,8 @@ venv/
 ENV/
 env.bak/
 venv.bak/
+.idea
+.DS_Store
 
 # Spyder project settings
 .spyderproject


### PR DESCRIPTION
Issue #, if available:

Description of changes:
Adding .idea and .DS_Store to gitignore so these files to not get checked in accidentally, and to be consist with other `ACK` repos.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
