### PR TITLE
Fix ECR public session token expiration in ack-discover

### DIFF
--- a/tools/ackdiscover/ecrpublic.py
+++ b/tools/ackdiscover/ecrpublic.py
@@ -38,7 +38,7 @@ def _assume_reader_role(writer):
     resp = sts_client.assume_role(
         RoleArn=ECR_PUBLIC_READER_ROLE_ARN,
         RoleSessionName=role_session_name,
-        DurationSeconds=2*60*60,  # 2 hours...
+        DurationSeconds=60*60,  # 1 hour...
     )
     creds = resp['Credentials']
     return AWSCredentials(

--- a/tools/cmd/ack-discover
+++ b/tools/cmd/ack-discover
@@ -101,13 +101,8 @@ gh = github.Github(GH_TOKEN)
 args = setup()
 writer = printer.Writer(args)
 
-try:
-    ep_client = ecrpublic.get_client(writer)
-except Exception as e:
-    print("ERROR: failed to get client for ECR Public:", str(e))
-    sys.exit(255)
 
 repo = awssdkgo.get_repo(writer, GH_TOKEN, CACHE_DIR)
 services = service.collect_all(writer, repo)
-controllers = controller.collect_all(writer, gh, ep_client, services)
+controllers = controller.collect_all(writer, gh, services)
 writer.print_services(services, controllers)


### PR DESCRIPTION
These changes improve the robustness of the ack-discover tool when dealing with
longg running operations that may exceed the 1 hour session token validity

- Move ECR Public client initialization into collect_all function
- Implement re fetching of ECR public client every 58 minutes
- Remove try/except block for ECR public client initialization in main script
- Update function signature and call to `collect_all` in main script

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
