### PR TITLE
Actually write out the token file to volume mount

### DIFF
--- a/scripts/pytest-image-runner.sh
+++ b/scripts/pytest-image-runner.sh
@@ -105,7 +105,7 @@ run_pytest_image() {
     params=()
     if [[ "$identity_file" != "" ]]; then
         params+=(-e AWS_WEB_IDENTITY_TOKEN_FILE="$TEST_CONTAINER_WEB_IDENTITY_TOKEN_FILE")
-        params+=(-v "$TEST_CONTAINER_WEB_IDENTITY_TOKEN_FILE":/root/web-identity-token)
+        params+=(-v "$identity_file":"$TEST_CONTAINER_WEB_IDENTITY_TOKEN_FILE")
     fi
 
     docker run --rm -t \


### PR DESCRIPTION
We were doing `-v target:target` instead of `-v source:target`. Doh.

Signed-off-by: Jay Pipes <jaypipes@gmail.com>

By submitting this pull request, I confirm that my contribution is made
under the terms of the Apache 2.0 license.
