### PR TITLE
prevent race cond by moving crd deletion to before helm uninstall

### DIFF
--- a/scripts/test-helm.sh
+++ b/scripts/test-helm.sh
@@ -98,6 +98,7 @@ pushd "$HELM_DIR" 1> /dev/null
     --set image.repository="$IMAGE_REPO" \
     --set image.tag="$IMAGE_TAG" \
     --set metrics.service.create=true \
+    --wait \
     "$HELM_CHART_NAME" . 1>/dev/null || exit 1
   echo "ok."
 popd 1> /dev/null
@@ -152,11 +153,11 @@ then
   exit 1
 fi
 echo "ok."
-echo -n "test-helm.sh] uninstalling the Helm Chart $HELM_CHART_NAME in namespace $K8S_NAMESPACE ... "
-helm uninstall --namespace "$K8S_NAMESPACE" "$HELM_CHART_NAME" 1>/dev/null || exit 1
-echo "ok."
 echo -n "test-helm.sh] removing $AWS_SERVICE crds installed by Helm ... "
 kubectl delete -f "$HELM_DIR/crds" 1>/dev/null || exit 1
+echo "ok."
+echo -n "test-helm.sh] uninstalling the Helm Chart $HELM_CHART_NAME in namespace $K8S_NAMESPACE ... "
+helm uninstall --namespace "$K8S_NAMESPACE" "$HELM_CHART_NAME" 1>/dev/null || exit 1
 echo "ok."
 echo -n "test-helm.sh] deleting $K8S_NAMESPACE namespace ... "
 kubectl delete namespace "$K8S_NAMESPACE" 1>/dev/null || exit 1


### PR DESCRIPTION
Issue #, if available:
N/A

Description of changes:
 - Prevent a race condition where CRDs are deleted after the helm chart is uninstalled which prevents the CRDs from being deleted since the controller is erroring out. This race condition caused the `kubectl delete crds...` command to freeze forever. To fix, I just moved the crd deletion to before the helm chart uninstall. 
 - Add `--wait` to helm install command to not rely as much on the 10sec wait. I think the controllers should have real readiness checks at some point to completely mitigate the need for any 10 sec wait.

**Update: More info on race condition**

The race condition occurs when a test errors and resources are not deleted. The controller is not uninstalled when the test fails and there are resources left. Maybe this is just a controller test problem and it should try harder to clean up everything even when a test fails. But uninstalling the helm chart first causes any resource left behind to be orphaned because the finalizers can't complete. This PR moves the CRD deletion before the controller deletion which cleans up any resources left by tests before it brings down the controller.

To Reproduce:

1. Change a test to fail in a controller e2e test suite (ec2-controller preferably)
1. `make kind-test`
1. Re-run with the same cluster `TMP_DIR.... make kind-test` You should see CRD delete hang because instances of the CRD exist and can't complete their finalizer.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
