### PR TITLE
Enhance parsing logic of `api-2.json` model files

### DIFF
--- a/prow/jobs/images/build-docs.sh
+++ b/prow/jobs/images/build-docs.sh
@@ -18,7 +18,7 @@ COMMUNITY_REPO="${COMMUNITY_REPO:-"aws-controllers-k8s/community"}"
 DEFAULT_COMMUNITY_PATH="${GITHUB_SRC_GOPATH}${COMMUNITY_REPO}"
 COMMUNITY_PATH="${COMMUNITY_PATH:-$DEFAULT_COMMUNITY_PATH}"
 DOCS_PATH="${COMMUNITY_PATH}/docs"
-DEBUG="${DEBUG:-"True"}"
+GEN_SERVICES_FLAGS="${GEN_SERVICES_FLAGS:-"--debug"}"
 
 # Generate new reference sources
 
@@ -28,7 +28,7 @@ echo "build-docs.sh] 📝 Installing requirements file... "
 pip install -r requirements.txt
 
 echo -n "build-docs.sh] 📄 Generating services page... "
-python3 ./scripts/gen_services.py --debug=${DEBUG}
+python3 ./scripts/gen_services.py ${GEN_SERVICES_FLAGS}
 echo "Done!"
 
 echo -n "build-docs.sh] 📄 Generating reference files... "

--- a/tools/requirements.txt
+++ b/tools/requirements.txt
@@ -3,3 +3,4 @@ GitPython==3.1.32
 PyYAML==6.0.1
 PyGitHub==1.55
 prettytable==3.2.0
+ijson==3.2.3


### PR DESCRIPTION
This commit introduces key improvements to the parsing
logic for the `api-2.json` file:

1. Abandon lazy JSON parsing in favor of loading the
entire file into memory. This change ensures a more
robust parsing process, addressing potential issues
related to partial loading and enhancing the
accuracy of extracting service/abbrev names.

2. Set the `services_gen.md` flag to `--debug`. This
completes the changes made in https://github.com/aws-controllers-k8s/community/pull/1975

Signed-off-by: Amine Hilaly <hilalyamine@gmail.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
