### PR TITLE
Use `apiserver_storage_objects` as new soak metric for resource counts

### DIFF
--- a/soak/monitoring/grafana/ack-dashboard-source.json
+++ b/soak/monitoring/grafana/ack-dashboard-source.json
@@ -533,7 +533,7 @@
         {
           "datasource": "$datasource",
           "exemplar": true,
-          "expr": "etcd_object_counts{resource=~\".*\\\\.services\\\\.k8s\\\\.aws\"} / on(instance) group_left topk(1, group by (instance) (etcd_object_counts))",
+          "expr": "apiserver_storage_objects{resource=~\".*\\\\.services\\\\.k8s\\\\.aws\"} / on(instance) group_left topk(1, group by (instance) (apiserver_storage_objects))",
           "interval": "",
           "legendFormat": "{{resource}}",
           "refId": "A"


### PR DESCRIPTION
Motivation:  noticed when running soak tests that the `ACK Resource Count` graph was blank.  After some digging, determined that the metric `etc_object_counts` is now deprecated upstream in favor of `apiserver_storage_objects`.

See:

- https://github.com/kubernetes/apiserver/blob/464f2d738348f8048b8791f4c6a7bf51144c1ac7/pkg/storage/etcd3/metrics/metrics.go#L50
- https://github.com/kubernetes/kubernetes/issues/98270 
- https://github.com/kubernetes/kubernetes/pull/99785 
- https://access.redhat.com/solutions/6969249

Before:
![image](https://user-images.githubusercontent.com/115744412/202563586-912f5428-dfb4-4e99-8ef4-45b32356d42d.png)

After:
![image](https://user-images.githubusercontent.com/115744412/202563659-0f732fe2-4af9-46ff-a261-3758832df132.png)


Description of changes:
Change the default Grafana dashboard used to monitor ACK soak tests to use this new metric.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
