### PR TITLE
rename var VERSION -> RELEASE_VERSION in olm templates

### DIFF
--- a/cd/olm/gh_issue_olm_create_error_template.txt
+++ b/cd/olm/gh_issue_olm_create_error_template.txt
@@ -1,11 +1,11 @@
 ### $ISSUE_TITLE
 
-#### stdout for \`olm-create-bundle.sh $SERVICE $VERSION\`:
+#### stdout for \`olm-create-bundle.sh $SERVICE $RELEASE_VERSION\`:
 \`\`\`
 $OLM_BUNDLE_STDOUT
 \`\`\`
 
-#### stderr for \`olm-create-bundle.sh $SERVICE $VERSION\`:
+#### stderr for \`olm-create-bundle.sh $SERVICE $RELEASE_VERSION\`:
 \`\`\`
 $OLM_BUNDLE_STDERR
 \`\`\`
@@ -13,7 +13,7 @@ $OLM_BUNDLE_STDERR
 
 #### Steps for closing this issue:
 1. Checkout [\`code-generator\`](https://github.com/aws-controllers-k8s/code-generator) and [\`$CONTROLLER_NAME\`](https://github.com/aws-controllers-k8s/$CONTROLLER_NAME) repositories
-2. From code-generator repo, execute \`./scripts/olm-create-bundle.sh $SERVICE $VERSION\`
+2. From code-generator repo, execute \`./scripts/olm-create-bundle.sh $SERVICE $RELEASE_VERSION\`
 3. Checkout [\`community-operators\`](https://github.com/k8s-operatorhub/community-operators) and [\`community-operators-prod\`](https://github.com/redhat-openshift-ecosystem/community-operators-prod) repositories
 4. Copy \`manifests\`, \`metadata\` and \`tests\` directories from
 \`$SERVICE-controller/olm/bundle/\` into \`community-operators/operators/ack-$SERVICE-controller/$OLM_BUNDLE_VERSION\`

--- a/cd/olm/gh_pr_body_template.txt
+++ b/cd/olm/gh_pr_body_template.txt
@@ -1,3 +1,3 @@
 ### $COMMIT_MSG
 
-This pull request is created by [\`ack-bot\`](https://github.com/ack-bot) after release of ACK [$CONTROLLER_NAME-$VERSION](https://gallery.ecr.aws/aws-controllers-k8s/$CONTROLLER_NAME)
+This pull request is created by [\`ack-bot\`](https://github.com/ack-bot) after release of ACK [$CONTROLLER_NAME-$RELEASE_VERSION](https://gallery.ecr.aws/aws-controllers-k8s/$CONTROLLER_NAME)


### PR DESCRIPTION
Description of changes:
* In the old-bundle-pr.sh script the variable 'VERSION' was renamed to 'RELEASE_VERSION', so making the same refactoring in template files as well.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
