### PR TITLE
Revert aws profile support in build-run-test-dockerfile.sh

### DIFF
--- a/scripts/build-run-test-dockerfile.sh
+++ b/scripts/build-run-test-dockerfile.sh
@@ -55,5 +55,4 @@ docker run --rm -t \
     -e AWS_ACCESS_KEY_ID \
     -e AWS_SECRET_ACCESS_KEY \
     -e AWS_SESSION_TOKEN \
-    -e AWS_PROFILE="${AWS_PROFILE:-"default"}" \
     $TEST_DOCKER_SHA


### PR DESCRIPTION
Description of changes:
* Revert aws profile support in build-run-test-dockerfile.sh to unblock presubmit PR workflows
* I will add this variable back after reproducing issue locally.  Error: https://prow.ack.aws.dev/log?container=test&id=1450524215621980160&job=sagemaker-kind-e2e

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
