### PR TITLE
Add SSM inventory reporting

### DIFF
--- a/infra/bin/test-ci.ts
+++ b/infra/bin/test-ci.ts
@@ -43,4 +43,7 @@ new TestCIStack(app, "TestCIStack", {
     app.node.tryGetContext("logs_bucket_import") ||
     process.env.LOGS_BUCKET_IMPORT ||
     false,
+
+    inventoryBucketName: app.node.tryGetContext("inventory_bucket") || process.env.INVENTORY_BUCKET,
+    inventoryBucketRegion: app.node.tryGetContext("inventory_bucket_region") || process.env.INVENTORY_BUCKET_REGION,
 });

--- a/infra/lib/ssm-inventory.ts
+++ b/infra/lib/ssm-inventory.ts
@@ -1,0 +1,40 @@
+import { Construct } from "constructs";
+import { aws_ssm as ssm } from "aws-cdk-lib";
+
+export type SSMInventoryCompileProps = {
+  inventoryBucketName: string;
+  inventoryBucketRegion: string
+};
+
+export type SSMInventoryRuntimeProps = {
+  account: string
+};
+
+export type SSMInventoryProps = SSMInventoryCompileProps & SSMInventoryRuntimeProps;
+
+export class SSMInventory extends Construct {
+  constructor(scope: Construct, id: string, props: SSMInventoryProps) {
+    super(scope, id);
+
+    if (props.inventoryBucketName === undefined || props.inventoryBucketRegion === undefined) {
+      throw new Error("Expected: Inventory bucket name and region to be defined")
+    }
+
+    new ssm.CfnAssociation(this, "GatherAssociation", {
+      name: "AWS-GatherSoftwareInventory",
+      scheduleExpression: "rate(30 minutes)",
+      targets: [{
+        // All instances within the account
+        key: "InstanceIds",
+        values: ["*"]
+      }]
+    })
+
+    new ssm.CfnResourceDataSync(this, "SSMSync", {
+      bucketName: props.inventoryBucketName,
+      bucketRegion: props.inventoryBucketRegion,
+      syncFormat: "JsonSerDe",
+      syncName: `${props.account}-SSMReportingForAllInstances`
+    })
+  }
+}

--- a/infra/lib/test-ci-stack.ts
+++ b/infra/lib/test-ci-stack.ts
@@ -3,6 +3,7 @@ import { CICluster, CIClusterCompileTimeProps } from "./ci-cluster";
 import { LogBucket, LogBucketCompileProps } from "./log-bucket";
 import { ProwServiceAccounts } from "./prow-service-accounts";
 import { Stack, StackProps } from "aws-cdk-lib";
+import { SSMInventory, SSMInventoryCompileProps } from './ssm-inventory';
 
 export const PROW_NAMESPACE = "prow";
 export const PROW_JOB_NAMESPACE = "test-pods";
@@ -11,6 +12,7 @@ export const FLUX_NAMESPACE = "flux-system";
 export const CLUSTER_NAME = "TestInfraCluster";
 
 export type TestCIStackProps = StackProps &
+  SSMInventoryCompileProps &
   LogBucketCompileProps & {
     clusterConfig: CIClusterCompileTimeProps;
   };
@@ -46,5 +48,10 @@ export class TestCIStack extends Stack {
       }
     );
     prowServiceAccounts.node.addDependency(testCluster);
+
+    new SSMInventory(this, "SSMInventoryConstruct", {
+      ...props,
+      account: this.account
+    })
   }
 }


### PR DESCRIPTION
Description of changes:
Adds a new construct with configuration for SSM `GatherInventory` and associated publishing to an S3 bucket.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
