### PR TITLE
Fix Prow ingress priority

### DIFF
--- a/prow/config/Chart.yaml
+++ b/prow/config/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: prow-config
 description: Configuration for the ACK Prow cluster
 type: application
-version: 0.3.0
+version: 0.3.1
 appVersion: "1.16.0"

--- a/prow/config/templates/ing-Ingress.yaml
+++ b/prow/config/templates/ing-Ingress.yaml
@@ -24,13 +24,6 @@ spec:
   - host: {{ .Values.prow.domain }}
     http:
       paths:
-      - path: /*
-        pathType: ImplementationSpecific
-        backend:
-          service:
-            name: deck
-            port:
-              number: 80
       - path: /hook
         pathType: ImplementationSpecific
         backend:
@@ -43,6 +36,13 @@ spec:
         backend:
           service:
             name: pushgateway-external
+            port:
+              number: 80
+      - path: /*
+        pathType: ImplementationSpecific
+        backend:
+          service:
+            name: deck
             port:
               number: 80
 {{ end }}

--- a/prow/config/values.yaml
+++ b/prow/config/values.yaml
@@ -42,7 +42,7 @@ hook:
   scrapeMetrics: false
   image: gcr.io/k8s-prow/hook:v20221121-dfec9ce18d
   service:
-    type: 'LoadBalancer'
+    type: 'ClusterIP'
   serviceAccount:
     create: false
     name: ''


### PR DESCRIPTION
Description of changes:
I noticed that the webhooks weren't working. When looking at the webhook panel within the Github app I saw that they were being met with 404s at `/hook`. Doing some digging, I found that the 404s were being returned by the `deck` service rather than `hook`. After adjusting the order that the ingress defines its routes, putting `/hook` and `/metrics` before `/*`, it gave precedence to the more specific subroutes and the webhooks were able to be delivered.

In this PR I also downgraded the `hook` from a `LoadBalancer` to a `ClusterIP` by default. Since this service is exposed through the ingress, which is itself behind a `LoadBalancer`, there is no need to serve it with an ALB. This is how it works for `deck` and so just to stay consistent this is how it should also work for `hook`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
