### PR TITLE
Allow 30 seconds for IAM role propagation after creation

### DIFF
--- a/src/acktest/bootstrapping/iam.py
+++ b/src/acktest/bootstrapping/iam.py
@@ -14,8 +14,11 @@ from ..aws.identity import get_region
 # Regex to match the role name from a role ARN
 ROLE_ARN_REGEX = r"^arn:aws:iam::\d{12}:(?:root|user|role\/([A-Za-z0-9-]+))$"
 
-# Time to wait (in seconds) after a role is created
-ROLE_CREATE_WAIT_IN_SECONDS = 3
+# Time to wait (in seconds) after a role is created.
+# Sometimes role propagation takes few seconds, specially
+# ServiceLinkedRoles. Waiting after role creation reduces
+# the chances of tests getting affected by propagation delay
+ROLE_CREATE_WAIT_IN_SECONDS = 30
 
 # Time to wait (in seconds) after a role is deleted
 ROLE_DELETE_WAIT_IN_SECONDS = 3


### PR DESCRIPTION
Description of changes:
* While debugging failures in opensearchservice-controller e2e, I found that tests were being flaky.
* Upon investigation, I saw Domain resource ending in Terminal Condition with message that SLR does not exist for connecting to private VPC
* tests were creating SLR but wait time of 3 seconds was not long enough to account for role propagation delay
* I increased this time to 30 seconds after testing locally. 30 seconds felt like a good wait time and selected after running some tests manually. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
