### PR TITLE
Add tag utils to acktest

### DIFF
--- a/src/acktest/tags.py
+++ b/src/acktest/tags.py
@@ -1,0 +1,25 @@
+# Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may
+# not use this file except in compliance with the License. A copy of the
+# License is located at
+#
+#	 http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+"""Utilities for working with tags"""
+
+from typing import List
+
+ACK_SYSTEM_TAG_PREFIX = "services.k8s.aws/"
+
+def clean(tags: List[object]) -> List[object]:
+    """Returns supplied tags collection, stripped of ACK system tags.
+    """
+    return [
+        t for t in tags if not t['Key'].startswith(ACK_SYSTEM_TAG_PREFIX)
+    ]


### PR DESCRIPTION
Description of changes:
Adds a new utility file for transforming ACK resource tag lists

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
