### PR TITLE
Fix infinite loop in `ecrpublic::DescribeImages` pagination

### DIFF
--- a/tools/ackdiscover/ecrpublic.py
+++ b/tools/ackdiscover/ecrpublic.py
@@ -125,7 +125,7 @@ def get_repository_latest_tag(ep_client, repo):
                 latest_tag = image["imageTags"][0]
         if 'nextToken' in images:
             next_token = images['nextToken']
-        if next_token is None:
+        else:
             break
     return latest_tag
 


### PR DESCRIPTION
the `get_repository_latest_tag` function in `ecrpublic.py` would
enter an infinite loop state if the first API response contained
a `nextToken`. This patch fixes the issue by breakin th eloop
when there's no `nextToken` in the response.

Why haven't we seen this before? the `ecr-controller` repository
just exceeded 100 images, triggering the pagination path for the
first time.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
