### PR TITLE
check for bg jobs before killing them

### DIFF
--- a/scripts/controller-setup.sh
+++ b/scripts/controller-setup.sh
@@ -137,7 +137,11 @@ dump_controller_logs() {
 
 _stop_loop_rotating_creds() {
     debug_msg "Killing all background jobs"
-    kill $(jobs -p)
+    local bg_jobs_pids=$(jobs -p)
+    if [[ -n $bg_jobs_pids ]]; then
+        echo "cleaning background jobs with pid : $bg_jobs_pids"
+        kill "$bg_jobs_pids"
+    fi
 }
 
 _loop_rotate_temp_creds() {
@@ -147,7 +151,11 @@ _loop_rotate_temp_creds() {
     local __dump_logs=$4
 
     function _kill_sleep() {
-        kill $(jobs -p)
+        local bg_jobs_pids=$(jobs -p)
+        if [[ -n $bg_jobs_pids ]]; then
+          echo "cleaning background jobs with pid : $bg_jobs_pids"
+          kill "$bg_jobs_pids"
+        fi
     }
     trap _kill_sleep EXIT SIGINT
 


### PR DESCRIPTION
Description of changes:
* I am seeing e2e test failures in latest prowjobs due failure of background job cleanup.
* This small change is one of the ideas i have to solve this issue. In this change we check that background jobs exist before killing them.

The error in prowjob looks like
```
2022-07-22T20:24:55+00:00 [DEBUG] Dumping controller logs
2022-07-22T20:24:55+00:00 [DEBUG] Killing all background jobs
/home/prow/go/src/github.com/aws-controllers-k8s/test-infra/scripts/lib/../controller-setup.sh: line 140: kill: (14794) - No such process
make: *** [Makefile:17: kind-test] Error 1
wrapper.sh] [TEST] Test Command exit code: 2
```


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
