### PR TITLE
Add additional note to OLM PR body

### DIFF
--- a/cd/olm/gh_pr_body_template.txt
+++ b/cd/olm/gh_pr_body_template.txt
@@ -1,3 +1,7 @@
 ### $COMMIT_MSG
 
 This pull request is created by [\`ack-bot\`](https://github.com/ack-bot) after release of ACK [$CONTROLLER_NAME-$RELEASE_VERSION](https://gallery.ecr.aws/aws-controllers-k8s/$CONTROLLER_NAME)
+
+NOTE: \`CreateContainerConfigError\` is expected since \`ACK controllers\` have
+pre-installation steps to create resources in a cluster before the manager pod
+can come up.


### PR DESCRIPTION
Description of changes:

* Adding an additional note on auto-generated OLM PR regarding expected upstream CI failures.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
