### PR TITLE
Bump boto3 version to `1.33.12`

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-boto3==1.28.42
+boto3==1.33.12
 kubernetes==12.0.1
 PyYAML==6.0.1
 pytest-xdist==2.2.0


### PR DESCRIPTION
Notes: This is need for `eks-controller` PodIdentityAssociation e2e tests

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
