### PR TITLE
Speed up controller auto-generation on code-gen/runtime new releases

### DIFF
--- a/cd/auto-generate/auto-generate-controllers.sh
+++ b/cd/auto-generate/auto-generate-controllers.sh
@@ -275,11 +275,14 @@ for CONTROLLER_NAME in $CONTROLLER_NAMES; do
 
     open_pull_request "$GITHUB_CONTROLLER_ORG_REPO" "$COMMIT_MSG" "$GITHUB_PR_BODY_FILE"
     echo "auto-generate-controllers.sh][INFO] Done :) "
+    # Sleep for 1 second before generating next service controller. 
+    # Our prow cluster will scale up/down based on the load (karpenter)
+    # History:
     # PRs created from this script trigger the presubmit prowjobs.
     # To control the number of presubmit prowjobs that will run in parallel,
     # adding sleep of 2 minutes. This will help distribute the load on prow
     # cluster.
-    echo "auto-generate-controllers.sh][INFO] Sleeping for 2 minutes before generating next service controller."
-    sleep 120
+    echo "auto-generate-controllers.sh][INFO] Sleeping for 1 seconds before generating next service controller."
+    sleep 1
   popd >/dev/null
 done


### PR DESCRIPTION
In ACK, everytime we release a new runtime/code-generation version, a
prow job will be triggererd to regenerate all the controllers and ship
PRs to their respective github repositories. Historically, we used to
sleep 2 minutes between code-generation, to control the number of e2e
tests/prow jobs running in parallel. The reason was that our cluster had
a static number of nodes, and didn't scale when needed. Now that we use
karpenter to scale our cluster, we can afford faster auto-generation for
the controllers...

Also, the fact that we have 39 controllers to maintain, this job takes
hours to finish, making the process of catching generation errors slow.

This patch, sets the sleep time to 1 second instead.

Signed-off-by: Amine Hilaly <hilalyamine@gmail.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
