### PR TITLE
Revert "Support charts without `v` prefix in `ack-chart` CD"

### DIFF
--- a/cd/ack-chart/update-chart.sh
+++ b/cd/ack-chart/update-chart.sh
@@ -90,9 +90,9 @@ _upgrade_dependency_and_chart_versions() {
 
         # Determine if the chart is in GA
         # shellcheck disable=SC2016
-        chart_major_version="$(yq '.version | split(".") | .[0]' "$controller_chart")"
+        chart_major_version="$(yq '.version | split(".") | .[0] | sub("v(\d+)", "$1")' "$controller_chart")"
         if [[ "$chart_major_version" == "0" ]]; then
-            >&2 echo "Skipping $controller_name - no GA releases"
+        >&2 echo "Skipping $controller_name - no GA releases"
             continue
         fi
 


### PR DESCRIPTION
Reverts aws-controllers-k8s/test-infra#343

If the charts don't have a `v` prefix, then this code does nothing. However, if the previous charts do have a `v` prefix then this code strips it correctly. There is no reason to remove this, and it is actually necessary for migration away from `v` prefix.