### PR TITLE
updating to the latest version of operator sdk

### DIFF
--- a/prow/jobs/images/Dockerfile.olm-bundle-pr
+++ b/prow/jobs/images/Dockerfile.olm-bundle-pr
@@ -49,9 +49,9 @@ RUN echo "Installing Helm v3.7.0... " \
     && tar xzf "${HELM_TARBALL}" --strip-components 1 -C /usr/bin \
     && rm "${HELM_TARBALL}"
 
-RUN echo "Installing operator-sdk v1.17.0 ... " \
+RUN echo "Installing operator-sdk v1.19.1 ... " \
     && export OPERATOR_SDK_BIN="operator-sdk" \
-    && curl -sq -L "https://github.com/operator-framework/operator-sdk/releases/download/v1.17.0/operator-sdk_linux_amd64" --output "${OPERATOR_SDK_BIN}" \
+    && curl -sq -L "https://github.com/operator-framework/operator-sdk/releases/download/v1.19.1/operator-sdk_linux_amd64" --output "${OPERATOR_SDK_BIN}" \
     && chmod +x "${OPERATOR_SDK_BIN}" \
     && mv "${OPERATOR_SDK_BIN}" "${OPERATOR_SDK_BIN_PATH}"/"${OPERATOR_SDK_BIN}"
 

--- a/prow/jobs/images/Dockerfile.olm-test
+++ b/prow/jobs/images/Dockerfile.olm-test
@@ -42,9 +42,9 @@ RUN echo "Installing Helm v3.7.0... " \
     && tar xzf "${HELM_TARBALL}" --strip-components 1 -C /usr/bin \
     && rm "${HELM_TARBALL}"
 
-RUN echo "Installing operator-sdk v1.17.0 ..." \
+RUN echo "Installing operator-sdk v1.19.1 ..." \
     && export OPERATOR_SDK_BIN="operator-sdk" \
-    && curl -sq -L "https://github.com/operator-framework/operator-sdk/releases/download/v1.17.0/operator-sdk_linux_amd64" --output "${OPERATOR_SDK_BIN}" \
+    && curl -sq -L "https://github.com/operator-framework/operator-sdk/releases/download/v1.19.1/operator-sdk_linux_amd64" --output "${OPERATOR_SDK_BIN}" \
     && chmod +x "${OPERATOR_SDK_BIN}" \
     && mv "${OPERATOR_SDK_BIN}" "${OPERATOR_SDK_BIN_PATH}"/"${OPERATOR_SDK_BIN}"
 


### PR DESCRIPTION
Issue #, if available:
- Fixes: aws-controllers-k8s/community#1286

Description of changes:
Updating to a newer version of OperatorSDK, so that this projects stays closer to the value that is used in the `Community` operators repos and we make sure that `bundle validate` will pass for all controllers.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Signed-off-by: Adam D. Cornett <adc@redhat.com>
