### PR TITLE
support aws-profiles when running in test container

### DIFF
--- a/scripts/build-run-test-dockerfile.sh
+++ b/scripts/build-run-test-dockerfile.sh
@@ -55,4 +55,5 @@ docker run --rm -t \
     -e AWS_ACCESS_KEY_ID \
     -e AWS_SECRET_ACCESS_KEY \
     -e AWS_SESSION_TOKEN \
+    -e AWS_PROFILE="${AWS_PROFILE:-"default"}" \
     $TEST_DOCKER_SHA


### PR DESCRIPTION
Issue #, if available:
N/A

Description of changes:
 - AWS_PROFILE was not being passed into the pytest container. The default profile was being used. This change just passed in AWS_PROFILE if set, and if not, set to `default` to work as it was before.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
