### PR TITLE
fix: pytest Dockerfile downloads yq for the target architecture

### DIFF
--- a/scripts/Dockerfile.pytest-image
+++ b/scripts/Dockerfile.pytest-image
@@ -21,8 +21,9 @@ ENV PYTHONPATH=/${AWS_SERVICE}-controller/tests/e2e
 
 RUN apk add --no-cache git bash gcc libc-dev
 
-RUN wget https://github.com/mikefarah/yq/releases/download/v4.26.1/yq_linux_amd64.tar.gz -O - |\
-  tar xz && mv yq_linux_amd64 /usr/bin/yq
+ARG TARGETARCH
+RUN wget https://github.com/mikefarah/yq/releases/download/v4.26.1/yq_linux_$TARGETARCH.tar.gz -O - |\
+  tar xz && mv yq_linux_$TARGETARCH /usr/bin/yq
 
 # Install python dependencies
 COPY ${CONTROLLER_E2E_PATH}/requirements.txt .


### PR DESCRIPTION
Issue #, if available:

Description of changes:

In order for tests to run on machines that are not amd64, use the `TARGETARCH` to download the proper `yq` binary.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
