### PR TITLE
Upgrade ack-test `PyYAML` dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 boto3==1.26.54
 kubernetes==12.0.1
-PyYAML==5.4
+PyYAML==6.0.1
 pytest-xdist==2.2.0


### PR DESCRIPTION
Fixes https://github.com/aws-controllers-k8s/community/issues/1848

For the last two days, our prow jobs were failing due to some package
installation errors. This was mainly due to deprecations in the pip3 CLI
tool. The deprecated features could no longer install PyYAML v5.0.X.

This patch upgrades `PyYAML` version to `6.0.2`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
