### PR TITLE
do not pass aws profile unless specified

### DIFF
--- a/scripts/build-run-test-dockerfile.sh
+++ b/scripts/build-run-test-dockerfile.sh
@@ -40,6 +40,10 @@ pushd "${ROOT_DIR}/.." 1> /dev/null
 popd 1>/dev/null
 
 echo "Running e2e test container $TEST_DOCKER_SHA"
+
+# Add AWS_PROFILE env var if one is set locally 
+aws_cli_profile_env=$([ ! -z "$AWS_PROFILE" ] && echo "--env AWS_PROFILE=$AWS_PROFILE")
+
 # Ensure it can connect to KIND cluster on host device by running on host 
 # network. 
 # Pass AWS credentials and kubeconfig through to Dockerfile.
@@ -55,5 +59,5 @@ docker run --rm -t \
     -e AWS_ACCESS_KEY_ID \
     -e AWS_SECRET_ACCESS_KEY \
     -e AWS_SESSION_TOKEN \
-    -e AWS_PROFILE="${AWS_PROFILE:-"default"}" \
+    $aws_cli_profile_env \
     $TEST_DOCKER_SHA


### PR DESCRIPTION
Issue #, if available:
https://github.com/aws-controllers-k8s/test-infra/pull/146
https://github.com/aws-controllers-k8s/ec2-controller/pull/17

Description of changes:
 - Turns out prow doesn't use a AWS_PROFILE, so the env var needs to be omitted if not specified explicitly by the user.  

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
