### PR TITLE
Set karpenter provisioner `ttlSecondsAfterEmpty` to 15minutes

### DIFF
--- a/flux/karpenter-config/provisioner.yaml
+++ b/flux/karpenter-config/provisioner.yaml
@@ -11,14 +11,14 @@ spec:
       memory: 1000Gi
       storage: 5000Gi
   requirements:
-  # Include general purpose instance families
+  # Use CPU optimized instance families
   - key: karpenter.k8s.aws/instance-family
     operator: In
-    values: [c6g, c7g, c6a, c6i, m6a, m6g, m6i, r6a, r6g, r6i]
+    values: [c6a, c7a, c6i, c7i]
   # Exclude small instance sizes
   - key: karpenter.k8s.aws/instance-size
     operator: In
-    values: [medium, large, xlarge, xlarge, 2xlarge, 4xlarge, 8xlarge]
+    values: [12xlarge, 16xlarge, 24xlarge, 32xlarge]
   - key: kubernetes.io/arch
     operator: In
     values:
@@ -31,6 +31,7 @@ spec:
     operator: In
     values:
     - linux
-  ttlSecondsUntilExpired: 36000 # 1 hour
+  ttlSecondsAfterEmpty: 900 # 15 minutes
+  ttlSecondsUntilExpired: 36000 # 10 hours
   providerRef:
     name: prowjob-node-provider


### PR DESCRIPTION
Our prow infra utilizes karpenter to scale up when there is the need of
execution multiple prow jobs in parallel (making new releases for
examples). However we observed that once those jobs are finished, the
karpenter provisioned nodes are note quickly drained and stay attached
approximatively an hour.. which increases the cost of our infra
unecessarily.

This patch sets a `ttlSecondsAfterEmpty` to instruct karpenter to drain
and delete nodes if they are not running any workload for 15minutes.

This patch also removes the tiny/memory optimized ec2 machine types
since most of our prow job pods require 8CPU/3Gi of memory.

Signed-off-by: Amine Hilaly <hilalyamine@gmail.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
