### PR TITLE
Provide a default factory for Bucket.policy_vars field

### DIFF
--- a/src/acktest/bootstrapping/s3.py
+++ b/src/acktest/bootstrapping/s3.py
@@ -13,7 +13,7 @@ class Bucket(Bootstrappable):
     name_prefix: str
     enable_versioning: bool = False
     policy: str = ""
-    policy_vars: dict = {}
+    policy_vars: dict = field(default_factory=dict)
 
     # Outputs
     name: str = field(init=False)


### PR DESCRIPTION
Issue #, if available:

Description of changes:

- Provide a default factory for Bucket.policy_vars field

This patch fixes an error in [cloudtrail e2e tests](https://prow.ack.aws.dev/view/s3/ack-prow-logs/pr-logs/pull/aws-controllers-k8s_cloudtrail-controller/3/cloudtrail-kind-e2e/1529500910298861568)



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
