### PR TITLE
do not use SIGKILL for cleaning up rotate-aws-creds bg task

### DIFF
--- a/scripts/kind-build-test.sh
+++ b/scripts/kind-build-test.sh
@@ -59,7 +59,7 @@ function clean_up {
     bg_jobs_pids=$(jobs -p)
     if [[ -n $bg_jobs_pids ]]; then
       echo "cleaning background jobs with pid : $bg_jobs_pids"
-      kill -9 "$bg_jobs_pids"
+      kill "$bg_jobs_pids"
     fi
 
     if [[ "$PRESERVE" == false ]]; then

--- a/scripts/rotate-aws-creds-in-kind.sh
+++ b/scripts/rotate-aws-creds-in-kind.sh
@@ -38,7 +38,7 @@ fi
 
 AWS_SERVICE=$(echo "$1" | tr '[:upper:]' '[:lower:]')
 
-trap 'kill -9 $(jobs -p)' EXIT SIGINT
+trap 'kill $(jobs -p)' EXIT SIGINT
 
 while true
 do


### PR DESCRIPTION
Description of changes:
* reproduced the issue locally and found out using SIGKILL does not give opportunity for subprocesses to be cleaned up. They endup getting owned by PID 1
* using default SIGTERM cleans up all the processes and sleep
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
