### PR TITLE
Support more policy value replacements for Bucket

### DIFF
--- a/src/acktest/bootstrapping/s3.py
+++ b/src/acktest/bootstrapping/s3.py
@@ -13,6 +13,7 @@ class Bucket(Bootstrappable):
     name_prefix: str
     enable_versioning: bool = False
     policy: str = ""
+    policy_vars: dict = {}
 
     # Outputs
     name: str = field(init=False)
@@ -46,10 +47,18 @@ class Bucket(Bootstrappable):
             )
 
         if self.policy != "":
-            policy = self.policy.replace("$NAME", self.name).replace("$ACCOUNT_ID", str(get_account_id()))
+            self.policy_vars.update({
+                "$NAME": self.name,
+                "$ACCOUNT_ID": str(get_account_id()),
+                "$REGION": get_region(),
+            })
+
+            for key, value in self.policy_vars:
+                self.policy = self.policy.replace(key, value)
+
             self.s3_client.put_bucket_policy(
                 Bucket=self.name,
-                Policy=policy,
+                Policy=self.policy,
             )
 
     def cleanup(self):


### PR DESCRIPTION
Issue #, if available:

Currently, cloudtrail-controller uses the boostrappable `Bucket` object
to setup the Trail logs bucket. This bucket needs a special policy that
references the bucket name, trail name, region, and account ID. This
patch adds a new parameter (`policy_vars`) to `Bucket` that will help
users to replace more variables that the ones known by the acktest
library.

By submitting this pull request, I confirm that my contribution is made
under the terms of the Apache 2.0 license.
