### PR TITLE
support AWS_PROFILE in test container

### DIFF
--- a/scripts/build-run-test-dockerfile.sh
+++ b/scripts/build-run-test-dockerfile.sh
@@ -40,6 +40,10 @@ pushd "${ROOT_DIR}/.." 1> /dev/null
 popd 1>/dev/null
 
 echo "Running e2e test container $TEST_DOCKER_SHA"
+
+# Add AWS_PROFILE env var if one is set locally 
+aws_cli_profile_env=$([ -z "${AWS_PROFILE:-}" ] || echo "-e AWS_PROFILE")
+
 # Ensure it can connect to KIND cluster on host device by running on host 
 # network. 
 # Pass AWS credentials and kubeconfig through to Dockerfile.
@@ -55,4 +59,5 @@ docker run --rm -t \
     -e AWS_ACCESS_KEY_ID \
     -e AWS_SECRET_ACCESS_KEY \
     -e AWS_SESSION_TOKEN \
+    $aws_cli_profile_env \
     $TEST_DOCKER_SHA


### PR DESCRIPTION
Issue #, if available:
N/A

Description of changes:
 - Supports using AWS_PROFILE within the e2e test container


Testing:

```
$ cat ~/.aws/credentials

[default]
<creds>

$ ENABLE_HELM_CHART_TEST=false make kind-test
......
========= ... 10 passed in 118.55s (0:01:58)  ...

## Rename default profile to "test"
$ cat ~/.aws/credentials

[test]
<creds>

$ AWS_PROFILE=test ENABLE_HELM_CHART_TEST=false make kind-test
......
========= ... 10 passed in 118.41s (0:01:58)  ...
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
