### PR TITLE
Create `ack-system` namespace before applying RBAC test resources

### DIFF
--- a/scripts/kind-build-test.sh
+++ b/scripts/kind-build-test.sh
@@ -217,6 +217,16 @@ for crd_file in $service_config_dir/crd/common/bases; do
 done
 echo "ok."
 
+echo -n "creating ack-system namespace"
+kubectl apply -f - <<'EOF'
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    control-plane: controller
+  name: ack-system
+EOF
+
 echo -n "loading RBAC manifests for $AWS_SERVICE into the cluster ... "
 kustomize build "$service_config_dir"/rbac | kubectl apply -f - 1>/dev/null
 echo "ok."

--- a/scripts/kind-two-node-cluster.yaml
+++ b/scripts/kind-two-node-cluster.yaml
@@ -2,11 +2,5 @@ kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
 nodes:
   - role: control-plane
-    kubeadmConfigPatches:
-      - |
-        apiVersion: kubeadm.k8s.io/v1beta2
-        kind: ClusterConfiguration
-        metadata:
-          name: config
   - role: worker
     

--- a/scripts/provision-kind-cluster.sh
+++ b/scripts/provision-kind-cluster.sh
@@ -23,12 +23,12 @@ else
     KIND_CONFIG_FILE="$SCRIPTS_DIR/kind-two-node-cluster.yaml"
 fi
 
-K8_1_21="kindest/node:v1.21.1@sha256:f2b782464e6c368487071ed114bc37d7f033658bfa27666f47629c6cf2d515c7"
-K8_1_18="kindest/node:v1.18.4@sha256:9ddbe5ba7dad96e83aec914feae9105ac1cffeb6ebd0d5aa42e820defe840fd4"
-K8_1_17="kindest/node:v1.17.5@sha256:ab3f9e6ec5ad8840eeb1f76c89bb7948c77bbf76bcebe1a8b59790b8ae9a283a"
-K8_1_16="kindest/node:v1.16.9@sha256:7175872357bc85847ec4b1aba46ed1d12fa054c83ac7a8a11f5c268957fd5765"
-K8_1_15="kindest/node:v1.15.11@sha256:6cc31f3533deb138792db2c7d1ffc36f7456a06f1db5556ad3b6927641016f50"
-K8_1_14="kindest/node:v1.14.10@sha256:6cd43ff41ae9f02bb46c8f455d5323819aec858b99534a290517ebc181b443c6"
+K8_1_21="kindest/node:v1.21.1"
+K8_1_18="kindest/node:v1.18.4"
+K8_1_17="kindest/node:v1.17.5"
+K8_1_16="kindest/node:v1.16.9"
+K8_1_15="kindest/node:v1.15.11"
+K8_1_14="kindest/node:v1.14.10"
 
 USAGE="
 Usage:


### PR DESCRIPTION
Issue #, if available:
- Relates: aws-controllers-k8s/community#777

Description of changes:
This pull request is needed to get tests to pass for 
- aws-controllers-k8s/code-generator#270 

It also removes `sha` information from k8's versions, since this `sha` version is not static. Meaning that k8s can and does update a sha for a given version to fix security updates and some of these `shas` can no longer be pulled locally.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
Signed-off-by: Adam D. Cornett <adc@redhat.com>