### PR TITLE
Poll before update

### DIFF
--- a/cd/ack-chart/update-chart.sh
+++ b/cd/ack-chart/update-chart.sh
@@ -218,13 +218,11 @@ _upgrade_chart_dependency() {
 }
 
 _rebuild_chart_dependencies() {
-    helm dependency update "$ACK_CHART_DIR"
-}
-
-_helm_ecr_public_login() {
     local ecr_pw
     ecr_pw=$(aws ecr-public get-login-password --region us-east-1)
     echo "$ecr_pw" | helm registry login -u AWS --password-stdin public.ecr.aws
+
+    helm dependency update "$ACK_CHART_DIR"
 }
 
 _add_chart_values_section() {
@@ -298,8 +296,6 @@ _poll_for_upgraded_chart() {
 }
 
 run() {
-    _helm_ecr_public_login
-
     # Poll until the triggering repo has uploaded the latest Helm chart
     _poll_for_upgraded_chart
 

--- a/cd/ack-chart/update-chart.sh
+++ b/cd/ack-chart/update-chart.sh
@@ -26,6 +26,9 @@ Environment variables:
   GITHUB_EMAIL_PREFIX:  The 7 digit unique id for no-reply email of
                         '$GITHUB_ACTOR'
   GITHUB_TOKEN:         Personal Access Token for '$GITHUB_ACTOR'
+  REPO_NAME:            The name of the repository that launched the ProwJob
+                        running the current script. Prow will automatically
+                        inject this variable.
 "
 
 THIS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"


### PR DESCRIPTION
Description of changes:
The `ack-chart` CD process was racing the controller Helm chart release process, and losing most of the time. This caused the `ack-chart` releases to fail and the chart to never be updated. This change introduces a new polling mechanism, with a 5 minute timeout, that ensures the newest version of the Helm chart that started the CD script has been uploaded to ECR public.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
