### PR TITLE
Fix map public IP on subnet bootstrap

### DIFF
--- a/src/acktest/bootstrapping/vpc.py
+++ b/src/acktest/bootstrapping/vpc.py
@@ -128,7 +128,7 @@ class Subnets(Bootstrappable):
             # Make a separate call to enable MapPublicIpOnLaunch since boto3
             # does not accept it in the `create_subnet` parameter list
             if self.map_public_ip:
-                vpc.modify_subnet_attribute(SubnetId=subnet.id, MapPublicIpOnLaunch={'Value': True})
+                self.ec2_client.modify_subnet_attribute(SubnetId=subnet.id, MapPublicIpOnLaunch={'Value': True})
 
             self.ec2_client.associate_route_table(RouteTableId=self.route_table.route_table_id, SubnetId=subnet.id)
 


### PR DESCRIPTION
Description of changes:
Fixes a bug introduced in the previous PR. `modify_subnet_attribute` is an operation on the EC2 client, not the VPC object directly. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
