### PR TITLE
Fix soak test service account name

### DIFF
--- a/soak/cluster-config.yaml
+++ b/soak/cluster-config.yaml
@@ -5,8 +5,8 @@ metadata:
   name: ack-soak-test
   region: us-west-2
 
-nodeGroups:
-  - name: ng-1
+managedNodeGroups:
+  - name: managed-ng-1
     instanceType: m5.xlarge
     desiredCapacity: 2
     volumeSize: 80

--- a/soak/helm/ack-soak-test/templates/job.yaml
+++ b/soak/helm/ack-soak-test/templates/job.yaml
@@ -13,7 +13,7 @@ spec:
       labels:
         app: {{ .Values.awsService }}-soak-test
     spec:
-      serviceAccountName: ack-{{ .Values.awsService }}-controller # same as service controller service-account
+      serviceAccountName: ack-soak-controller # same as service controller service-account
       restartPolicy: Never
       containers:
         - name: soak-test


### PR DESCRIPTION
Description of changes:
We have to use a static service account name to put it inside the `eksctl` config file. Therefore, rather than referencing the default service account name, I have updated the soak test Helm chart to use the static one.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
