### PR TITLE
Increase pod pending timeout to 20s

### DIFF
--- a/scripts/test-helm.sh
+++ b/scripts/test-helm.sh
@@ -119,8 +119,8 @@ kubectl -n "$K8S_NAMESPACE" set env deployment/"$CONTROLLER_DEPLOYMENT_NAME" \
     AWS_SESSION_TOKEN="$AWS_SESSION_TOKEN" 1>/dev/null
 echo "ok."
 
-echo -n "test-helm.sh] waiting 10 seconds for $AWS_SERVICE controller to start ... "
-sleep 10
+echo -n "test-helm.sh] waiting 20 seconds for $AWS_SERVICE controller to start ... "
+sleep 20
 echo "ok"
 # NOTE: Currently there is only a single pod. Keeping this logic very simple
 # right now.


### PR DESCRIPTION
Description of changes:
Some tests have been failing because the pod did not change from `Pending` to `Running` state within the 10s timeout. This PR updates the timeout to be 20s, so there is a greater chance the pod will transition in time.

Example of failure: https://prow.ack.aws.dev/view/s3/ack-prow-logs/pr-logs/pull/aws-controllers-k8s_code-generator/222/s3-controller-test/1451273317129392128

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
