### PR TITLE
Fix `upgrade-go-version` prow job template typo and refactor command

### DIFF
--- a/prow/jobs/images_config.yaml
+++ b/prow/jobs/images_config.yaml
@@ -11,7 +11,7 @@ images:
   auto-update-controllers: prow-auto-update-controllers-0.0.6
   controller-release-tag: prow-controller-release-tag-0.0.3
   deploy: prow-deploy-0.0.16
-  upgrade-go-version: prow-upgrade-go-version-0.0.4
+  upgrade-go-version: prow-upgrade-go-version-0.0.5
   build-prow-images: prow-build-prow-images-0.0.29
 
   olm-test: prow-olm-test-0.0.2

--- a/prow/jobs/templates/periodics/upgrade-go-version.tpl
+++ b/prow/jobs/templates/periodics/upgrade-go-version.tpl
@@ -25,5 +25,5 @@
             memory: "500Mi"
         command: ["ack-build-tools", "upgrade-go-version", 
         "--build-config-path", "./build_config.yaml", 
-        "images-config-path", "./prow/jobs/images_config.yaml",
+        "--images-config-path", "./prow/jobs/images_config.yaml",
         "--golang-ecr-repository", "v2/docker/library/golang"]

--- a/prow/jobs/tools/cmd/command/helpers.go
+++ b/prow/jobs/tools/cmd/command/helpers.go
@@ -66,7 +66,7 @@ func readCurrentImagesConfig(filepath string) (*ImagesConfig, error) {
 	return imagesConfig, nil
 }
 
-func patchImageConfigVersion(filepath string, imagesConfig *ImagesConfig) error {
+func patchImageConfigVersionFile(imagesConfig *ImagesConfig, filepath string) error {
 	file, err := os.Create(filepath)
 	if err != nil {
 		return fmt.Errorf("unable to create file %s: %s", filepath, err)

--- a/prow/jobs/tools/cmd/command/upgrade_go_version_helper.go
+++ b/prow/jobs/tools/cmd/command/upgrade_go_version_helper.go
@@ -35,7 +35,7 @@ const (
 	// 	The local file is separated by its target location by a semi-colon.
 	// 	If the file should be in the same location with the same name, you can just put the file name and omit the repetition.
 	// 	Example: README.md,main.go:prow/jobs/tools/cmd/main.go`
-	updateGoSourceFiles    = "build_config.yaml,images_config.yaml:./prow/jobs/images_config.yaml"
+	updateGoSourceFiles = "build_config.yaml,./prow/jobs/images_config.yaml:prow/jobs/images_config.yaml"
 )
 
 func listGoVersion(repository string) ([]string, error) {
@@ -87,7 +87,7 @@ func increasePatchImageConfig(imagesConfig *ImagesConfig) error {
 	return nil
 }
 
-func patchGoBuildVersion(filepath string, versionConfig *BuildConfig) error {
+func patchGoBuildVersionFile(versionConfig *BuildConfig, filepath string) error {
 	file, err := os.Create(filepath)
 	if err != nil {
 		return fmt.Errorf("unable to create file %s: %s", filepath, err)


### PR DESCRIPTION
Description of changes:
* Fix the `upgrade-go-version` job template `--images-config-path` flag typo
* Refactor the `upgrade-go-version` command to improve readability and logging
* Update the `updateGoSourceFiles` constant to include correct source file paths

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
