### PR TITLE
Bump `build-prow-images` version to `0.0.33`

### DIFF
--- a/prow/jobs/images_config.yaml
+++ b/prow/jobs/images_config.yaml
@@ -2,7 +2,7 @@ image_repo: public.ecr.aws/m5q3e4b2/prow
 images:
     auto-generate-controllers: prow-auto-generate-controllers-0.0.16
     auto-update-controllers: prow-auto-update-controllers-0.0.7
-    build-prow-images: prow-build-prow-images-0.0.32
+    build-prow-images: prow-build-prow-images-0.0.33
     controller-release-tag: prow-controller-release-tag-0.0.4
     deploy: prow-deploy-0.0.17
     docs: prow-docs-0.0.12

--- a/prow/jobs/jobs.yaml
+++ b/prow/jobs/jobs.yaml
@@ -18445,7 +18445,7 @@ postsubmits:
     spec:
       serviceAccountName: post-submit-service-account
       containers:
-        - image: public.ecr.aws/m5q3e4b2/prow:prow-build-prow-images-0.0.31
+        - image: public.ecr.aws/m5q3e4b2/prow:prow-build-prow-images-0.0.33
           resources:
             limits:
               cpu: 2


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
