### PR TITLE
Use Prow's Censorer to remove secrets from job logs

### DIFF
--- a/prow/config/templates/config-ConfigMap.yaml
+++ b/prow/config/templates/config-ConfigMap.yaml
@@ -69,6 +69,9 @@ data:
           timeout: 48h
           grace_period: 1h
           censor_secrets: true
+          censoring_options:
+            include_directories:
+              - "/etc/github"
           gcs_configuration:
             bucket: s3://{{ .Values.prow.presubmitsBucketName }}
             path_strategy: explicit


### PR DESCRIPTION
Description of changes:

It has been noticed on rare occasions that it's possible for some secrets to show up inadvertently in the log output of some Prow jobs.  This change changes the default configuration for Plank to add the contents of `/etc/github` (where secrets are mounted by default in Prow job containers) to the set of things that should be censored from the logs.  

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
