### PR TITLE
Set vfs as storage driver env for `build-prow-images` job Dockerfile

### DIFF
--- a/prow/jobs/images/Dockerfile.build-prow-images
+++ b/prow/jobs/images/Dockerfile.build-prow-images
@@ -20,6 +20,8 @@ ENV GOPROXY=${GOPROXY}
 ARG GO_VERSION=1.22.5
 ENV GO_VERSION=${GO_VERSION}
 
+ENV STORAGE_DRIVER=vfs
+
 ENV GOPATH=/home/prow/go \
     GO111MODULE=on \
     PATH=/home/prow/go/bin:/usr/local/go/bin:${PATH}


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
