### PR TITLE
Patch labels config into `test-pods` namespace

### DIFF
--- a/prow/jobs/kustomization.yaml
+++ b/prow/jobs/kustomization.yaml
@@ -17,7 +17,7 @@ configMapGenerator:
   files:
   - test_config.yaml
 - name: label-config
-  namespace: prow
+  namespace: test-pods
   behavior: create
   files:
   - labels.yaml


### PR DESCRIPTION
After investigating why label_sync jobs were never completed, we found
out that the pod was not successfully initialized and stayed in a Pending
state. The reason is that labels-config ConfigMap was not created in the
right namespace causing the pod failing to mount it as a volume, and
staying in a pending state.

This patch fixes this issue by correcting the CM namespace.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
