### PR TITLE
Move Karpenter config to GitOps

### DIFF
--- a/flux/karpenter-config/kustomization.yaml
+++ b/flux/karpenter-config/kustomization.yaml
@@ -2,7 +2,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-- prometheus.yaml
-- prometheus-dashboards.yaml
-- prow.yaml
-- karpenter.yaml
+- node-template.yaml
+- provisioner.yaml

--- a/flux/karpenter-config/node-template.yaml
+++ b/flux/karpenter-config/node-template.yaml
@@ -4,9 +4,9 @@ metadata:
   name: prowjob-node-provider
 spec:
   securityGroupSelector:
-    kubernetes.io/cluster/TestInfraCluster: owned
+    ${tagKey}: ${tagValue}
   subnetSelector:
-    kubernetes.io/cluster/TestInfraCluster: owned
+    ${tagKey}: ${tagValue}
   amiFamily: AL2
   blockDeviceMappings:
     - deviceName: /dev/xvda

--- a/flux/karpenter-config/node-template.yaml
+++ b/flux/karpenter-config/node-template.yaml
@@ -1,0 +1,16 @@
+apiVersion: karpenter.k8s.aws/v1alpha1
+kind: AWSNodeTemplate
+metadata:
+  name: prowjob-node-provider
+spec:
+  securityGroupSelector:
+    kubernetes.io/cluster/TestInfraCluster: owned
+  subnetSelector:
+    kubernetes.io/cluster/TestInfraCluster: owned
+  amiFamily: AL2
+  blockDeviceMappings:
+    - deviceName: /dev/xvda
+      ebs:
+        volumeType: gp3
+        volumeSize: 200Gi
+        deleteOnTermination: true

--- a/flux/karpenter-config/provisioner.yaml
+++ b/flux/karpenter-config/provisioner.yaml
@@ -1,0 +1,36 @@
+apiVersion: karpenter.sh/v1alpha5
+kind: Provisioner
+metadata:
+  name: default
+spec:
+  consolidation:
+    enabled: false
+  limits:
+    resources:
+      cpu: 1k
+      memory: 1000Gi
+      storage: 5000Gi
+  requirements:
+  # Include general purpose instance families
+  - key: karpenter.k8s.aws/instance-family
+    operator: In
+    values: [c6g, c7g, c6a, c6i, m6a, m6g, m6i, r6a, r6g, r6i]
+  # Exclude small instance sizes
+  - key: karpenter.k8s.aws/instance-size
+    operator: In
+    values: [medium, large, xlarge, xlarge, 2xlarge, 4xlarge, 8xlarge]
+  - key: kubernetes.io/arch
+    operator: In
+    values:
+    - amd64
+  - key: karpenter.sh/capacity-type
+    operator: In
+    values:
+    - on-demand
+  - key: kubernetes.io/os
+    operator: In
+    values:
+    - linux
+  ttlSecondsUntilExpired: 36000 # 1 hour
+  providerRef:
+    name: prowjob-node-provider

--- a/flux/karpenter.yaml
+++ b/flux/karpenter.yaml
@@ -1,0 +1,14 @@
+apiVersion: kustomize.toolkit.fluxcd.io/v1beta1
+kind: Kustomization
+metadata:
+  name: karpenter-provisioner
+  namespace: flux-system
+spec:
+  interval: 5m
+  sourceRef:
+    kind: GitRepository
+    name: test-infra
+  path: ./flux/karpenter-config
+  prune: true
+  targetNamespace: karpenter
+  validation: client

--- a/flux/karpenter.yaml
+++ b/flux/karpenter.yaml
@@ -12,3 +12,7 @@ spec:
   prune: true
   targetNamespace: karpenter
   validation: client
+  postBuild:
+    substituteFrom:
+    - kind: ConfigMap
+      name: karpenter-tags # Installed as part of the CDK

--- a/infra/bin/test-ci.ts
+++ b/infra/bin/test-ci.ts
@@ -1,10 +1,10 @@
 #!/usr/bin/env node
 import "source-map-support/register";
 import { App } from "aws-cdk-lib";
-import { TestCIStack, STACK_NAME } from "../lib/test-ci-stack";
+import { TestCIStack } from "../lib/test-ci-stack";
 
 const app = new App();
