### PR TITLE
Omit `ulimit` calls in docker-ce init.d script

### DIFF
--- a/prow/jobs/images/Dockerfile.integration
+++ b/prow/jobs/images/Dockerfile.integration
@@ -36,7 +36,8 @@ RUN echo "Installing Docker ..." \
     && apt-get update \
     && apt-get install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin \
     && rm -rf /var/lib/apt/lists/* \
-    && sed -i 's/cgroupfs_mount$/#cgroupfs_mount\n/' /etc/init.d/docker
+    && sed -i 's/cgroupfs_mount$/#cgroupfs_mount\n/' /etc/init.d/docker \
+    && sed -i 's/ulimit -Hn/# ulimit -Hn/g' /etc/init.d/docker \
 
 RUN echo "Ensuring Legacy Iptables ..." \
     && update-alternatives --set iptables  /usr/sbin/iptables-legacy || true \


### PR DESCRIPTION
Context and fix are mentioned here https://github.com/docker/cli/issues/4807#issuecomment-1903950217

Looks like this was only impacting new image builds, which pulled very
recent docker init.d scripts and failed to call new `ulimit`.

Signed-off-by: Amine Hilaly <hilalyamine@gmail.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
