### PR TITLE
Add trap for rotating AWS credential sleep

### DIFF
--- a/scripts/run-e2e-tests.sh
+++ b/scripts/run-e2e-tests.sh
@@ -95,6 +95,7 @@ run() {
     ensure_cluster
     
     build_and_run_tests
+    exit $?
 }
 
 ensure_inputs() {


### PR DESCRIPTION
Description of changes:
In the Prow cluster, the `sleep` command was becoming a hanging process and causing the container to never exit. On my development machine, and inside a `debian-slim` container, I was not able to reproduce this since killing the calling method (in this case `_loop_rotate_temp_creds`) killed all child sleep processes. This pull request adds a SIGINT and EXIT trap for the rotating credentials loop, and a trap inside the rotating loop function for the `sleep`, to ensure that any forked processes are killed every time.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