-new TestCIStack(app, STACK_NAME, {
+new TestCIStack(app, "TestCIStack", {
   /* If you don't specify 'env', this stack will be environment-agnostic.
    * Account/Region-dependent features and context lookups will not work,
    * but a single synthesized template can be deployed anywhere. */

--- a/infra/lib/charts/karpenter-tags.ts
+++ b/infra/lib/charts/karpenter-tags.ts
@@ -1,0 +1,28 @@
+import { Construct } from "constructs";
+import { Chart } from "cdk8s";
+import * as kplus from "cdk8s-plus-24";
+
+export interface KarpenterTagsChartProps {
+  readonly tagKey: string;
+  readonly tagValue: string;
+}
+
+export class KarpenterTagsChart extends Chart {
+  readonly configMap: kplus.ConfigMap;
+
+  constructor(scope: Construct, id: string, props: KarpenterTagsChartProps) {
+    super(scope, id, {
+      namespace: "flux-system",
+    });
+
+    this.configMap = new kplus.ConfigMap(this, "TagsConfigMap", {
+      metadata: {
+        name: "karpenter-tags",
+      },
+      data: {
+        tagKey: props.tagKey,
+        tagValue: props.tagValue,
+      },
+    });
+  }
+}

--- a/infra/lib/ci-cluster.ts
+++ b/infra/lib/ci-cluster.ts
@@ -1,5 +1,5 @@
 import { Construct } from "constructs";
-import { aws_eks as eks, aws_ec2 as ec2, Stack, Tags } from "aws-cdk-lib";
+import { aws_eks as eks, Stack, Tags } from "aws-cdk-lib";
 import * as blueprints from "@aws-quickstart/eks-blueprints";
 import * as cdk8s from "cdk8s";
 import {
@@ -7,17 +7,14 @@ import {
   ProwGitHubSecretsChartProps,
 } from "./charts/prow-secrets";
 import {
-  STACK_NAME,
   FLUX_NAMESPACE,
   PROW_JOB_NAMESPACE,
   PROW_NAMESPACE,
   CLUSTER_NAME,
-  CLUSTER_CONSTRUCT_NAME,
 } from "./test-ci-stack";
 import {
   GlobalResources,
   ImportHostedZoneProvider,
-  KarpenterAddOn,
 } from "@aws-quickstart/eks-blueprints";
 
 export type CIClusterCompileTimeProps = ProwGitHubSecretsChartProps & {

--- a/infra/lib/test-ci-stack.ts
+++ b/infra/lib/test-ci-stack.ts
@@ -9,7 +9,6 @@ export const PROW_JOB_NAMESPACE = "test-pods";
 export const FLUX_NAMESPACE = "flux-system";
 
 export const CLUSTER_NAME = "TestInfraCluster";
-export const CLUSTER_CONSTRUCT_NAME = "CIClusterConstruct";
 
 export type TestCIStackProps = StackProps &
   LogBucketCompileProps & {
@@ -25,7 +24,7 @@ export class TestCIStack extends Stack {
       account: this.account,
     });
 
-    const testCluster = new CICluster(this, CLUSTER_CONSTRUCT_NAME, {
+    const testCluster = new CICluster(this, "CIClusterConstruct", {
       ...props.clusterConfig,
     });
 

--- a/infra/lib/test-ci-stack.ts
+++ b/infra/lib/test-ci-stack.ts
@@ -4,7 +4,6 @@ import { LogBucket, LogBucketCompileProps } from "./log-bucket";
 import { ProwServiceAccounts } from "./prow-service-accounts";
 import { Stack, StackProps } from "aws-cdk-lib";
 
-export const STACK_NAME = "TestCIStack";
 export const PROW_NAMESPACE = "prow";
 export const PROW_JOB_NAMESPACE = "test-pods";
 export const FLUX_NAMESPACE = "flux-system";


### PR DESCRIPTION
Description of changes:
Moves the configuration of the Karpenter provider and provisioner to a GitOps `Kustomization` - so that we aren't restrained by what the EKS blueprints project supports. It also allows us to update the configuration by making changes in Git, without requiring slow CDK deployments.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
