### PR TITLE
[ack-discover] Skip images with no tags

### DIFF
--- a/tools/ackdiscover/ecrpublic.py
+++ b/tools/ackdiscover/ecrpublic.py
@@ -117,6 +117,8 @@ def get_repository_latest_tag(ep_client, repo):
         except ep_client.exceptions.RepositoryNotFoundException:
             return latest_tag
         for image in images["imageDetails"]:
+            if not 'imageTags' in image:
+                continue
             pushed_at = image["imagePushedAt"]
             if most_recent is None or pushed_at > most_recent:
                 most_recent = pushed_at


### PR DESCRIPTION
Fixes https://github.com/aws-controllers-k8s/community/issues/1424

A few days ago the prow `community-docs-release` were failing because
`ackdiscover` was panicking when trying to access "imageTags" key in
"imageDetails" (returned by `ecr_public.describe_images`).

This patch enables `get_repository_latest_tag` to skip untagged images.

Signed-off-by: Amine Hilaly <hilalyamine@gmail.com>

By submitting this pull request, I confirm that my contribution is made
under the terms of the Apache 2.0 license.
