### PR TITLE
Add `upgrade-eks-distro-version` prow job

### DIFF
--- a/build_config.yaml
+++ b/build_config.yaml
@@ -1,1 +1,2 @@
 go_version: 1.23.0
+eks_distro_version: 2024-04-01-1711929684.2

--- a/prow/jobs/images/Dockerfile.upgrade-go-version
+++ b/prow/jobs/images/Dockerfile.upgrade-go-version
@@ -14,5 +14,3 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o ack-build-tools ./prow/job
 FROM alpine:latest
 
 COPY --from=builder /go/ack-build-tools /usr/local/bin/
-
-RUN chmod +x /usr/local/bin/ack-build-tools

--- a/prow/jobs/images_config.yaml
+++ b/prow/jobs/images_config.yaml
@@ -11,4 +11,4 @@ images:
     olm-test: prow-olm-test-0.0.3
     soak-test: prow-soak-0.0.7
     unit-test: prow-unit-0.0.8
-    upgrade-go-version: prow-upgrade-go-version-0.0.6
+    upgrade-go-version: prow-upgrade-go-version-0.0.7

--- a/prow/jobs/templates/periodics/upgrade-eks-distro-version.tpl
+++ b/prow/jobs/templates/periodics/upgrade-eks-distro-version.tpl
@@ -1,0 +1,27 @@
+- name: upgrade-eks-distro-version
+  decorate: true
+  interval: 12h
+  annotations:
+    description: Querys eks-distro version in ECR and compare it with version in build_config.yaml. Creates a PR with updated eks-distro version and bumped prow image versions if outdated
+    karpenter.sh/do-not-evict: "true"
+  extra_refs:
+  - org: aws-controllers-k8s
+    repo: test-infra
+    base_ref: main
+    workdir: true
+  labels:
+    preset-github-secrets: "true"
+  agent: kubernetes
+  spec:
+    serviceAccountName: periodic-service-account
+    containers:
+      - image: {{printf "%s:%s" $.ImageContext.ImageRepo (index $.ImageContext.Images "upgrade-go-version") }} #Use upgrade-go-version image for now
+        resources:
+          limits:
+            cpu: 1
+            memory: "500Mi"
+          requests:
+            cpu: 1
+            memory: "500Mi"
+        command: ["ack-build-tools", "upgrade-eks-distro-version", 
+            "--images-config-path", "./prow/jobs/images_config.yaml"]

