### PR TITLE
Fix  `upgrade-go-version` template command

### DIFF
--- a/prow/jobs/templates/periodics/upgrade-go-version.tpl
+++ b/prow/jobs/templates/periodics/upgrade-go-version.tpl
@@ -18,4 +18,7 @@
           requests:
             cpu: 1
             memory: "500Mi"
-        command: ["ack-build-tools", "upgrade-go-version", "--build-config-path", "./build_config.yaml", "images-config-path", "./prow/jobs/images_config.yaml","--golang-ecr-repository", "docker/library/golang"]
+        command: ["ack-build-tools", "upgrade-go-version", 
+        "--build-config-path", "./build_config.yaml", 
+        "images-config-path", "./prow/jobs/images_config.yaml",
+        "--golang-ecr-repository", "v2/docker/library/golang"]


### PR DESCRIPTION
Description of changes:
* change `--golang-ecr-repository` flag to `v2/docker/library/golang`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
