### PR TITLE
allow var substitution in SNS/SQS bootstraps

### DIFF
--- a/src/acktest/bootstrapping/s3.py
+++ b/src/acktest/bootstrapping/s3.py
@@ -17,7 +17,7 @@ class Bucket(Bootstrappable):
 
     # Outputs
     name: str = field(init=False)
-    
+
     @property
     def s3_client(self):
         return boto3.client("s3", region_name=self.region)


### PR DESCRIPTION
When building e2e tests for the SNS Subscription resource, I need to create an SQS Queue that refers to an SNS Topic and in order to do that, I need to add a policy document to the Queue that references the Topic. To make that easier, this patch adds support for variable substitution for the Topic and Queue bootstrap resources in the same way that the S3 Bucket bootstrap resource allows variable substitution.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
