### PR TITLE
Use alias in ack-chart `values.yaml` file

### DIFF
--- a/cd/ack-chart/update-chart.sh
+++ b/cd/ack-chart/update-chart.sh
@@ -231,7 +231,7 @@ _rebuild_chart_dependencies() {
 _add_chart_values_section() {
     local __service_name=$1
 
-    SERVICE_NAME=$__service_name yq --inplace '.[env(SERVICE_NAME)+"-chart"] += {
+    SERVICE_NAME=$__service_name yq --inplace '.[env(SERVICE_NAME)] += {
         "enabled": false
     }' "$PARENT_CHART_VALUES"
 }


### PR DESCRIPTION
Issue #, if available: https://github.com/aws-controllers-k8s/community/issues/1800

Description of changes:
When adding a new service to the `values.yaml` file of `ack-chart`, don't use `-chart` in its name. The `Chart.yaml` file uses aliases to refer to the services that specifically remove the need for these suffixes.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
