### PR TITLE
Add `ProvisionedThrouput` parameter to dynamodb `Table` bootstrappable resources

### DIFF
--- a/src/acktest/bootstrapping/dynamodb.py
+++ b/src/acktest/bootstrapping/dynamodb.py
@@ -13,6 +13,7 @@ class Table(Bootstrappable):
     attribute_definitions: List[dict]
     key_schema: List[dict]
     stream_specification: dict
+    provisioned_throughput: dict
 
     # Outputs
     name: str = field(init=False)
@@ -35,6 +36,7 @@ class Table(Bootstrappable):
             KeySchema=self.key_schema,
             AttributeDefinitions=self.attribute_definitions,
             StreamSpecification=self.stream_specification,
+            ProvisionedThroughput=self.provisioned_throughput,
         )
         self.latest_stream_arn = table.latest_stream_arn
 


### PR DESCRIPTION
Description of changes:

Currently, tests are failing when attempting to create a Dynamodb table
using bootstrappable resources, mainly because `ReadCapacityUnits` and
`WriteCapacityUnits` are missing in the create request.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
