### PR TITLE
Remove ultra large instances from karpenter pool.

### DIFF
--- a/flux/karpenter-config/provisioner.yaml
+++ b/flux/karpenter-config/provisioner.yaml
@@ -18,7 +18,7 @@ spec:
   # Exclude small instance sizes
   - key: karpenter.k8s.aws/instance-size
     operator: In
-    values: [xlarge, 2xlarge, 4xlarge, 8xlarge, 12xlarge, 16xlarge, 24xlarge, 32xlarge]
+    values: [medium, large, xlarge, xlarge, 2xlarge, 4xlarge, 8xlarge]
   - key: kubernetes.io/arch
     operator: In
     values:


### PR DESCRIPTION
With more CPUs comes higher memory usage. We need to keep to pool as it
originally was, until we migrate bump karpneter to v0.34+

Signed-off-by: Amine Hilaly <hilalyamine@gmail.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
