### PR TITLE
make cred-rotation bg sleep interruptable

### DIFF
--- a/scripts/controller-setup.sh
+++ b/scripts/controller-setup.sh
@@ -161,7 +161,7 @@ _loop_rotate_temp_creds() {
 
     while true; do
         info_msg "Sleeping for $__rotation_time_in_seconds seconds before rotating temporary aws credentials"
-        sleep $__rotation_time_in_seconds &
+        sleep $__rotation_time_in_seconds & wait
 
         rotate_temp_creds "$__controller_namespace" "$__deployment_name" "$__dump_logs"
     done


### PR DESCRIPTION
* Make the background sleep interruptible for temporary credential rotation.
* Similar previous PR https://github.com/aws-controllers-k8s/test-infra/pull/152

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
