### PR TITLE
Bump kind version to `0.19.0` and k8s to `1.28.0`

### DIFF
--- a/prow/jobs/images/Dockerfile.integration
+++ b/prow/jobs/images/Dockerfile.integration
@@ -43,6 +43,6 @@ RUN echo "Ensuring Legacy Iptables ..." \
     && update-alternatives --set ip6tables /usr/sbin/ip6tables-legacy || true \
     && update-alternatives --set arptables /usr/sbin/arptables-legacy || true
 
-RUN echo "Installing Kind v0.17.0..." \
-    && go install "sigs.k8s.io/kind@v0.17.0" \
+RUN echo "Installing Kind v0.19.0..." \
+    && go install "sigs.k8s.io/kind@v0.19.0" \
     && mv $GOPATH/bin/kind /usr/bin/kind

--- a/prow/jobs/images_config.yaml
+++ b/prow/jobs/images_config.yaml
@@ -3,7 +3,7 @@ images:
   docs: prow-docs-0.0.6
 
   unit-test: prow-unit-0.0.4
-  integration-test: prow-integration-0.0.15
+  integration-test: prow-integration-0.0.16
   soak-test: prow-soak-0.0.5
 
   auto-generate-controllers: prow-auto-generate-controllers-0.0.10

--- a/prow/jobs/test_config.yaml
+++ b/prow/jobs/test_config.yaml
@@ -1,6 +1,6 @@
 cluster:
   create: true
-  k8s_version: 1.22.9
+  k8s_version: 1.28.0
 
 aws:
   region: us-west-2


### PR DESCRIPTION
Addresses: https://github.com/aws-controllers-k8s/community/issues/1903

Description of changes:
- Bump kind version to `0.19.0` [avoiding `0.20.0` for now - [multiple users reported a bug when using in dind ](https://github.com/kubernetes-sigs/kind/issues/3277)]
- Bump `k8s` to `1.28.0`
- Rebuild and publish a new integration image (containing the `kind` binary)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
