### PR TITLE
Install libffi for ACM in pytest image

### DIFF
--- a/scripts/Dockerfile.pytest-image
+++ b/scripts/Dockerfile.pytest-image
@@ -20,6 +20,11 @@ WORKDIR /${AWS_SERVICE}-controller/tests/e2e
 ENV PYTHONPATH=/${AWS_SERVICE}-controller/tests/e2e
 
 RUN apk add --no-cache git bash gcc libc-dev
+RUN if [[ "$AWS_SERVICE" = "acm" ]]; then \
+    apk add libffi-dev; \
+  fi
+
+
 
 RUN wget https://github.com/mikefarah/yq/releases/download/v4.26.1/yq_linux_amd64.tar.gz -O - |\
   tar xz && mv yq_linux_amd64 /usr/bin/yq


### PR DESCRIPTION
Description of changes:
As part of https://github.com/aws-controllers-k8s/acm-controller/pull/40, an integration test was added that has a dependency on the `cryptography` module. In order for this to work, `libffi` needs to be installed in Alpine-based images.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
