### PR TITLE
Upgrade prow eks cluster version to `1.21`

### DIFF
--- a/infra/lib/ci-cluster.ts
+++ b/infra/lib/ci-cluster.ts
@@ -25,7 +25,7 @@ export class CICluster extends cdk.Construct {
     super(scope, id);
 
     this.testCluster = new eks.Cluster(scope, 'TestInfraCluster', {
-      version: eks.KubernetesVersion.V1_20,
+      version: eks.KubernetesVersion.V1_21,
       defaultCapacity: 0
     })
     this.testNodegroup = this.testCluster.addNodegroupCapacity('TestInfraNodegroup', {


### PR DESCRIPTION
Description of changes:
- Upgrade prow eks cluster version to `1.21`

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.
