### PR TITLE
Remove `--push-gateway` from ghproxy deployment

### DIFF
--- a/prow/config/templates/ghProxy-Deployment.yaml
+++ b/prow/config/templates/ghProxy-Deployment.yaml
@@ -50,7 +50,6 @@ spec:
         args:
         - --cache-dir=/cache
         - --cache-sizeGB={{ add .Values.ghproxy.volumeSize -1 }}
-        - --push-gateway=pushgateway
         - --serve-metrics=true
         ports:
         - containerPort: 8888


### PR DESCRIPTION
We don't currently run an instance of `pushgateway`

If/when we want to:   https://github.com/kubernetes/test-infra/blob/master/config/prow/cluster/pushgateway_deployment.yaml

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
