### PR TITLE
Update the `yq` version inside the test container

### DIFF
--- a/scripts/Dockerfile.pytest-image
+++ b/scripts/Dockerfile.pytest-image
@@ -21,7 +21,10 @@ ENV TEST_CONFIG_PATH ${TEST_CONFIG_PATH}
 WORKDIR /${AWS_SERVICE}-controller/tests/e2e
 ENV PYTHONPATH=/${AWS_SERVICE}-controller/tests/e2e
 
-RUN apk add --no-cache git bash gcc libc-dev yq
+RUN apk add --no-cache git bash gcc libc-dev
+
+RUN wget https://github.com/mikefarah/yq/releases/download/v4.26.1/yq_linux_amd64.tar.gz -O - |\
+  tar xz && mv yq_linux_amd64 /usr/bin/yq
 
 # Install python dependencies
 COPY ${CONTROLLER_E2E_PATH}/requirements.txt .


### PR DESCRIPTION
Description of changes:

Updates the version of `yq` used inside the e2e test container so that we can pin it to a known good version to match the syntax we are using

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
