### PR TITLE
Switch from kaniko to buildah for building prow images

### DIFF
--- a/prow/jobs/images/Dockerfile.build-prow-images
+++ b/prow/jobs/images/Dockerfile.build-prow-images
@@ -1,6 +1,6 @@
 ARG GO_VERSION=1.22.5
 
-FROM golang:${GO_VERSION}-alpine AS builder
+FROM public.ecr.aws/docker/library/golang:${GO_VERSION}-alpine AS builder
 
 RUN apk add --no-cache git
 
@@ -12,16 +12,40 @@ RUN go mod download
 
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o ack-build-tools ./prow/jobs/tools/cmd
 
-FROM busybox:musl AS busybox
+FROM quay.io/containers/buildah:v1.37.0
 
-FROM gcr.io/kaniko-project/executor:v1.23.2
-# Override the entrypoint
-ENTRYPOINT [ ]
+ARG GOPROXY=https://proxy.golang.org|direct
+ENV GOPROXY=${GOPROXY}
 
-ENV PATH /usr/local/bin:/kaniko:/busybox:/app
+ARG GO_VERSION=1.22.5
+ENV GO_VERSION=${GO_VERSION}
 
-COPY --from=busybox /bin /busybox
+ENV GOPATH=/home/prow/go \
+    GO111MODULE=on \
+    PATH=/home/prow/go/bin:/usr/local/go/bin:${PATH}
+
+RUN dnf -y install \
+		which \
+		git \
+		unzip \
+		openssl \
+		jq \
+		gettext \
+        findutils \
+    && curl -sL https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip -o awscliv2.zip \
+    && unzip awscliv2.zip \
+    && aws/install \
+    && export AWS_PAGER="" \
+    && curl -L -s https://github.com/mikefarah/yq/releases/download/v4.31.2/yq_linux_amd64 --output /usr/bin/yq \
+    && chmod +x /usr/bin/yq
+
+RUN echo "Installing Go ..." \
+    && export GO_TARBALL="go${GO_VERSION}.linux-amd64.tar.gz"\
+    && curl -fsSL "https://storage.googleapis.com/golang/${GO_TARBALL}" --output "${GO_TARBALL}" \
+    && tar xzf "${GO_TARBALL}" -C /usr/local \
+    && rm "${GO_TARBALL}"\
+    && mkdir -p "${GOPATH}/bin"
+
+RUN chmod +x ./prow/jobs/tools/cmd/build-prow-images.sh
+
 COPY --from=builder /app/ack-build-tools /busybox
-VOLUME /busybox
-RUN ["/busybox/mkdir", "-p", "/bin"]
-RUN ["/busybox/ln", "-s", "/busybox/sh", "/bin/sh"]

--- a/prow/jobs/templates/postsubmits/test-infra.tpl
+++ b/prow/jobs/templates/postsubmits/test-infra.tpl
@@ -17,9 +17,6 @@
             requests:
               cpu: 2
               memory: "4096Mi"
-          command: ["/busybox/ack-build-tools", "build-prow-images",
-                  "--images-config-path", "./prow/jobs/images_config.yaml",
-                  "--jobs-config-path", "./prow/jobs/jobs_config.yaml",
-                  "--jobs-templates-path", "./prow/jobs/templates/",
-                  "--jobs-output-path", "./prow/jobs/jobs.yaml",
-                  "--prow-ecr-repository", "prow"]
+          command: ["./prow/jobs/tools/cmd/build-prow-images.sh"]
+    branches:
+    - main                

--- a/prow/jobs/tools/cmd/build-prow-images.sh
+++ b/prow/jobs/tools/cmd/build-prow-images.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+buildah_login() {
+  __pw=$(aws ecr-public get-login-password --region us-east-1)
+  echo "$__pw" | buildah login -u AWS --password-stdin public.ecr.aws
+}
+
+ECR_PUBLISH_ARN=$(aws ssm get-parameter --name /ack/prow/cd/public_ecr/publish_role --query Parameter.Value --output text 2>/dev/null) || ASSUME_EXIT_VALUE=$?
+if [ "$ASSUME_EXIT_VALUE" -ne 0 ]; then
+  echo "build-prow-images.sh] [SETUP] Could not find the iam role to publish images to public ecr repository"
+  exit 1
+fi
+export ECR_PUBLISH_ARN
+echo "build-prow-images.sh] [SETUP] exported ECR_PUBLISH_ARN"
+
+ASSUME_COMMAND=$(aws sts assume-role --role-arn $ECR_PUBLISH_ARN --role-session-name 'publish-images' --duration-seconds 3600 | jq -r '.Credentials | "export AWS_ACCESS_KEY_ID=\(.AccessKeyId)\nexport AWS_SECRET_ACCESS_KEY=\(.SecretAccessKey)\nexport AWS_SESSION_TOKEN=\(.SessionToken)\n"')
+eval $ASSUME_COMMAND
+echo "build-prow-images.sh] [SETUP] Assumed ECR_PUBLISH_ARN"
+
+buildah_login
+
+ack-build-tools build-prow-images \
+  --images-config-path ./prow/jobs/images_config.yaml \
+  --jobs-config-path ./prow/jobs/jobs_config.yaml \
+  --jobs-templates-path ./prow/jobs/templates/ \
+  --jobs-output-path ./prow/jobs/jobs.yaml \
+  --prow-ecr-repository prow

--- a/prow/jobs/tools/cmd/command/patch_prowjobs.go
+++ b/prow/jobs/tools/cmd/command/patch_prowjobs.go
@@ -94,10 +94,15 @@ func buildProwImages(cmd *cobra.Command, args []string) error {
 	}
 
 	log.Printf("Tags to build:\n %v\n", tagsToBuild)
-	if err = buildImagesWithKaniko(imagesConfig.ImageRepo, tagsToBuild); err != nil {
+	if err = buildImages(tagsToBuild); err != nil {
 		return err
 	}
 	log.Println("Successfully built all images")
+
+	if err = tagAndPushImages(imagesConfig.ImageRepo, tagsToBuild); err != nil {
+		return err
+	}
+	log.Println("Successfully tagged and pushed images")
 
 	// exit if we're not creating a PR
 	if OptCreatePR == "false" {


### PR DESCRIPTION
Description of changes:

This commit refactors the process of building prow images,
moving from kaniko to buildah.
The reason for this change
is because kaniko's intended use is to build a single
image in a single container. We attempted doing a
workaround and attempt building prow images
in a single container, and the results were unpredictable.

We also considered spinning up pods/prowjobs for each
image we want to build. We decided not to go forward with
that upproach, since building images can be unpredictable,
and the prowjob that is spinning these pods is going to have
to wait for an unknown amount of time, while considering the
the different statuses a /prowjob would be in.

With these changes we are building images with buildah, and only
attempting to push when all builds are successful.

This ensures that we will have a PR with a generated `jobs.yaml`
that reflects the latest image versions in our prow ECR repository

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
