### PR TITLE
pull changes locally before creating the auto-generated PR

### DIFF
--- a/cd/auto-generate/auto-generate-controllers.sh
+++ b/cd/auto-generate/auto-generate-controllers.sh
@@ -245,6 +245,13 @@ for CONTROLLER_NAME in $CONTROLLER_NAMES; do
       continue
     fi
     echo "ok"
+    # fetch all remotes to bring changes locally
+    git fetch --all >/dev/null
+    # set local branch to track origin(PR source)
+    git branch "$LOCAL_GIT_BRANCH" --set-upstream-to origin/"$PR_SOURCE_BRANCH" >/dev/null
+    # sync local branch with the origin, if there is a diff the gh pr command
+    # prompts for user input
+    git pull --rebase >/dev/null
 
     # Capture 'make build-controller' command output, then persist
     # in '$GITHUB_PR_BODY_FILE'


### PR DESCRIPTION
Description of changes:

* the change for using common `open_pull_request` caused auto generated PR for fail with reason "aborted: you must first push the current branch to a remote, or use the --head flag"
* The fix is similar to one used in `olm-bundle-pr.sh` . Fetching the PR source branch locally allows `gh` cli to create pull request successfully.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
