### PR TITLE
Correct usage of "date" in timestamp creation

### DIFF
--- a/scripts/lib/logging.sh
+++ b/scripts/lib/logging.sh
@@ -15,7 +15,7 @@ _indented_msg() {
         indent="$( for each in $( seq 0 $__indent_level ); do printf " "; done )"
     fi
 
-    local timestamp=$(date -Is)
+    local timestamp=$(date -Iseconds)
 
     echo "$timestamp $__indent$__msg"
 }

--- a/scripts/lib/logging.sh
+++ b/scripts/lib/logging.sh
@@ -15,7 +15,7 @@ _indented_msg() {
         indent="$( for each in $( seq 0 $__indent_level ); do printf " "; done )"
     fi
 
-    local timestamp=$(date -Iseconds)
+    local timestamp=$(date +"%Y-%m-%dT%H:%M:%S")
 
     echo "$timestamp $__indent$__msg"
 }


### PR DESCRIPTION
 to support cross-platform compatibility

On a Mac, the parameter must be `-Iseconds`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
