### PR TITLE
Bump boto3 version to v1.24.35

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-boto3==1.21.8
+boto3==1.24.35
 kubernetes==12.0.1
 PyYAML==5.4
 pytest-xdist==2.2.0


### PR DESCRIPTION
Issue #, if available:

Description of changes:
- Bump boto3 version to v1.24.35

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
