### PR TITLE
Patch `upgrade-go-version` prow job to `0.0.4`

### DIFF
--- a/prow/jobs/images_config.yaml
+++ b/prow/jobs/images_config.yaml
@@ -11,7 +11,7 @@ images:
   auto-update-controllers: prow-auto-update-controllers-0.0.6
   controller-release-tag: prow-controller-release-tag-0.0.3
   deploy: prow-deploy-0.0.16
-  upgrade-go-version: prow-upgrade-go-version-0.0.3
+  upgrade-go-version: prow-upgrade-go-version-0.0.4
   build-prow-images: prow-build-prow-images-0.0.29
 
   olm-test: prow-olm-test-0.0.2


### PR DESCRIPTION
Description of changes:
 `build-prow-images` will build and push

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
