### PR TITLE
add perform_buildah_and_helm_login command

### DIFF
--- a/cd/scripts/release-controller.sh
+++ b/cd/scripts/release-controller.sh
@@ -43,9 +43,7 @@ CODE_GEN_DIR="$WORKSPACE_DIR/code-generator"
 
 # Check all the dependencies are present in container.
 source "$TEST_INFRA_DIR"/scripts/lib/common.sh
-check_is_installed buildah
-check_is_installed aws
-check_is_installed helm
+source "$TEST_INFRA_DIR"/scripts/lib/login.sh
 check_is_installed git
 check_is_installed jq
 check_is_installed yq

--- a/scripts/lib/login.sh
+++ b/scripts/lib/login.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+
+# login.sh contains functions for logging into container repositories.
+# Note: These functions are not placed inside tools specific file like
+# helm.sh, because those files ensure binaries(ex: kind) that are not
+# really needed for simple actions like repository login.
+# A future refactor can make those files more modular and then login
+# functions can be refactored in tool specific file like buildah.sh
+# and helm.sh
+
+perform_buildah_and_helm_login() {
+  #ecr-public only exists in us-east-1 so use that region specifically
+  local __pw=$(aws ecr-public get-login-password --region us-east-1)
+  echo "$__pw" | buildah login -u AWS --password-stdin public.ecr.aws
+  export HELM_EXPERIMENTAL_OCI=1
+  echo "$__pw" | helm registry login -u AWS --password-stdin public.ecr.aws
+}
+
+ensure_binaries() {
+    check_is_installed "aws"
+    check_is_installed "buildah"
+    check_is_installed "helm"
+}
+
+ensure_binaries

--- a/soak/prow/scripts/soak-on-release.sh
+++ b/soak/prow/scripts/soak-on-release.sh
@@ -34,9 +34,7 @@ SERVICE_CONTROLLER_DIR="$WORKSPACE_DIR/$AWS_SERVICE-controller"
 
 # Check all the dependencies are present in container.
 source "$TEST_INFRA_DIR"/scripts/lib/common.sh
-check_is_installed buildah
-check_is_installed aws
-check_is_installed helm
+source "$TEST_INFRA_DIR"/scripts/lib/login.sh
 check_is_installed git
 check_is_installed kubectl
 check_is_installed yq


### PR DESCRIPTION
Description of changes:
* fixing the ACK controller release job, by adding `perform_buildah_and_helm_login` command
* The same function existed before the refactoring so there is no new logic
* There is a scope for better refactoring but currently i am just adding same function to unblock controller release

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
