### PR TITLE
Prow: Add Karpenter configuration

### DIFF
--- a/infra/bin/test-ci.ts
+++ b/infra/bin/test-ci.ts
@@ -1,10 +1,10 @@
 #!/usr/bin/env node
 import "source-map-support/register";
 import { App } from "aws-cdk-lib";
-import { TestCIStack } from "../lib/test-ci-stack";
+import { TestCIStack, STACK_NAME } from "../lib/test-ci-stack";
 
 const app = new App();
-new TestCIStack(app, "TestCIStack", {
+new TestCIStack(app, STACK_NAME, {
   /* If you don't specify 'env', this stack will be environment-agnostic.
    * Account/Region-dependent features and context lookups will not work,
    * but a single synthesized template can be deployed anywhere. */

--- a/infra/lib/ci-cluster.ts
+++ b/infra/lib/ci-cluster.ts
@@ -44,6 +44,7 @@ export class CICluster extends Construct {
     };
 
     const karpenterAddonProps = {
+      version: "v0.24.0",
       requirements: [
           {
             key: 'node.kubernetes.io/instance-type',

--- a/infra/lib/ci-cluster.ts
+++ b/infra/lib/ci-cluster.ts
@@ -57,13 +57,12 @@ export class CICluster extends Construct {
         new ImportHostedZoneProvider(props.hostedZoneId)
       )
       .addOns(
-        new blueprints.addons.VpcCniAddOn(),
-        new blueprints.addons.KarpenterAddOn(),
-        new blueprints.addons.AwsLoadBalancerControllerAddOn(),
-        new blueprints.addons.EbsCsiDriverAddOn(),
-        new blueprints.addons.ExternalDnsAddOn({
-          hostedZoneResources: [GlobalResources.HostedZone],
-        })
+        new blueprints.CertManagerAddOn,
+        new blueprints.AwsLoadBalancerControllerAddOn,
+        new blueprints.VpcCniAddOn,
+        new blueprints.KarpenterAddOn,
+        new blueprints.EbsCsiDriverAddOn,
+        new blueprints.ExternalDnsAddOn({ hostedZoneResources: [GlobalResources.HostedZone] })
       )
       .build(this, "TestInfraCluster");
 

--- a/infra/lib/ci-cluster.ts
+++ b/infra/lib/ci-cluster.ts
@@ -65,8 +65,7 @@ export class CICluster extends Construct {
       securityGroupTags: securityGroupTags,
       amiFamily: "AL2" as const,
       consolidation: { enabled: true },
-      ttlSecondsUntilExpired: 30 * 24 * 60 * 60, // 30 days in seconds
-      weight: 20,
+      ttlSecondsUntilExpired: 1 * 60 * 60, // 1 hour in seconds
       interruptionHandling: true,
     }
     const karpenterAddOn = new blueprints.addons.KarpenterAddOn(karpenterAddonProps);

--- a/infra/lib/ci-cluster.ts
+++ b/infra/lib/ci-cluster.ts
@@ -60,14 +60,9 @@ export class CICluster extends Construct {
       ],
       subnetTags: { "Name": subnetTagPattern },
       securityGroupTags: { securityGroupTagPattern : "owned" },
-      taints: [{
-        key: "workload",
-        value: "test",
-        effect: "NoSchedule" as const,
-      }],
       amiFamily: "AL2" as const,
       consolidation: { enabled: true },
-      ttlSecondsUntilExpired: 2592000,
+      ttlSecondsUntilExpired: 30 * 24 * 60 * 60, // 30 days in seconds
       weight: 20,
       interruptionHandling: true,
     }

--- a/infra/lib/ci-cluster.ts
+++ b/infra/lib/ci-cluster.ts
@@ -39,6 +39,9 @@ export class CICluster extends Construct {
 
     const subnetTagPattern = `${STACK_NAME}/${CLUSTER_CONSTRUCT_NAME}/${CLUSTER_NAME}/${CLUSTER_NAME}-vpc/PrivateSubnet*`;
     const securityGroupTagPattern = "kubernetes.io/cluster/" + CLUSTER_NAME;
+    const securityGroupTags = {
+      [securityGroupTagPattern] : "owned",
+    };
 
     const karpenterAddonProps = {
       requirements: [
@@ -59,7 +62,7 @@ export class CICluster extends Construct {
           },
       ],
       subnetTags: { "Name": subnetTagPattern },
-      securityGroupTags: { securityGroupTagPattern : "owned" },
+      securityGroupTags: securityGroupTags,
       amiFamily: "AL2" as const,
       consolidation: { enabled: true },
       ttlSecondsUntilExpired: 30 * 24 * 60 * 60, // 30 days in seconds

--- a/infra/lib/test-ci-stack.ts
+++ b/infra/lib/test-ci-stack.ts
@@ -4,9 +4,13 @@ import { LogBucket, LogBucketCompileProps } from "./log-bucket";
 import { ProwServiceAccounts } from "./prow-service-accounts";
 import { Stack, StackProps } from "aws-cdk-lib";
 
+export const STACK_NAME = "TestCIStack";
 export const PROW_NAMESPACE = "prow";
 export const PROW_JOB_NAMESPACE = "test-pods";
 export const FLUX_NAMESPACE = "flux-system";
+
+export const CLUSTER_NAME = "TestInfraCluster";
+export const CLUSTER_CONSTRUCT_NAME = "CIClusterConstruct";
 
 export type TestCIStackProps = StackProps &
   LogBucketCompileProps & {
@@ -22,7 +26,7 @@ export class TestCIStack extends Stack {
       account: this.account,
     });
 
-    const testCluster = new CICluster(this, "CIClusterConstruct", {
+    const testCluster = new CICluster(this, CLUSTER_CONSTRUCT_NAME, {
       ...props.clusterConfig,
     });
 


### PR DESCRIPTION
Issue #, if available:

Description of changes:
The default Karpenter provisioner in our Prow deployment was not properly configured to make use of the subnets and security groups that are spun up the CDK stack.   Also, the current CDK stack is trying to use both a managed nodegroup and Karpenter, which are not compatible.

This change:
- removes the MNG entirely
- adds some parameters to the `KarpenterAddOn` for instance types, architecture, and capacity type for EC2 resources for node
- points to the subnets and security groups that are spun up by the CDK stack

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
