### PR TITLE
Increase security token TTL to 2 hours for docs-release prow job

### DIFF
--- a/tools/ackdiscover/ecrpublic.py
+++ b/tools/ackdiscover/ecrpublic.py
@@ -38,7 +38,7 @@ def _assume_reader_role(writer):
     resp = sts_client.assume_role(
         RoleArn=ECR_PUBLIC_READER_ROLE_ARN,
         RoleSessionName=role_session_name,
-        DurationSeconds=60*60,  # 1 hour...
+        DurationSeconds=2*60*60,  # 2 hours...
     )
     creds = resp['Credentials']
     return AWSCredentials(


### PR DESCRIPTION
The docs release prowjob is currently failing because it's taking
more than two hours... now that we have more than 43 contorllers,
it's naturally taking more time.

I still believe we can do better than this and improve our docs
generation process..

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
