### PR TITLE
Bump prow integrations image version

### DIFF
--- a/prow/jobs/images_config.yaml
+++ b/prow/jobs/images_config.yaml
@@ -6,7 +6,7 @@ images:
     controller-release-tag: prow-controller-release-tag-0.0.4
     deploy: prow-deploy-0.0.17
     docs: prow-docs-0.0.13
-    integration-test: prow-integration-0.0.23
+    integration-test: prow-integration-0.0.24
     olm-bundle-pr: prow-olm-bundle-pr-0.0.4
     olm-test: prow-olm-test-0.0.3
     soak-test: prow-soak-0.0.7


### PR DESCRIPTION
It looks like we have already built `v0.0.23` in the past, trying to upgrade
the kind version, but we failed miserably and had to rollback to `v0.0.22`.

Recently `ack-build-tools` bumped all the versions, but it didn't force push
a new image for our integrations tests (as intended). Now we want to trigger
a new build for the ingrations image.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
