### PR TITLE
Fix ECR/GH release version mismatches in `ackdiscover`'s `controller.py`

### DIFF
--- a/tools/ackdiscover/controller.py
+++ b/tools/ackdiscover/controller.py
@@ -112,10 +112,13 @@ def collect_all(writer, gh, ep_client, services):
             latest_release.aws_sdk_go_version = aws_sdk_version
             
             try:
-                gh_release = repo.get_release(image_repo_latest_version)
+                gh_repo_release_version = image_repo_latest_version
+                if not gh_repo_release_version.startswith("v"):
+                    gh_repo_release_version = "v" + gh_repo_release_version
+                gh_release = repo.get_release(gh_repo_release_version)
                 latest_release.release_url = gh_release.html_url
             except github.UnknownObjectException:
-                writer.debug(f"[controller.collect_all] no github release associated with controller version {image_repo_latest_version}")
+                writer.debug(f"[controller.collect_all] no github release associated with controller version {gh_repo_release_version}")
 
         chart_repo_url = f"{ecrpublic.BASE_ECR_URL}/{service_package_name}-chart"
         chart_repo = ecrpublic.get_repository(writer, ep_client, chart_repo_url)


### PR DESCRIPTION
We noticed that `gen_services.py` was generating bad version links (e.g., `https://aws-controllers-k8s.github.io/community/docs/community/services/None`) in its output of the [Services page](https://aws-controllers-k8s.github.io/community/docs/community/services/); this was traced back to a recent change in the way image tags are versioned in ECR.  Previously, ECR image tags matched GitHub release strings exactly (e.g., `"1.0.0" == "1.0.0"`), but now the former have a `v` prefix and no longer match (e.g., `"v1.0.0" != "1.0.0"`).

This is an easy fix to rectify the problem by simply prefixing the version string with `v` if that character is not already present.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
