### PR TITLE
Bump boto3 version to `1.34.39` for `acktest` library

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-boto3==1.34.11
+boto3==1.34.39
 kubernetes==28.1.0
 PyYAML==6.0.1
 pytest-xdist==3.5.0


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
