### PR TITLE
Lint all shell scripts with shellcheck

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ PROW_JOBS_PATH="./prow/jobs"
 
 AWS_SERVICE=$(shell echo $(SERVICE) | tr '[:upper:]' '[:lower:]')
 
-.PHONY: build-prow-jobs
+.PHONY: build-prow-jobs lint-shell
 
 # Assumes python3 is installed as default python on the host.
 build-prow-jobs: ## Compiles the Prow jobs
@@ -35,6 +35,9 @@ test-recommended-policy:
 delete-all-kind-clusters:	## Delete all local kind clusters
 	@kind delete clusters --all
 	@rm -rf build/*
+
+lint-shell:	## Run linters against all of the bash scripts
+	@find . -type f -name "*.sh" ! -path "./infra/*" | xargs shellcheck -e SC1091,SC2015
 
 help:           ## Show this help.
 	@grep -F -h "##" $(MAKEFILE_LIST) | grep -F -v grep | sed -e 's/\\$$//' \

--- a/cd/auto-generate/controller-release-tag.sh
+++ b/cd/auto-generate/controller-release-tag.sh
@@ -39,7 +39,6 @@ CONTROLLER_NAME="$AWS_SERVICE"-controller
 
 # Important Directory references based on prowjob configuration.
 THIS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
-AUTO_GEN_DIR=$THIS_DIR
 CD_DIR=$THIS_DIR/..
 TEST_INFRA_DIR=$CD_DIR/..
 WORKSPACE_DIR=$TEST_INFRA_DIR/..
@@ -71,31 +70,31 @@ cd "$CONTROLLER_DIR"
 # Find latest Git tag on controller repo
 echo "controller-release-tag.sh][INFO] Finding latest Git tag for $CONTROLLER_NAME"
 LATEST_GIT_TAG=$(git describe --abbrev=0 --tags || echo "$MISSING_GIT_TAG")
-if [[ $LATEST_GIT_TAG == $MISSING_GIT_TAG ]]; then
+if [[ $LATEST_GIT_TAG == "$MISSING_GIT_TAG" ]]; then
   echo "controller-release-tag.sh][INFO] No git tag exists for $CONTROLLER_NAME"
 fi
 
 # Find the image tag used in helm release artifacts
 HELM_IMAGE_TAG=$(yq eval '.image.tag' helm/values.yaml || echo "$MISSING_IMAGE_TAG")
-if [[ $HELM_IMAGE_TAG == $MISSING_IMAGE_TAG ]]; then
+if [[ $HELM_IMAGE_TAG == "$MISSING_IMAGE_TAG" ]]; then
   echo "controller-release-tag.sh][ERROR] Unable to find image tag in helm/values.yaml for $CONTROLLER_NAME. Exiting"
   exit 1
 fi
 
-if [[ $HELM_IMAGE_TAG == $NON_RELEASE_IMAGE_TAG ]]; then
+if [[ $HELM_IMAGE_TAG == "$NON_RELEASE_IMAGE_TAG" ]]; then
   echo "controller-release-tag.sh][INFO] Helm artifacts have $NON_RELEASE_IMAGE_TAG tag. Skipping $CONTROLLER_NAME"
   exit 0
 fi
 
 # Currently only supports auto-tagging for patch releases
-if [[ $LATEST_GIT_TAG == $MISSING_GIT_TAG ]]; then
+if [[ $LATEST_GIT_TAG == "$MISSING_GIT_TAG" ]]; then
   # If no git tag exist for controller, use v0.0.1 as next git tag
   NEXT_GIT_TAG="v0.0.1"
 else
   NEXT_GIT_TAG=$(echo "$LATEST_GIT_TAG" | awk -F. -v OFS=. '{$NF++;print}')
 fi
 
-if [[ $HELM_IMAGE_TAG != $NEXT_GIT_TAG ]]; then
+if [[ $HELM_IMAGE_TAG != "$NEXT_GIT_TAG" ]]; then
   echo "controller-release-tag.sh][ERROR] Helm image tag $HELM_IMAGE_TAG is not the next patch release for current $LATEST_GIT_TAG release"
   echo "controller-release-tag.sh][INFO] Not tagging the GitHub repository with $HELM_IMAGE_TAG tag"
   exit 0

--- a/cd/auto-update/project-static-files.sh
+++ b/cd/auto-update/project-static-files.sh
@@ -80,7 +80,7 @@ pushd "$WORKSPACE_DIR" >/dev/null
 popd >/dev/null
 
 for CONTROLLER_NAME in $CONTROLLER_NAMES; do
-  SERVICE_NAME=$(echo "$CONTROLLER_NAME"| sed 's/-controller$//g')
+  SERVICE_NAME=${CONTROLLER_NAME//-controller/}
   CONTROLLER_DIR="$WORKSPACE_DIR/$CONTROLLER_NAME"
   cd "$CONTROLLER_BOOTSTRAP_DIR"
 
@@ -113,10 +113,11 @@ for CONTROLLER_NAME in $CONTROLLER_NAMES; do
     # Capture 'make run' command output & error, then persist
     # in '$GITHUB_ISSUE_BODY_FILE'
     MAKE_RUN_OUTPUT=$(cat "$MAKE_RUN_OUTPUT_FILE")
+    # shellcheck disable=SC2034 # Variables are used in templates
     MAKE_RUN_ERROR_OUTPUT=$(cat "$MAKE_RUN_ERROR_FILE")
     GITHUB_ISSUE_BODY_TEMPLATE_FILE="$THIS_DIR/gh_issue_update_controller_template.txt"
     GITHUB_ISSUE_BODY_FILE=/tmp/"$SERVICE_NAME"_gh_issue_update_controller
-    eval "echo \"$(cat "$GITHUB_ISSUE_BODY_TEMPLATE_FILE")\"" > $GITHUB_ISSUE_BODY_FILE
+    eval "echo \"$(cat "$GITHUB_ISSUE_BODY_TEMPLATE_FILE")\"" > "$GITHUB_ISSUE_BODY_FILE"
 
     open_gh_issue "$GITHUB_ISSUE_ORG_REPO" "$ISSUE_TITLE" "$GITHUB_ISSUE_BODY_FILE"
     # Skip creating PR for this service controller after updating GitHub issue.
@@ -174,10 +175,11 @@ for CONTROLLER_NAME in $CONTROLLER_NAMES; do
 
     # Capture 'make run' command output, then persist
     # in '$GITHUB_PR_BODY_FILE'
+    # shellcheck disable=SC2034 # Variables are used in templates
     MAKE_RUN_OUTPUT=$(cat "$MAKE_RUN_OUTPUT_FILE")
     GITHUB_PR_BODY_TEMPLATE_FILE="$THIS_DIR/gh_pr_body_template.txt"
     GITHUB_PR_BODY_FILE=/tmp/"$SERVICE_NAME"_gh_pr_body_update_controller
-    eval "echo \"$(cat "$GITHUB_PR_BODY_TEMPLATE_FILE")\"" > $GITHUB_PR_BODY_FILE
+    eval "echo \"$(cat "$GITHUB_PR_BODY_TEMPLATE_FILE")\"" > "$GITHUB_PR_BODY_FILE"
 
     open_pull_request "$GITHUB_CONTROLLER_ORG_REPO" "$COMMIT_MSG" "$GITHUB_PR_BODY_FILE"
     echo "project-static-files.sh][INFO] Done :) "

--- a/cd/core-validator/generate-test-controller.sh
+++ b/cd/core-validator/generate-test-controller.sh
@@ -12,7 +12,6 @@ Environment variables:
 
 # Important Directory references based on prowjob configuration.
 THIS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
-CORE_VALIDATOR_DIR=$THIS_DIR
 CD_DIR=$THIS_DIR/..
 TEST_INFRA_DIR=$CD_DIR/..
 WORKSPACE_DIR=$TEST_INFRA_DIR/..

--- a/cd/lib/gh.sh
+++ b/cd/lib/gh.sh
@@ -26,8 +26,8 @@ open_gh_issue() {
   fi
 
   echo -n "gh.sh][INFO] Querying already open GitHub issue ... "
-  local __issue_number=$(gh issue list -R "$__org_repo" -L 1 -s open --json number -S "$__issue_title" --jq '.[0].number' -A @me $__label_arg)
-  if [[ $? -ne 0 ]]; then
+  local __issue_number
+  if ! __issue_number=$(gh issue list -R "$__org_repo" -L 1 -s open --json number -S "$__issue_title" --jq '.[0].number' -A @me "$__label_arg"); then
     echo ""
     echo "gh.sh][ERROR] Unable to query open github issues."
   else
@@ -36,7 +36,7 @@ open_gh_issue() {
 
   if [[ -z $__issue_number ]]; then
     echo -n "gh.sh][INFO] No open issues exist. Creating a new GitHub issue inside $__org_repo ... "
-    if ! gh issue create -R "$__org_repo" -t "$__issue_title" -F "$__issue_body_file_path" $__label_arg >/dev/null ; then
+    if ! gh issue create -R "$__org_repo" -t "$__issue_title" -F "$__issue_body_file_path" "$__label_arg" >/dev/null ; then
       echo ""
       echo "gh.sh][ERROR] Unable to create GitHub issue"
     else
@@ -83,8 +83,8 @@ open_pull_request() {
   fi
 
   echo -n "gh.sh][INFO] Finding existing open pull requests ... "
-  local __pr_number=$(gh pr list -R "$__org_repo" -A @me -L 1 -s open --json number -S "$__commit_msg" --jq '.[0].number' $__label_arg)
-  if [[ $? -ne 0 ]]; then
+  local __pr_number
+  if ! __pr_number=$(gh pr list -R "$__org_repo" -A @me -L 1 -s open --json number -S "$__commit_msg" --jq '.[0].number' "$__label_arg"); then
     echo ""
     echo "gh.sh][ERROR] Failed to query for an existing pull request for $__org_repo , from $__source_branch -> $__target_branch branch"
   else
@@ -93,7 +93,7 @@ open_pull_request() {
 
   if [[ -z $__pr_number ]]; then
     echo -n "gh.sh][INFO] No Existing PRs found. Creating a new pull request for $__org_repo , from $__source_branch -> $__target_branch branch... "
-    if ! gh pr create -R "$__org_repo" -t "$__commit_msg" -F "$__pr_body_file_path" -B "$__target_branch" $__label_arg >/dev/null ; then
+    if ! gh pr create -R "$__org_repo" -t "$__commit_msg" -F "$__pr_body_file_path" -B "$__target_branch" "$__label_arg" >/dev/null ; then
       echo ""
       echo "gh.sh][ERROR] Failed to create pull request. Exiting... "
       return 1

--- a/cd/olm/olm-bundle-pr.sh
+++ b/cd/olm/olm-bundle-pr.sh
@@ -42,7 +42,6 @@ export ACK_GENERATE_OLM=true
 
 # Important Directory references based on prowjob configuration.
 THIS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
-OLM_DIR=$THIS_DIR
 CD_DIR=$THIS_DIR/..
 TEST_INFRA_DIR=$CD_DIR/..
 WORKSPACE_DIR=$TEST_INFRA_DIR/..
@@ -111,7 +110,9 @@ if ! ./scripts/build-controller-release.sh "$SERVICE" > "$OLM_BUNDLE_STDOUT_FILE
   ISSUE_TITLE="Errors while generating olm bundle for \`$CONTROLLER_NAME-$RELEASE_VERSION\`"
   # Capture 'build-controller-release.sh' command output & error, then persist
   # in '$GITHUB_ISSUE_BODY_FILE_PATH'
+  # shellcheck disable=SC2034 # Variables are used in templates
   OLM_BUNDLE_STDOUT=$(cat "$OLM_BUNDLE_STDOUT_FILE")
+  # shellcheck disable=SC2034 # Variables are used in templates
   OLM_BUNDLE_STDERR=$(cat "$OLM_BUNDLE_STDERR_FILE")
   GITHUB_ISSUE_BODY_TEMPLATE_FILE="$THIS_DIR/gh_issue_olm_create_error_template.txt"
   GITHUB_ISSUE_BODY_FILE_PATH=/tmp/"$SERVICE"_gh_issue_body
@@ -125,7 +126,6 @@ fi
 for OH_ORG_REPO in k8s-operatorhub/community-operators redhat-openshift-ecosystem/community-operators-prod
 do
   cd "$WORKSPACE_DIR"
-  OH_ORG=$(echo "$OH_ORG_REPO" | cut -d"/" -f1)
   OH_REPO=$(echo "$OH_ORG_REPO" | cut -d"/" -f2)
   echo -n "olm-bundle-pr.sh][INFO] forking and cloning $OH_ORG_REPO... "
   if ! gh repo fork "$OH_ORG_REPO" --clone=true --remote=true >/dev/null; then

--- a/prow/jobs/images/build-docs.sh
+++ b/prow/jobs/images/build-docs.sh
@@ -21,7 +21,7 @@ DOCS_PATH="${COMMUNITY_PATH}/docs"
 
 # Generate new reference sources
 
-pushd $DOCS_PATH 1> /dev/null
+pushd "$DOCS_PATH" 1> /dev/null
 
 echo "build-docs.sh] 📝 Installing requirements file... "
 pip install -r requirements.txt

--- a/prow/jobs/images/build-images.sh
+++ b/prow/jobs/images/build-images.sh
@@ -37,8 +37,9 @@ docker build -f "$IMAGE_DIR/Dockerfile.auto-update-controllers" "${docker_build_
 docker build -f "$IMAGE_DIR/Dockerfile.controller-release-tag" "${docker_build_args[@]}" -t "prow/controller-release-tag" "${IMAGE_DIR}"
 docker build -f "$IMAGE_DIR/Dockerfile.soak" "${docker_build_args[@]}" --build-arg DEPLOY_BASE_TAG="prow/deploy" -t "prow/soak" "${IMAGE_DIR}"
 
-export TEST_BASE_TAG=$(echo "prow/test-$(uuidgen | cut -c1-8)" | tr '[:upper:]' '[:lower:]')
-docker build -f "$IMAGE_DIR/Dockerfile.test" "${docker_build_args[@]}" -t $TEST_BASE_TAG "${IMAGE_DIR}"
+TEST_BASE_TAG=$(echo "prow/test-$(uuidgen | cut -c1-8)" | tr '[:upper:]' '[:lower:]')
+export TEST_BASE_TAG
+docker build -f "$IMAGE_DIR/Dockerfile.test" "${docker_build_args[@]}" -t "$TEST_BASE_TAG" "${IMAGE_DIR}"
 
 for IMAGE_TYPE in integration unit; do
   docker build -f "$IMAGE_DIR/Dockerfile.$IMAGE_TYPE" "${docker_build_args[@]}" --build-arg TEST_BASE_TAG -t "prow/$IMAGE_TYPE" "${IMAGE_DIR}"

--- a/prow/jobs/images/push-image.sh
+++ b/prow/jobs/images/push-image.sh
@@ -16,8 +16,9 @@ Usage:
 Pushes all of the tagged 'prow/*' images into a public ECR repository. Use
 DOCKER_REPOSITORY to specify the ECR repository URI. Use VERSION to set the 
 SemVer value in the image tag.
-Valid IMAGE_TYPE are "deploy", "docs", "soak", "integration", "auto-generate-controllers",
-"auto-update-controllers", "olm-bundle-pr", "olm-test", "controller-release-tag" and "unit"
+Valid IMAGE_TYPE are \"deploy\", \"docs\", \"soak\", \"integration\",
+\"auto-generate-controllers\", \"auto-update-controllers\", \"olm-bundle-pr\",
+\"olm-test\", \"controller-release-tag\" and \"unit\"
 
 Example:
 $(basename "$0") integration
@@ -39,13 +40,10 @@ fi
 
 IMAGE_TYPE=$(echo "$1" | tr '[:upper:]' '[:lower:]')
 
-# Important Directory references
-DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
-IMAGE_DIR=$DIR
-
 docker_login() {
   #ecr-public only exists in us-east-1 so use that region specifically
-  local __pw=$(aws ecr-public get-login-password --region us-east-1)
+  local __pw
+  __pw=$(aws ecr-public get-login-password --region us-east-1)
   echo "$__pw" | docker login -u AWS --password-stdin public.ecr.aws
 }
 
@@ -57,5 +55,5 @@ image_tag() {
 
 docker_login
 
-docker tag prow/$IMAGE_TYPE $(image_tag $IMAGE_TYPE)
-docker push $(image_tag $IMAGE_TYPE)
+docker tag "prow/$IMAGE_TYPE" "$(image_tag "$IMAGE_TYPE")"
+docker push "$(image_tag "$IMAGE_TYPE")"

--- a/prow/jobs/images/wrapper.sh
+++ b/prow/jobs/images/wrapper.sh
@@ -29,6 +29,7 @@ cleanup(){
   fi
 }
 
+# shellcheck disable=SC2317 # Ignore unused function since this is attached to trap
 early_exit_handler() {
   >&2 echo "wrapper.sh] [EARLY EXIT] Interrupted, entering handler ..."
   if [ -n "${EXIT_VALUE:-}" ]; then
@@ -110,7 +111,7 @@ aws ecr-public get-login-password --region us-east-1 | docker login --username A
 >&2 echo "wrapper.sh] [SETUP] Logged in"
 
 ASSUME_EXIT_VALUE=0
-ASSUMED_ROLE_ARN=$(aws ssm get-parameter --name /ack/prow/service_team_role/$AWS_SERVICE --query Parameter.Value --output text 2>/dev/null) || ASSUME_EXIT_VALUE=$?
+ASSUMED_ROLE_ARN=$(aws ssm get-parameter --name "/ack/prow/service_team_role/$AWS_SERVICE" --query Parameter.Value --output text 2>/dev/null) || ASSUME_EXIT_VALUE=$?
 if [ "$ASSUME_EXIT_VALUE" -ne 0 ]; then
   >&2 echo "wrapper.sh] [SETUP] Could not find service team role for $AWS_SERVICE"
   exit 1
@@ -118,8 +119,8 @@ fi
 export ASSUMED_ROLE_ARN
 >&2 echo "wrapper.sh] [SETUP] Exported ASSUMED_ROLE_ARN"
 
-ASSUME_COMMAND=$(aws sts assume-role --role-arn $ASSUMED_ROLE_ARN --role-session-name $PROW_JOB_ID --duration-seconds 3600 | jq -r '.Credentials | "export AWS_ACCESS_KEY_ID=\(.AccessKeyId)\nexport AWS_SECRET_ACCESS_KEY=\(.SecretAccessKey)\nexport AWS_SESSION_TOKEN=\(.SessionToken)\n"')
-eval $ASSUME_COMMAND
+ASSUME_COMMAND=$(aws sts assume-role --role-arn "$ASSUMED_ROLE_ARN" --role-session-name "$PROW_JOB_ID" --duration-seconds 3600 | jq -r '.Credentials | "export AWS_ACCESS_KEY_ID=\(.AccessKeyId)\nexport AWS_SECRET_ACCESS_KEY=\(.SecretAccessKey)\nexport AWS_SESSION_TOKEN=\(.SessionToken)\n"')
+eval "$ASSUME_COMMAND"
 >&2 echo "wrapper.sh] [SETUP] Assumed ASSUMED_ROLE_ARN"
 
 # actually run the user supplied command

--- a/scripts/helm.sh
+++ b/scripts/helm.sh
@@ -21,23 +21,26 @@ source "$SCRIPTS_DIR/controller-setup.sh"
 _assert_pod_running() {
     local __chart_namespace=$1
 
-    local controller_pod_name=$(kubectl get pods -n $__chart_namespace -ojson | jq -r ".items[0].metadata.name")
+    local controller_pod_name
+    controller_pod_name=$(kubectl get pods -n "$__chart_namespace" -ojson | jq -r ".items[0].metadata.name")
     [[ -z "$controller_pod_name" ]] && { error_msg "Unable to find controller pod"; return 1; }
 
     debug_msg "ACK $AWS_SERVICE controller pod name is $__chart_namespace/$controller_pod_name"
     info_msg "Verifying that pod status is in Running state ... "
 
-    local pod_status=$(kubectl get pod/"$controller_pod_name" -n $__chart_namespace -ojson | jq -r ".status.phase")
+    local pod_status
+    pod_status=$(kubectl get pod/"$controller_pod_name" -n "$__chart_namespace" -ojson | jq -r ".status.phase")
     [[ $pod_status != Running ]] && { error_msg "Pod is in status '$pod_status'. Expected 'Running' "; return 1; }
 
     info_msg "Verifying that there are no ERROR in controller logs ... "
 
-    local controller_logs=$(kubectl logs pod/"$controller_pod_name" -n $__chart_namespace)
+    local controller_logs
+    controller_logs=$(kubectl logs pod/"$controller_pod_name" -n "$__chart_namespace")
     [[ -z "$controller_logs" ]] && { error_msg "Unable to find controller logs"; return 1; }
 
     if (echo "$controller_logs" | grep -q "ERROR"); then
         error_msg "Found following ERROR statements in controller logs:"
-        error_msg "$(echo $controller_logs | grep "ERROR")"
+        error_msg "$(echo "$controller_logs" | grep "ERROR")"
         return 1
     fi
 }

--- a/scripts/iam-policy-test-runner.sh
+++ b/scripts/iam-policy-test-runner.sh
@@ -44,7 +44,7 @@ assert_iam_policies() {
     fi
 
     info_msg "Validating contents of recommended-policy-arn ..."
-    for policy_arn in $(awk NF=NF FS="\n" $recommended_policy_path); do
+    for policy_arn in $(awk NF=NF FS="\n" "$recommended_policy_path"); do
         debug_msg "Validating \"$policy_arn\" ..."
         if ! (aws iam get-policy --policy-arn "$policy_arn" >/dev/null); then
             error_msg "\"$policy_arn\" is not a valid managed IAM policy ARN"

--- a/scripts/lib/common.sh
+++ b/scripts/lib/common.sh
@@ -35,7 +35,7 @@ check_is_installed() {
 
 is_installed() {
     local __name="$1"
-    if $(which $__name >/dev/null 2>&1); then
+    if which "$__name" >/dev/null 2>&1; then
         return 0
     else
         return 1

--- a/scripts/lib/config.sh
+++ b/scripts/lib/config.sh
@@ -20,9 +20,9 @@ _get_config_field() {
     local __default="${2:-""}"
 
     if [[ "$__default" != "" ]]; then
-        yq "$__field_path // \"$__default\"" $TEST_CONFIG_PATH 2>/dev/null
+        yq "$__field_path // \"$__default\"" "$TEST_CONFIG_PATH" 2>/dev/null
     else
-        yq "$__field_path // \"\"" $TEST_CONFIG_PATH 2>/dev/null
+        yq "$__field_path // \"\"" "$TEST_CONFIG_PATH" 2>/dev/null
     fi
 }
 
@@ -33,11 +33,12 @@ _get_config_boolean() {
     local __field_path="$1"
     local __default="${2:-""}"
 
-    local ret=$(yq "$__field_path" $TEST_CONFIG_PATH 2>/dev/null)
+    local ret
+    ret=$(yq "$__field_path" "$TEST_CONFIG_PATH" 2>/dev/null)
     if [[ "$ret" == "null" ]]; then
-        echo $__default
+        echo "$__default"
     fi
-    echo $ret
+    echo "$ret"
 }
 
 get_cluster_create() { _get_config_boolean ".cluster.create"; }
@@ -49,7 +50,7 @@ get_aws_profile() { _get_config_field ".aws.profile"; }
 get_aws_token_file() { _get_config_field ".aws.token_file"; }
 get_aws_region() { _get_config_field ".aws.region" "us-west-2"; }
 get_assumed_role_arn() {
-    [[ ! -z "${ASSUMED_ROLE_ARN}" ]] && echo "${ASSUMED_ROLE_ARN}" || _get_config_field ".aws.assumed_role_arn";
+    [[ -n "${ASSUMED_ROLE_ARN}" ]] && echo "${ASSUMED_ROLE_ARN}" || _get_config_field ".aws.assumed_role_arn";
 }
 get_test_markers() { _get_config_field ".tests.markers"; }
 get_test_methods() { _get_config_field ".tests.methods"; }
@@ -70,7 +71,7 @@ ensure_required_fields() {
 
     local required_field_paths=( ".cluster.create" )
     for path in "${required_field_paths[@]}"; do
-        [[ -z $(_get_config_boolean $path) ]] && { error_msg "Required config path \`$path\` not provided"; exit 1; } || :
+        [[ -z $(_get_config_boolean "$path") ]] && { error_msg "Required config path \`$path\` not provided"; exit 1; } || :
     done
 }
 

--- a/scripts/lib/logging.sh
+++ b/scripts/lib/logging.sh
@@ -12,26 +12,27 @@ _indented_msg() {
     local __indent_level=${2:-}
     local indent=""
     if [ -n "$__indent_level" ]; then
-        indent="$( for each in $( seq 0 $__indent_level ); do printf " "; done )"
+        indent="$( for _ in $( seq 0 "$__indent_level" ); do printf " "; done )"
     fi
 
-    local timestamp=$(date +"%Y-%m-%dT%H:%M:%S")
+    local timestamp
+    timestamp=$(date +"%Y-%m-%dT%H:%M:%S")
 
-    echo "$timestamp $__indent$__msg"
+    echo "$timestamp $indent$__msg"
 }
 
 # debug_msg prints out a supplied message if the ACK_TEST_DEBUGGING_MODE environ
 # variable is set.
 debug_msg() {
     local __debug="${ACK_TEST_DEBUGGING_MODE:-""}"
-    if [ ! -n "$__debug" ]; then
+    if [ -z "$__debug" ]; then
         return 0
     fi
 
     local __msg=${1:-}
     local __indent=${2:-}
     local __debug_prefix="${DEBUG_PREFIX:-"[DEBUG] "}"
-    _indented_msg "$__debug_prefix$__msg" $__indent
+    _indented_msg "$__debug_prefix$__msg" "$__indent"
 }
 
 # info_msg prints out a supplied message if the DEBUG environs variable is
@@ -40,7 +41,7 @@ info_msg() {
     local __msg=${1:-}
     local __indent=${2:-}
     local __info_prefix="${INFO_PREFIX:-"[INFO] "}"
-    _indented_msg "$__info_prefix$__msg" $__indent
+    _indented_msg "$__info_prefix$__msg" "$__indent"
 }
 
 # debug_msg prints out a supplied message if the DEBUG environs variable is
@@ -49,5 +50,5 @@ error_msg() {
     local __msg=${1:-}
     local __indent=${2:-}
     local __error_prefix="${ERROR_PREFIX:-"[ERROR] "}"
-    >&2 _indented_msg "$__error_prefix$__msg" $__indent
+    >&2 _indented_msg "$__error_prefix$__msg" "$__indent"
 }

--- a/scripts/lib/login.sh
+++ b/scripts/lib/login.sh
@@ -10,7 +10,8 @@
 
 perform_buildah_and_helm_login() {
   #ecr-public only exists in us-east-1 so use that region specifically
-  local __pw=$(aws ecr-public get-login-password --region us-east-1)
+  local __pw
+  __pw=$(aws ecr-public get-login-password --region us-east-1)
   echo "$__pw" | buildah login -u AWS --password-stdin public.ecr.aws
   export HELM_EXPERIMENTAL_OCI=1
   echo "$__pw" | helm registry login -u AWS --password-stdin public.ecr.aws

--- a/scripts/public-ecr.sh
+++ b/scripts/public-ecr.sh
@@ -17,12 +17,13 @@ ensure_repository() {
         fi
 
         export aws_service
-        local catalog_data=$(envsubst < $ecr_tpl_file_path 2>&1)
+        local catalog_data
+        catalog_data=$(envsubst < "$ecr_tpl_file_path" 2>&1)
 
-        if ! (aws ecr-public describe-repositories --region us-east-1 --repository-names $ecr_repo >/dev/null 2>&1); then
+        if ! (aws ecr-public describe-repositories --region us-east-1 --repository-names "$ecr_repo" >/dev/null 2>&1); then
             echo "ensure-ecr-repository.sh][INFO] $ecr_repo repository does not exist in Amazon ECR public repositories for AWS Controllers for Kubernetes (ACK), creating $ecr_repo public repository ..."
-            aws ecr-public create-repository --region us-east-1 --repository-name $ecr_repo 1>/dev/null
-            aws ecr-public put-repository-catalog-data --region us-east-1 --repository-name $ecr_repo --catalog-data "$catalog_data" 1>/dev/null
+            aws ecr-public create-repository --region us-east-1 --repository-name "$ecr_repo" 1>/dev/null
+            aws ecr-public put-repository-catalog-data --region us-east-1 --repository-name "$ecr_repo" --catalog-data "$catalog_data" 1>/dev/null
         fi
     done
 }

--- a/scripts/pytest-local-runner.sh
+++ b/scripts/pytest-local-runner.sh
@@ -34,22 +34,24 @@ cleanup_tests() {
 }
 
 run_python_tests() {
-    local markers_args=""
-    local method_args=""
+    local markers_args=()
+    local method_args=()
 
     for (( i=0; i<$(get_test_markers | yq '. | length' -); i++)); do
-        local test_marker="$(get_test_markers | I=$i yq '.[env(I)]' -)"
-        markers_args="$markers_args -m "$test_marker""
+        local test_marker
+        test_marker="$(get_test_markers | I=$i yq '.[env(I)]' -)"
+        markers_args=("${markers_args[@]}" -m "$test_marker")
     done
 
     for (( i=0; i<$(get_test_methods | yq '. | length' -); i++)); do
-        local test_method="$(get_test_methods | I=$i yq '.[env(I)]' -)"
-        method_args="$method_args -k $test_method"
+        local test_method
+        test_method="$(get_test_methods | I=$i yq '.[env(I)]' -)"
+        method_args=("${method_args[@]}" -k "$test_method")
     done
 
     pushd "${SERVICE_CONTROLLER_E2E_TEST_PATH}" 1> /dev/null
-        pytest -n ${PYTEST_NUM_THREADS} --dist no -o log_cli=true ${markers_args} \
-            ${method_args} --log-cli-level "${PYTEST_LOG_LEVEL}" \
+        pytest -n "${PYTEST_NUM_THREADS}" --dist no -o log_cli=true "${markers_args[@]}" \
+            "${method_args[@]}" --log-cli-level "${PYTEST_LOG_LEVEL}" \
             --log-level "${PYTEST_LOG_LEVEL}" .
         local test_exit_code=$?
     popd 1> /dev/null

--- a/scripts/run-e2e-tests.sh
+++ b/scripts/run-e2e-tests.sh
@@ -16,7 +16,7 @@ CONTROLLER_NAMESPACE=${CONTROLLER_NAMESPACE:-"ack-system"}
 DEFAULT_SERVICE_CONTROLLER_SOURCE_PATH="$ROOT_DIR/../$AWS_SERVICE-controller"
 SERVICE_CONTROLLER_SOURCE_PATH=${SERVICE_CONTROLLER_SOURCE_PATH:-$DEFAULT_SERVICE_CONTROLLER_SOURCE_PATH}
 
-VERSION=$(git --git-dir=$SERVICE_CONTROLLER_SOURCE_PATH/.git describe --tags --always --dirty || echo "unknown")
+VERSION=$(git "--git-dir=$SERVICE_CONTROLLER_SOURCE_PATH/.git" describe --tags --always --dirty || echo "unknown")
 CONTROLLER_IMAGE_TAG="aws-controllers-k8s:${AWS_SERVICE}-${VERSION}"
 
 source "$SCRIPTS_DIR/lib/aws.sh"
@@ -29,9 +29,11 @@ source "$SCRIPTS_DIR/kind.sh"
 source "$SCRIPTS_DIR/pytest-image-runner.sh"
 
 ensure_cluster() {
-    local cluster_create="$(get_cluster_create)"
+    local cluster_create
+    cluster_create="$(get_cluster_create)"
     if [[ "$cluster_create" == true ]]; then
-        local cluster_name=$(_get_kind_cluster_name)
+        local cluster_name
+        cluster_name=$(_get_kind_cluster_name)
 
         info_msg "Creating KIND cluster ..."
         setup_kind_cluster "$cluster_name" "$CONTROLLER_NAMESPACE"
@@ -44,7 +46,8 @@ ensure_cluster() {
 }
 
 ensure_debug_mode() {
-    local debug_enabled="$(get_debug_enabled)"
+    local debug_enabled
+    debug_enabled="$(get_debug_enabled)"
     if [[ "$debug_enabled" == true && ${ACK_TEST_DEBUGGING_MODE-""} == "" ]]; then
         export ACK_TEST_DEBUGGING_MODE="true"
         debug_msg "Debug mode enabled"
@@ -52,10 +55,12 @@ ensure_debug_mode() {
 }
 
 build_and_run_tests() {
-    local run_locally=$(get_run_tests_locally)
+    local run_locally
+    run_locally=$(get_run_tests_locally)
     local test_exit_code=0
     if [[ "$run_locally" == true ]]; then
-        local region=$(get_aws_region)
+        local region
+        region=$(get_aws_region)
         source "$SCRIPTS_DIR/pytest-local-runner.sh"
 
         set +e
@@ -63,7 +68,8 @@ build_and_run_tests() {
         test_exit_code=$?
         set -e
     else
-        local image_uuid=$(uuidgen | cut -d'-' -f1 | tr '[:upper:]' '[:lower:]')
+        local image_uuid
+        image_uuid=$(uuidgen | cut -d'-' -f1 | tr '[:upper:]' '[:lower:]')
         local image_name="ack-test-${AWS_SERVICE}-${image_uuid}"
 
         build_pytest_image "$image_name"
@@ -74,7 +80,8 @@ build_and_run_tests() {
         set -e
     fi
 
-    local dump_logs=$(get_dump_controller_logs)
+    local dump_logs
+    dump_logs=$(get_dump_controller_logs)
     if [[ "$dump_logs" == "true" ]]; then
         dump_controller_logs "$CONTROLLER_NAMESPACE"
     fi

--- a/soak/run_soak_test.sh
+++ b/soak/run_soak_test.sh
@@ -24,7 +24,7 @@ Environment variables:
   DEFAULT_SOAK_DURATION_MINUTES: Default duration of soak test execution in minutes.
 "
 
-SOAK_DURATION_MINUTES=$(yq eval ".durationMinutes // \"$DEFAULT_SOAK_DURATION_MINUTES\"" $SOAK_CONFIG_PATH) #default: $DEFAULT_SOAK_DURATION_MINUTES
+SOAK_DURATION_MINUTES=$(yq eval ".durationMinutes // \"$DEFAULT_SOAK_DURATION_MINUTES\"" "$SOAK_CONFIG_PATH") #default: $DEFAULT_SOAK_DURATION_MINUTES
 echo "[INFO] Starting the soak test run."
 echo "[INFO] START_TIME_EPOCH_SECONDS is $START_TIME_EPOCH_SECONDS"
 ((END_TIME_EPOCH_SECONDS= "$START_TIME_EPOCH_SECONDS" + "$SOAK_DURATION_MINUTES"*60))
@@ -35,17 +35,17 @@ pushd "${CONTROLLER_E2E_PATH}" 1>/dev/null
 export PYTHONPATH=..
 python service_bootstrap.py
 set +e
-ALL_PYTEST_MARKERS=$(yq eval '.pytestMarkers|keys|.[]' $SOAK_CONFIG_PATH)
+ALL_PYTEST_MARKERS=$(yq eval '.pytestMarkers|keys|.[]' "$SOAK_CONFIG_PATH")
 #If current time is less than $END_TIME_EPOCH_SECONDS, keep executing the e2e tests.
-while [ $(date +%s) -le $END_TIME_EPOCH_SECONDS ]
+while [ "$(date +%s)" -le $END_TIME_EPOCH_SECONDS ]
 do
   echo "[INFO] Current time is $(date +%s%3N) and end time is $END_TIME_EPOCH_SECONDS in epoch seconds. Executing e2e tests..."
-  for marker in `echo $ALL_PYTEST_MARKERS`
+  for marker in $ALL_PYTEST_MARKERS
   do
-	  log_level=$(yq eval ".pytestMarkers.$marker.logLevel // \"info\"" $SOAK_CONFIG_PATH) #default: info
-	  num_threads=$(yq eval ".pytestMarkers.$marker.numThreads // \"auto\"" $SOAK_CONFIG_PATH) #default: auto
-	  dist=$(yq eval ".pytestMarkers.$marker.dist // \"no\"" $SOAK_CONFIG_PATH) # default: no
-	  pytest -m $marker -n $num_threads --dist $dist -o log_cli=true --log-cli-level $log_level --log-level $log_level .
+	  log_level=$(yq eval ".pytestMarkers.$marker.logLevel // \"info\"" "$SOAK_CONFIG_PATH") #default: info
+	  num_threads=$(yq eval ".pytestMarkers.$marker.numThreads // \"auto\"" "$SOAK_CONFIG_PATH") #default: auto
+	  dist=$(yq eval ".pytestMarkers.$marker.dist // \"no\"" "$SOAK_CONFIG_PATH") # default: no
+	  pytest -m "$marker" -n "$num_threads" --dist "$dist" -o log_cli=true --log-cli-level "$log_level" --log-level "$log_level" .
   done
 done
 


### PR DESCRIPTION
Description of changes:
Used the output of the `shellcheck` tool to make style changes to all of the shell scripts within the repository. Added a new `make` target for `lint-shell` which lints all of the scripts and excludes [SC1091](https://www.shellcheck.net/wiki/SC1091), which fails because we `source` other scripts using path variables (a known limitation of `shellcheck`), and [SC2015](https://www.shellcheck.net/wiki/SC2015), which fails because we are using ternaries for some part of the configuration checking code which `shellcheck` warns may cause early execution of functions.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
