### PR TITLE
move aws-creds-rotation sleep to background to be interruptable

### DIFF
--- a/scripts/rotate-aws-creds-in-kind.sh
+++ b/scripts/rotate-aws-creds-in-kind.sh
@@ -43,7 +43,7 @@ trap 'kill -9 $(jobs -p)' EXIT SIGINT
 while true
 do
   echo "rotate-aws-creds-in-kind.sh][INFO] sleeping for 50 mins before rotating temporary aws credentials"
-  sleep 3000
+  sleep 3000 & wait
   if [[ "$DUMP_CONTROLLER_LOGS" == true ]]; then
     if [[ ! -d $ARTIFACTS ]]; then
       echo "rotate-aws-creds-in-kind.sh][ERROR] Error evaluating ARTIFACTS environment variable" 1>&2


### PR DESCRIPTION
Description of changes:
* move aws-creds-rotation sleep to background to be interruptable and use wait with sleep command
* source -> https://newbedev.com/bash-sleep-process-not-getting-killed
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
