### PR TITLE
Use underscore delimiter for SigningProfile resources

### DIFF
--- a/src/acktest/bootstrapping/signer.py
+++ b/src/acktest/bootstrapping/signer.py
@@ -34,7 +34,7 @@ class SigningProfile(Bootstrappable):
     def bootstrap(self):
         """Creates a Signing profile with a generated name
         """
-        self.name = resources.random_suffix_name(self.name_prefix, 32)
+        self.name = resources.random_suffix_name(self.name_prefix, 32, delimiter="_")
         signing_profile = self.signer_client.put_signing_profile(
             profileName=self.name,
             platformId=self.signing_platform_id,


### PR DESCRIPTION
Description of changes
Use underscore delimiter for SigningProfile resources.
Currently, the Signer API only accepts alphanumerical, numbers and
underscored in SigningProfile names.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
