### PR TITLE
fix(elbv2): remove nlb dependency on get_bootstrap_resources()

### DIFF
--- a/src/acktest/bootstrapping/elbv2.py
+++ b/src/acktest/bootstrapping/elbv2.py
@@ -17,8 +17,7 @@ import boto3
 from dataclasses import dataclass, field
 
 from .. import resources
-from . import Bootstrappable
-from e2e.bootstrap_resources import get_bootstrap_resources
+from . import Bootstrappable, VPC
 
 
 @dataclass
@@ -48,7 +47,8 @@ class NetworkLoadBalancer(Bootstrappable):
     super().bootstrap()
 
     self.name = resources.random_suffix_name(self.name_prefix, 32)
-    test_vpc = get_bootstrap_resources().SharedTestVPC
+    test_vpc = VPC(name_prefix="test_vpc", num_public_subnet=2, num_private_subnet=0)
+    test_vpc.bootstrap()
 
     network_load_balancer = self.elbv2_client.create_load_balancer(
       Name=self.name,

--- a/src/acktest/bootstrapping/elbv2.py
+++ b/src/acktest/bootstrapping/elbv2.py
@@ -28,12 +28,14 @@ class NetworkLoadBalancer(Bootstrappable):
   type: str = "network"
   scheme: str = "internet-facing"
 
+  # Subresources
+  test_vpc: VPC = field(init=False, default=None)
+  
   # Outputs
   arn: str = field(init=False)
 
   def __post_init__(self):
     self.test_vpc = VPC(name_prefix="test_vpc", num_public_subnet=2, num_private_subnet=0)
-    self.test_vpc.bootstrap()
 
   @property
   def elbv2_client(self):

--- a/src/acktest/bootstrapping/elbv2.py
+++ b/src/acktest/bootstrapping/elbv2.py
@@ -10,7 +10,6 @@
 # on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
-import time
 
 import boto3
 


### PR DESCRIPTION
Description of changes:
#327 added the ELBv2 / Network Load Balancer bootstrap resource, which is useful for testing resources like the VPC Endpoint Service. This PR improves upon it by removing the dependency of that bootstrap resource on the "Shared Test VPC" and the `get_bootstrap_resources()` method. In doing so, we avoid circular dependency errors in the `$SERVICE-controller` repo's test frameworks that will use the NLB bootstrap resource.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