--- a/prow/jobs/tools/cmd/command/helpers.go
+++ b/prow/jobs/tools/cmd/command/helpers.go
@@ -35,10 +35,11 @@ type ImagesConfig struct {
 // where the build versions are stored
 type BuildConfig struct {
 	// so far we only have the go-version
-	GoVersion string `yaml:"go_version"`
+	GoVersion        string `yaml:"go_version"`
+	EksDistroVersion string `yaml:"eks_distro_version"`
 }
 
-func readCurrentBuildGoVersion(filepath string) (*BuildConfig, error) {
+func readBuildConfigFile(filepath string) (*BuildConfig, error) {
 	fileData, err := os.ReadFile(filepath)
 	if err != nil {
 		return nil, fmt.Errorf("unable to read file %s: %s", OptBuildConfigPath, err)

--- a/prow/jobs/tools/cmd/command/upgrade_eks_distro_version.go
+++ b/prow/jobs/tools/cmd/command/upgrade_eks_distro_version.go
@@ -1,0 +1,93 @@
+package command
+
+import (
+	"fmt"
+	"log"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+var (
+	OptEksDistroEcrRepository string
+)
+
+var upgradeEksDistroCMD = &cobra.Command{
+	Use:   "upgrade-eks-distro-version",
+	Short: "upgrade-eks-distro-version - queries ecr for latest eks-distro version and patches prow images if there's an update",
+	RunE:  runUpgradeEksDistro,
+}
+
+func init() {
+	upgradeEksDistroCMD.PersistentFlags().StringVar(
+		&OptEksDistroEcrRepository, "eks-distro-ecr-repository", "v2/eks-distro-build-tooling/eks-distro-minimal-base-nonroot", "ecr gallery repository for eks-distro",
+	)
+	upgradeEksDistroCMD.PersistentFlags().StringVar(
+		&OptBuildConfigPath, "build-config-path", "./build_config.yaml", "path to build_config.yaml, where all the build versions are stored",
+	)
+	rootCmd.AddCommand(upgradeEksDistroCMD)
+}
+
+// runUpgradeEksDistro command queries ECR for the latest eks-distro version
+// if the one in build_config.yaml is outdated we use the latest version,
+// and patch all prow images in images_config.yaml
+func runUpgradeEksDistro(cmd *cobra.Command, args []string) error {
+
+	log.SetPrefix("upgrade-eks-distro-version: ")
+
+	ecrEksDistroVersion, err := listRepositoryTags(OptEksDistroEcrRepository)
+	if err != nil {
+		return fmt.Errorf("unable to get eks-distro versions from %s: %v", OptEksDistroEcrRepository, err)
+	}
+	log.Printf("Successfully listed eks-distro versions from %s", OptEksDistroEcrRepository)
+
+	highestEcrEksDistroVersion, err := findHighestEcrEksDistroVersion(ecrEksDistroVersion)
+	if err != nil {
+		return err
+	}
+	log.Printf("Highest EKS Distro version: %s\n", highestEcrEksDistroVersion)
+
+	buildConfigData, err := readBuildConfigFile(OptBuildConfigPath)
+	if err != nil {
+		return err
+	}
+	log.Printf("Build Config EKS Distro version: %s\n", buildConfigData.EksDistroVersion)
+
+	needUpgrade := eksDistroVersionIsGreaterThan(highestEcrEksDistroVersion, buildConfigData.EksDistroVersion)
+	if !needUpgrade {
+		log.Println("eks-distro version is up-to-date")
+		return nil
+	}
+
+	log.Printf("Updating eks-distro version to %s\n", highestEcrEksDistroVersion)
+	olderVersion := buildConfigData.EksDistroVersion
+	buildConfigData.EksDistroVersion = highestEcrEksDistroVersion
+	if err = patchBuildVersionFile(buildConfigData, OptBuildConfigPath); err != nil {
+		return err
+	}
+	log.Printf("Successfully updated eks-distro version in build_config")
+
+	log.Printf("Patching prow image versions in %s\n", OptImagesConfigPath)
+	imagesConfig, err := readCurrentImagesConfig(OptImagesConfigPath)
+	if err != nil {
+		return err
+	}
+	if err = increasePatchImageConfig(imagesConfig); err != nil {
+		return err
+	}
+	if err = patchImageConfigVersionFile(imagesConfig, OptImagesConfigPath); err != nil {
+		return err
+	}
+	log.Println("Successfully patched prow image versions!")
+
+	commitBranch := fmt.Sprintf(updateEksDistroPRCommitBranch, highestEcrEksDistroVersion)
+	prSubject := fmt.Sprintf(updateEksDistroPRSubject, highestEcrEksDistroVersion)
+	prDescription := fmt.Sprintf(updateEksDistroPRDescription, olderVersion, highestEcrEksDistroVersion)
+
+	log.Println("Commiting changes and creating PR")
+	err = commitAndSendPR(OptSourceOwner, OptSourceRepo, commitBranch, updateEksDistroSourceFiles, baseBranch, prSubject, prDescription)
+	if err != nil && !strings.Contains(err.Error(), "pull request already exists") {
+		return err
+	}
+	return nil
+}

--- a/prow/jobs/tools/cmd/command/upgrade_eks_distro_version_helper.go
+++ b/prow/jobs/tools/cmd/command/upgrade_eks_distro_version_helper.go
@@ -1,0 +1,47 @@
+package command
+
+import (
+	"regexp"
+	"strings"
+)
+
+const (
+	updateEksDistroPRSubject      = "Update to eks-distro %s"
+	updateEksDistroPRCommitBranch = "eks-distro-update-%s"
+	updateEksDistroPRDescription  = "Update eks-distro from %s to %s "
+
+	// `Comma-separated list of files to commit and their location.
+	// 	The local file is separated by its target location by a semi-colon.
+	// 	If the file should be in the same location with the same name, you can just put the file name and omit the repetition.
+	// 	Example: README.md,main.go:prow/jobs/tools/cmd/main.go`
+	updateEksDistroSourceFiles = "build_config.yaml,./prow/jobs/images_config.yaml:prow/jobs/images_config.yaml"
+)
+
+// When comparing EKS-distro versions we are assuming their values
+// mean the following
+// YYYY-MM-DD-TTMMSS000.2
+// This format of date can be compared using string comparison
+// In the future if the meaning or the standard of the version
+// changes, we need to change this function to reflect 
+// the comparison of eks-distro version
+func eksDistroVersionIsGreaterThan(v1 string, v2 string) bool {
+	return v1 > v2
+}
+
+func findHighestEcrEksDistroVersion(tags []string) (string, error) {
+
+	regex := regexp.MustCompile(`[a-z]`)
+	max := "2000-08-13-1723575672.2"
+
+	for _, tag := range tags {
+		temp := strings.Split(tag, ".")
+		if regex.MatchString(tag) || len(temp) != 2 || temp[1] != "2" {
+			continue
+		}
+		if eksDistroVersionIsGreaterThan(tag, max) {
+			max = tag
+		}
+	}
+
+	return max, nil
+}

--- a/prow/jobs/tools/cmd/command/upgrade_go_version_helper.go
+++ b/prow/jobs/tools/cmd/command/upgrade_go_version_helper.go
@@ -38,7 +38,7 @@ const (
 	updateGoSourceFiles = "build_config.yaml,./prow/jobs/images_config.yaml:prow/jobs/images_config.yaml"
 )
 
-func listGoVersion(repository string) ([]string, error) {
+func listRepositoryTags(repository string) ([]string, error) {
 	client := ecrpublic.New()
 	tags, err := client.ListRepositoryTags(repository)
 	if err != nil {
@@ -87,7 +87,7 @@ func increasePatchImageConfig(imagesConfig *ImagesConfig) error {
 	return nil
 }
 
-func patchGoBuildVersionFile(versionConfig *BuildConfig, filepath string) error {
+func patchBuildVersionFile(versionConfig *BuildConfig, filepath string) error {
 	file, err := os.Create(filepath)
 	if err != nil {
 		return fmt.Errorf("unable to create file %s: %s", filepath, err)


### PR DESCRIPTION
Description of changes:

This prow job acts similarly to `upgrade-go-version`. With this prow job, 
we will ensure that we have the latest build images, and in the future we 
will add any other dependencies we want to keep an eye on.

This PR also contains some refactoring done to `upgrade-go-version` to allow reusability.
We are also using the `upgrade-go-version` image for this job.

In the future we will see if we can combine these two jobs into one

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
