### PR TITLE
Testing `build-prow-images`

### DIFF
--- a/prow/jobs/images_config.yaml
+++ b/prow/jobs/images_config.yaml
@@ -1,7 +1,7 @@
 #DO NOT MODIFY ORDER
 image_repo: public.ecr.aws/m5q3e4b2/prow
 images:
-  docs: prow-docs-0.0.9
+  docs: prow-docs-0.0.10
 
   unit-test: prow-unit-0.0.7
   integration-test: prow-integration-0.0.22


### PR DESCRIPTION
Description of changes:
We bumped `prow-docs` image version to `0.0.10`.
We are now expecting `build-prow-images` to:
* Build and push `prow-docs` with newest image version
* Once successful, generate `jobs.yaml`
* Create a Pull Request in `test-infra`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
