### PR TITLE
Bump the default k8s testing cluster version to `v1.22`

### DIFF
--- a/scripts/kind-build-test.sh
+++ b/scripts/kind-build-test.sh
@@ -23,7 +23,7 @@ RUN_PYTEST_LOCALLY=${RUN_PYTEST_LOCALLY:="false"}
 ACK_LOG_LEVEL="debug"
 ACK_RESOURCE_TAGS='services.k8s.aws/managed=true, services.k8s.aws/created=%UTCNOW%, services.k8s.aws/namespace=%KUBERNETES_NAMESPACE%'
 DELETE_CLUSTER_ARGS=""
-K8S_VERSION=${K8S_VERSION:-"1.16"}
+K8S_VERSION=${K8S_VERSION:-"1.22"}
 PRESERVE=${PRESERVE:-"false"}
 LOCAL_MODULES=${LOCAL_MODULES:-"false"}
 START=$(date +%s)
@@ -97,8 +97,8 @@ Environment variables:
                             Default: aws-controllers-k8s:$AWS_SERVICE-$VERSION
   TMP_DIR                   Cluster context directory, if operating on an existing cluster
                             Default: $ROOT_DIR/build/tmp-$CLUSTER_NAME
-  K8S_VERSION               Kubernetes Version [1.14, 1.15, 1.16, 1.17, and 1.18]
-                            Default: 1.16
+  K8S_VERSION               Kubernetes Version [1.19, 1.20, 1.21, 1.22, 1.23 and 1.24]
+                            Default: 1.22
   ENABLE_HELM_CHART_TEST    Whether to run the Helm Chart test (<true|false>)
                             Default: true
   ENABLE_E2E_TESTS          Whether to run the kind e2e tests (<true|false>)

--- a/scripts/provision-kind-cluster.sh
+++ b/scripts/provision-kind-cluster.sh
@@ -23,12 +23,12 @@ else
     KIND_CONFIG_FILE="$SCRIPTS_DIR/kind-two-node-cluster.yaml"
 fi
 
-K8_1_21="kindest/node:v1.21.1"
-K8_1_18="kindest/node:v1.18.4"
-K8_1_17="kindest/node:v1.17.5"
-K8_1_16="kindest/node:v1.16.9"
-K8_1_15="kindest/node:v1.15.11"
-K8_1_14="kindest/node:v1.14.10"
+K8_1_24="kindest/node:v1.24.0"
+K8_1_23="kindest/node:v1.23.6"
+K8_1_22="kindest/node:v1.22.9"
+K8_1_21="kindest/node:v1.21.12"
+K8_1_20="kindest/node:v1.20.15"
+K8_1_19="kindest/node:v1.19.16"
 
 USAGE="
 Usage:
@@ -39,8 +39,8 @@ Provisions a KinD cluster for local development and testing.
 Example: $(basename "$0") my-test
 
 Environment variables:
-  K8S_VERSION               Kubernetes Version [1.14, 1.15, 1.16, 1.17, 1.18 and 1.21]
-                            Default: 1.16
+  K8S_VERSION               Kubernetes Version [1.19, 1.20, 1.21, 1.22, 1.23 and 1.24]
+                            Default: 1.22
   ENABLE_PROMETHEUS:        Enables a different cluster config to enable Prometheus support.
                             Default: false
 "
@@ -65,7 +65,7 @@ if [ ! -z ${K8S_VERSION} ]; then
         exit 2
     fi
 else
-    K8_VERSION=${K8_1_16}
+    K8_VERSION=${K8_1_22}
 fi
 
 TMP_DIR=$ROOT_DIR/build/tmp-$cluster_name


### PR DESCRIPTION
Issue #, if available:

Description of changes:
- Add support for 1.20, 1.22, 1.23 and 1.24
- Remove support for 1.14, 1.15, 1.16, 1.17 and 1.18
- Default testing cluster version to 1.22

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
