### PR TITLE
Add Prow job to verify licenses and `ATTRIBUTION.md` files

### DIFF
--- a/cd/scripts/verify-attribution.sh
+++ b/cd/scripts/verify-attribution.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+
+set -eo pipefail
+
+USAGE="
+Usage:
+  $(basename "$0")
+
+Runs attribution-gen on the specified service's or repos go.mod file and compares the output with existing ATTRIBUTION.md file
+
+Environment variables:
+  SERVICE:     The name of the service (e.g., s3, ec2, etc....
+  REPO_NAME:   The name of the repository (used if SERVICE is not set)
+  DEBUG:       Enable debug mode for attribution-gen (default: false)
+  OUTPUT_PATH: Path for the output file (default: ./temp_attribution.md)
+"
+
+DEBUG=${DEBUG:-false}
+OUTPUT_PATH=${OUTPUT_PATH:-"./temp_attribution.md"}
+
+# Check if either SERVICE or REPO_NAME is set
+if [ -z "$SERVICE" ] && [ -z "$REPO_NAME" ]; then
+    echo "ERROR: Either SERVICE or REPO_NAME environment variable must be set"
+    echo "$USAGE"
+    exit 1
+fi
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+SCRIPTS_DIR=$DIR
+CD_DIR=$DIR/..
+TEST_INFRA_DIR=$CD_DIR/..
+WORKSPACE_DIR=$TEST_INFRA_DIR/..
+
+# Determine the target directory based on SERVICE or REPO_NAME
+if [ -n "$SERVICE" ]; then
+    TARGET_DIR="$WORKSPACE_DIR/${SERVICE}-controller"
+else
+    TARGET_DIR="$WORKSPACE_DIR/${REPO_NAME}"
+fi
+
+GOMOD_PATH="$TARGET_DIR/go.mod"
+
+source "$TEST_INFRA_DIR/scripts/lib/common.sh"
+
+error() {
+    echo "ERROR: $1" >&2
+    exit 1
+}
+
+check_is_installed attribution-gen
+
+# Check if the go.mod file exists
+if [ ! -f "$GOMOD_PATH" ]; then
+    error "go.mod file not found at: $GOMOD_PATH"
+fi
+
+GOMOD_PATH=$(realpath "$GOMOD_PATH")
+GOMOD_DIR=$(dirname "$GOMOD_PATH")
+
+# Check if ATTRIBUTION.md exists in the same directory as go.mod
+if [ ! -f "$GOMOD_DIR/ATTRIBUTION.md" ]; then
+    error "ATTRIBUTION.md file not found in the same directory as go.mod"
+fi
+
+ATTR_GEN_CMD="attribution-gen --modfile $GOMOD_PATH --output $OUTPUT_PATH"
+if [ "$DEBUG" = true ]; then
+    ATTR_GEN_CMD+=" --debug"
+fi
+
+echo "Running attribution-gen for ${SERVICE:-$REPO_NAME}..."
+$ATTR_GEN_CMD || error "attribution-gen failed to execute successfully."
+
+# Compare the output with the existing ATTRIBUTION.md
+if cmp -s "$GOMOD_DIR/ATTRIBUTION.md" "$OUTPUT_PATH"; then
+    echo "Success: Generated ATTRIBUTION.md matches the existing file for ${SERVICE:-$REPO_NAME}."
+    rm "$OUTPUT_PATH"
+    exit 0
+else
+    error "Generated ATTRIBUTION.md differs from the existing file for ${SERVICE:-$REPO_NAME}."
+fi

--- a/prow/jobs/images/Dockerfile.verify-attribution
+++ b/prow/jobs/images/Dockerfile.verify-attribution
@@ -1,0 +1,22 @@
+# Building github.com/awslabs/attribution-gen binary and image
+
+ARG GO_VERSION=1.22.5
+
+FROM golang:${GO_VERSION}-alpine AS builder
+
+RUN apk add --no-cache git
+
+WORKDIR /app
+
+RUN git clone https://github.com/awslabs/attribution-gen .
+
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o attribution-gen ./cmd
+
+# Start a new stage from scratch
+FROM alpine:latest  
+
+COPY --from=builder /app/attribution-gen /usr/local/bin/
+
+RUN chmod +x /usr/local/bin/attribution-gen
+
+CMD ["attribution-gen"]

--- a/prow/jobs/images/build-images.sh
+++ b/prow/jobs/images/build-images.sh
@@ -29,6 +29,7 @@ GO_VERSION=${GO_VERSION:-"1.22.5"}
 docker_build_args=( "--quiet=$QUIET" "--build-arg=GO_VERSION=$GO_VERSION" )
 
 # docker build -f "$IMAGE_DIR/Dockerfile.deploy" "${docker_build_args[@]}" -t "prow/deploy" "${IMAGE_DIR}"
+# docker build -f "$IMAGE_DIR/Dockerfile.verify-attribution" "${docker_build_args[@]}" -t "prow/verify-attribution" "${IMAGE_DIR}"
 # docker build -f "$IMAGE_DIR/Dockerfile.docs" "${docker_build_args[@]}" -t "prow/docs" "${IMAGE_DIR}"
 # docker build -f "$IMAGE_DIR/Dockerfile.olm-bundle-pr" "${docker_build_args[@]}" -t "prow/olm-bundle-pr" "${IMAGE_DIR}"
 # docker build -f "$IMAGE_DIR/Dockerfile.olm-test" "${docker_build_args[@]}" -t "prow/olm-test" "${IMAGE_DIR}"

--- a/prow/jobs/images_config.yaml
+++ b/prow/jobs/images_config.yaml
@@ -12,3 +12,4 @@ images:
     soak-test: prow-soak-0.0.7
     unit-test: prow-unit-0.0.8
     upgrade-go-version: prow-upgrade-go-version-0.0.8
+    verify-attribution: prow-verify-attribution-0.0.1

--- a/prow/jobs/templates/presubmits/code_generator_tests.tpl
+++ b/prow/jobs/templates/presubmits/code_generator_tests.tpl
@@ -17,6 +17,46 @@
             cpu: 2
             memory: "3072Mi"
         command: ["make", "test"]
+
+  - name: verify-attribution
+    # We probably want to uncomment the following line once we have the attribution
+    # files verified for all the controlelrs
+    # run_if_changed: "go.mod"
+    always_run: true
+    decorate: true
+    optional: false
+    annotations:
+      karpenter.sh/do-not-evict: "true"
+    extra_refs:
+    - org: aws-controllers-k8s
+      repo: test-infra
+      base_ref: main
+      workdir: true
+    spec:
+      containers:
+      - image: {{printf "%s:%s" $.ImageContext.ImageRepo (index $.ImageContext.Images "verify-attribution") }}
+        resources:
+          limits:
+            cpu: 1000m
+            memory: "512Mi"
+          requests:
+            cpu: 250m
+            memory: "512Mi"
+        securityContext:
+          runAsUser: 0
+        env:
+        - name: REPO_NAME
+          value: code-generator
+        - name: OUTPUT_PATH
+          value: "/tmp/generated_attribution.md"
+        - name: DEBUG
+          value: "true"
+        command:
+        - "wrapper.sh"
+        - "bash"
+        - "-c"
+        - "./cd/scripts/verify-attribution.sh"
+
   - name: s3-olm-test
     decorate: true
     optional: true

--- a/prow/jobs/templates/presubmits/pkg_tests.tpl
+++ b/prow/jobs/templates/presubmits/pkg_tests.tpl
@@ -18,3 +18,41 @@
             memory: "1536Mi"
         command: ["make", "test"]
 
+  - name: verify-attribution
+    # We probably want to uncomment the following line once we have the attribution
+    # files verified for all the controlelrs
+    # run_if_changed: "go.mod"
+    always_run: true
+    decorate: true
+    optional: false
+    annotations:
+      karpenter.sh/do-not-evict: "true"
+    extra_refs:
+    - org: aws-controllers-k8s
+      repo: test-infra
+      base_ref: main
+      workdir: true
+    spec:
+      containers:
+      - image: {{printf "%s:%s" $.ImageContext.ImageRepo (index $.ImageContext.Images "verify-attribution") }}
+        resources:
+          limits:
+            cpu: 1000m
+            memory: "512Mi"
+          requests:
+            cpu: 250m
+            memory: "512Mi"
+        securityContext:
+          runAsUser: 0
+        env:
+        - name: REPO_NAME
+          value: pkg
+        - name: OUTPUT_PATH
+          value: "/tmp/generated_attribution.md"
+        - name: DEBUG
+          value: "true"
+        command:
+        - "wrapper.sh"
+        - "bash"
+        - "-c"
+        - "./cd/scripts/verify-attribution.sh"

--- a/prow/jobs/templates/presubmits/runtime_tests.tpl
+++ b/prow/jobs/templates/presubmits/runtime_tests.tpl
@@ -17,6 +17,46 @@
             cpu: 2
             memory: "3072Mi"
         command: ["make", "test"]
+
+  - name: verify-attribution
+    # We probably want to uncomment the following line once we have the attribution
+    # files verified for all the controlelrs
+    # run_if_changed: "go.mod"
+    always_run: true
+    decorate: true
+    optional: false
+    annotations:
+      karpenter.sh/do-not-evict: "true"
+    extra_refs:
+    - org: aws-controllers-k8s
+      repo: test-infra
+      base_ref: main
+      workdir: true
+    spec:
+      containers:
+      - image: {{printf "%s:%s" $.ImageContext.ImageRepo (index $.ImageContext.Images "verify-attribution") }}
+        resources:
+          limits:
+            cpu: 1000m
+            memory: "512Mi"
+          requests:
+            cpu: 250m
+            memory: "512Mi"
+        securityContext:
+          runAsUser: 0
+        env:
+        - name: REPO_NAME
+          value: runtime
+        - name: OUTPUT_PATH
+          value: "/tmp/generated_attribution.md"
+        - name: DEBUG
+          value: "true"
+        command:
+        - "wrapper.sh"
+        - "bash"
+        - "-c"
+        - "./cd/scripts/verify-attribution.sh"
+
 {{ range $_, $service := .Config.RuntimePresubmitServices }}
   - name: {{ $service }}-controller-test
     decorate: true

--- a/prow/jobs/templates/presubmits/service_tests.tpl
+++ b/prow/jobs/templates/presubmits/service_tests.tpl
@@ -165,4 +165,43 @@
         - name: SERVICE
           value: {{ $service }}
         command: ["bash", "-c", "make test-metadata-file SERVICE=$SERVICE"]
+
+  - name: {{ $service }}-verify-attribution
+    # We probably want to uncomment the following line once we have the attribution
+    # files verified for all the controlelrs
+    # run_if_changed: "go.mod"
+    always_run: true
+    decorate: true
+    optional: false
+    annotations:
+      karpenter.sh/do-not-evict: "true"
+    extra_refs:
+    - org: aws-controllers-k8s
+      repo: test-infra
+      base_ref: main
+      workdir: true
+    spec:
+      containers:
+      - image: {{printf "%s:%s" $.ImageContext.ImageRepo (index $.ImageContext.Images "verify-attribution") }}
+        resources:
+          limits:
+            cpu: 1000m
+            memory: "512Mi"
+          requests:
+            cpu: 250m
+            memory: "512Mi"
+        securityContext:
+          runAsUser: 0
+        env:
+        - name: SERVICE
+          value: "{{ $service }}"
+        - name: OUTPUT_PATH
+          value: "/tmp/generated_attribution.md"
+        - name: DEBUG
+          value: "true"
+        command:
+        - "wrapper.sh"
+        - "bash"
+        - "-c"
+        - "./cd/scripts/verify-attribution.sh"
 {{ end }}


### PR DESCRIPTION
All ACK repositories and artifacts (helm charts/container images) need to
contain an `ATTRIBUTION.md` file, giving attribution to open source
software used in each project/repository.
While originally sir Jay Pipes wrote this file manually - it has become
increasingly challenging to maintain these files, especially with the current
scale of the projct - over 50 repositories...

Last year, we developed a new tool (https://github.com/awslabs/attribution-gen)
to  help generating these files, which has been valuable to ACK (and other
projects). However, we still rely on human action to regenerate these files
whenever new dependencies are introduced or old ones are removed

To address this, we're introducing a new Prow job that runs against every
ACK git repository (triggered on PR creation) and verifies that the
`ATTRIBUTION.md` exists and that it is up to date. This will block any
new PRs that change dependencies without regenerating the attribution file.

Initially, we'll trigger this Prow job for **EVERY** upcoming PR; in the
near future, we plan to optimize by triggering it only when `go.mod`
files change.

Key benefits:
- Ensures up to date attribution across all repos
- Reduces manual effort in license compliance
- Blocks PRs with outdated attribution info
- Improves project transparency and legal compliance

Implementation details:
- Added a new bash script to simplify the the attribution verificaiton
  process
- Added a new "Dockerfile" image for attribution verification
- Added a Prow job `verify-attribution` template for all ACK repositories


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
