### PR TITLE
move web-identity-token to conditional mount

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -133,3 +133,4 @@ dmypy.json
 /test_config.yaml
 
 # End of https://www.gitignore.io/api/python
+/scripts/web-identity-token

--- a/scripts/Dockerfile.pytest-image
+++ b/scripts/Dockerfile.pytest-image
@@ -10,9 +10,6 @@ ARG CONTROLLER_E2E_PATH=./${AWS_SERVICE}-controller/test/e2e
 # Path to the test-infra directory in the build context
 ARG TEST_INFRA_PATH=./test-infra
 
-# Destination path to copy aws-web-identity-token
-ARG WEB_IDENTITY_TOKEN_DEST_PATH=/root/web-identity-token
-
 # Destination path for the test config YAML
 ARG TEST_CONFIG_PATH=/root/test-config.yaml
 ENV TEST_CONFIG_PATH ${TEST_CONFIG_PATH}
@@ -36,8 +33,6 @@ RUN mkdir -p $HOME/.kube
 # Copy the runner script
 COPY ${TEST_INFRA_PATH}/scripts/pytest-local-runner.sh .
 COPY ${TEST_INFRA_PATH}/scripts/lib/* ./lib/
-
-COPY ${TEST_INFRA_PATH}/scripts/web-identity-token* ${WEB_IDENTITY_TOKEN_DEST_PATH}
 
 # Run the tests
 ENTRYPOINT ["/bin/bash"]

--- a/scripts/pytest-image-runner.sh
+++ b/scripts/pytest-image-runner.sh
@@ -105,6 +105,7 @@ run_pytest_image() {
     params=()
     if [[ "$identity_file" != "" ]]; then
         params+=(-e AWS_WEB_IDENTITY_TOKEN_FILE="$TEST_CONTAINER_WEB_IDENTITY_TOKEN_FILE")
+        params+=(-v "$TEST_CONTAINER_WEB_IDENTITY_TOKEN_FILE":/root/web-identity-token)
     fi
 
     docker run --rm -t \


### PR DESCRIPTION
On non-Mac machines, the COPY directive that previously was in `scripts/Dockerfile.pytest-image` that was supposed to conditionally copy the `scripts/web-identity-token` file into the Docker image was not working. Running `scripts/pytest-image-runner.sh` would end up complaining about a missing file if `scripts/web-identity-token` was missing, forcing non-Mac users to do `touch scripts/web-identity-token` as a workaround.

This patch removes the COPY directive from the Dockerfile and replaces it with a conditional volume mount in `scripts/pytest-image-runner.sh` if and only if there is a web identity token file built (typically only on the CI systems).

Here is evidence this patch fixes the problem:

```
[jaypipes@thelio test-infra]$ ll scripts/web-*
ls: cannot access 'scripts/web-*': No such file or directory
[jaypipes@thelio test-infra]$ make kind-test ACK_ROLE_ARN=$ROLE_ARN SERVICE=iam
2022-10-10T14:46:39-04:00 [INFO] Creating KIND cluster ...
2022-10-10T14:46:39-04:00 [INFO] Creating cluster with name "ack-test-25ce5ef7"
2022-10-10T14:46:39-04:00 [INFO] Using configuration "kind-two-node-cluster.yaml"
2022-10-10T14:48:25-04:00 [INFO] Sleeping for 3000 seconds before rotating temporary aws credentials
<snip>
2022-10-10T14:48:25-04:00 [INFO] Building e2e test container for iam ...
2022-10-10T14:49:09-04:00 [INFO] Running e2e test container for iam ...
2022-10-10T18:49:10+00:00 [INFO] Running test bootstrap ...
INFO:root:🛠️ Bootstrapping resources ...
INFO:root:Wrote bootstrap to /iam-controller/tests/e2e/bootstrap.pkl
2022-10-10T18:49:10+00:00 [INFO] Running tests ...
<snip>
2022-10-10T18:51:21+00:00 [INFO] Tests succeeded!
2022-10-10T18:51:21+00:00 [INFO] Running test cleanup ...
INFO:root:🧹 Cleaning up resources ...
```

Signed-off-by: Jay Pipes <jaypipes@gmail.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
