### PR TITLE
Add support for S3Bucket policy

### DIFF
--- a/src/acktest/bootstrapping/s3.py
+++ b/src/acktest/bootstrapping/s3.py
@@ -5,13 +5,14 @@ from dataclasses import dataclass, field
 
 from . import Bootstrappable
 from .. import resources
-from ..aws.identity import get_region
+from ..aws.identity import get_region, get_account_id
 
 @dataclass
 class Bucket(Bootstrappable):
     # Inputs
     name_prefix: str
     enable_versioning: bool = False
+    policy: str = ""
 
     # Outputs
     name: str = field(init=False)
@@ -42,6 +43,13 @@ class Bucket(Bootstrappable):
                 VersioningConfiguration={
                     "Status": "Enabled"
                 }
+            )
+
+        if self.policy != "":
+            policy = self.policy.replace("$NAME", self.name).replace("$ACCOUNT_ID", str(get_account_id()))
+            self.s3_client.put_bucket_policy(
+                Bucket=self.name,
+                Policy=policy,
             )
 
     def cleanup(self):


### PR DESCRIPTION
Issue #, if available:

Description of changes:
To correctly execute cloudtrail-controller e2e we will need to set the
trai bucket policy. This patch adds possibility of creating a bucket and
setting it policy directly with the test-infra e2e test framework.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
