### PR TITLE
export ACK_GENERATE_OLM env var for olm-bundle

### DIFF
--- a/cd/olm/olm-bundle-pr.sh
+++ b/cd/olm/olm-bundle-pr.sh
@@ -38,7 +38,7 @@ RELEASE_VERSION=$PULL_BASE_REF
 # Drop 'v' from controller semver to find olm bundle version
 OLM_BUNDLE_VERSION=$(echo "$RELEASE_VERSION" | awk -F v '{print $NF}')
 echo "olm-bundle-pr.sh][INFO] olm bundle version is $OLM_BUNDLE_VERSION"
-ACK_GENERATE_OLM=true
+export ACK_GENERATE_OLM=true
 
 # Important Directory references based on prowjob configuration.
 THIS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"


### PR DESCRIPTION
Description of changes:
* ole-bundle creation requires ACK_GENERATE_OLM variable in sub shell, so exporting it now.
* Reproduced locally and exporting variable fixes the issue.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
