### PR TITLE
Enhance prow build images logging and build system

### DIFF
--- a/prow/jobs/images/Dockerfile.build-prow-images
+++ b/prow/jobs/images/Dockerfile.build-prow-images
@@ -49,6 +49,3 @@ RUN echo "Installing Go ..." \
     && mkdir -p "${GOPATH}/bin"
 
 COPY --from=builder /app/ack-build-tools /usr/local/bin
-COPY --from=builder /app/prow/jobs/tools/cmd/build-prow-images.sh /usr/local/bin
-
-RUN chmod +x /usr/local/bin/build-prow-images.sh

--- a/prow/jobs/images_config.yaml
+++ b/prow/jobs/images_config.yaml
@@ -2,7 +2,7 @@ image_repo: public.ecr.aws/m5q3e4b2/prow
 images: 
     auto-generate-controllers: prow-auto-generate-controllers-0.0.16
     auto-update-controllers: prow-auto-update-controllers-0.0.7
-    build-prow-images: prow-build-prow-images-0.0.34
+    build-prow-images: prow-build-prow-images-0.0.35
     controller-release-tag: prow-controller-release-tag-0.0.4
     deploy: prow-deploy-0.0.17
     docs: prow-docs-0.0.13

--- a/prow/jobs/templates/postsubmits/test-infra.tpl
+++ b/prow/jobs/templates/postsubmits/test-infra.tpl
@@ -17,6 +17,6 @@
             requests:
               cpu: 2
               memory: "4096Mi"
-          command: ["build-prow-images.sh"]
+          command: ["./prow/jobs/tools/cmd/build-prow-images.sh"]
     branches:
     - main                

--- a/prow/jobs/tools/cmd/build-prow-images.sh
+++ b/prow/jobs/tools/cmd/build-prow-images.sh
@@ -5,23 +5,23 @@ buildah_login() {
   echo "$__pw" | buildah login -u AWS --password-stdin public.ecr.aws
 }
 
-ECR_PUBLISH_ARN=""
-if ! ECR_PUBLISH_ARN="$(aws ssm get-parameter --name /ack/prow/cd/test-infra/publish-prow-images --query Parameter.Value --output text 2>/dev/null)"; then
+PROW_ECR_PUBLISH_ARN=""
+if ! PROW_ECR_PUBLISH_ARN="$(aws ssm get-parameter --name /ack/prow/cd/test-infra/publish-prow-images --query Parameter.Value --output text 2>/dev/null)"; then
     echo "Could not find the IAM role to publish images to the public ECR repository"
     exit 1
 fi
-export ECR_PUBLISH_ARN
-echo "build-prow-images.sh] [SETUP] exported ECR_PUBLISH_ARN"
+export PROW_ECR_PUBLISH_ARN
+echo "build-prow-images.sh] [SETUP] exported PROW_ECR_PUBLISH_ARN"
 
 ASSUME_COMMAND=$(aws sts assume-role-with-web-identity \
-    --role-arn $ECR_PUBLISH_ARN \
+    --role-arn $PROW_ECR_PUBLISH_ARN \
     --role-session-name "WebIdentitySession" \
     --web-identity-token "$(cat $AWS_WEB_IDENTITY_TOKEN_FILE)" \
     --output json \
     --duration-seconds 3600 \
     | jq -r '.Credentials | "export AWS_ACCESS_KEY_ID=\(.AccessKeyId)\nexport AWS_SECRET_ACCESS_KEY=\(.SecretAccessKey)\nexport AWS_SESSION_TOKEN=\(.SessionToken)\n"')
 eval $ASSUME_COMMAND
-echo "build-prow-images.sh] [SETUP] Assumed ECR_PUBLISH_ARN"
+echo "build-prow-images.sh] [SETUP] Assumed PROW_ECR_PUBLISH_ARN"
 
 buildah_login
 


### PR DESCRIPTION
Description of changes:
* Bump `build-prow-images` version
* Call `build-prow-images` from test-infra repo instead of injecting in the built image.
* Rename `ECR_PUBLISH_ARN` to `PROW_ECR_PUBLISH_ARN` in `build-prow-images.sh`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
