### PR TITLE
use trap in background thread to kill sleep

### DIFF
--- a/scripts/kind-build-test.sh
+++ b/scripts/kind-build-test.sh
@@ -59,7 +59,7 @@ function clean_up {
     bg_jobs_pids=$(jobs -p)
     if [[ -n $bg_jobs_pids ]]; then
       echo "cleaning background jobs with pid : $bg_jobs_pids"
-      kill "$bg_jobs_pids"
+      kill -9 "$bg_jobs_pids"
     fi
 
     if [[ "$PRESERVE" == false ]]; then

--- a/scripts/rotate-aws-creds-in-kind.sh
+++ b/scripts/rotate-aws-creds-in-kind.sh
@@ -38,6 +38,8 @@ fi
 
 AWS_SERVICE=$(echo "$1" | tr '[:upper:]' '[:lower:]')
 
+trap 'kill -9 $(jobs -p)' EXIT SIGINT
+
 while true
 do
   echo "rotate-aws-creds-in-kind.sh][INFO] sleeping for 50 mins before rotating temporary aws credentials"


### PR DESCRIPTION
Description of changes:
* New changes with credential files work fine but prowjobs is refusing to finish until 50 second sleep in BGTask is done. 
* Using trap in `rotate-creds` file to cleanup it's spawned sleep process 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
