### PR TITLE
Add Prow job to detect CVEs in ACK supported AWS service controllers

### DIFF
--- a/prow/jobs/images/Dockerfile.scan-controllers-cve
+++ b/prow/jobs/images/Dockerfile.scan-controllers-cve
@@ -1,0 +1,24 @@
+ARG GO_VERSION=1.22.5
+
+FROM public.ecr.aws/docker/library/golang:${GO_VERSION}-alpine AS builder
+
+RUN apk add --no-cache git
+
+ENV GOPROXY=direct
+COPY . .
+RUN go mod download
+
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o ack-build-tools ./prow/jobs/tools/cmd
+
+# Start a new stage from scratch
+FROM alpine:latest
+
+RUN apk add --no-cache wget tar
+
+ARG TRIVY_VERSION=0.54.1
+
+RUN wget https://github.com/aquasecurity/trivy/releases/download/v${TRIVY_VERSION}/trivy_${TRIVY_VERSION}_Linux-64bit.tar.gz -O - | tar -xz && \
+    chmod +x trivy && \
+    mv trivy /usr/local/bin/
+
+COPY --from=builder /go/ack-build-tools /usr/local/bin/

--- a/prow/jobs/images_config.yaml
+++ b/prow/jobs/images_config.yaml
@@ -9,6 +9,7 @@ images:
     integration-test: prow-integration-0.0.24
     olm-bundle-pr: prow-olm-bundle-pr-0.0.4
     olm-test: prow-olm-test-0.0.3
+    scan-controllers-cve: prow-scan-controllers-cve-0.0.1
     soak-test: prow-soak-0.0.7
     unit-test: prow-unit-0.0.8
     upgrade-go-version: prow-upgrade-go-version-0.0.8

--- a/prow/jobs/templates/periodics/scan-controllers-cve.tpl
+++ b/prow/jobs/templates/periodics/scan-controllers-cve.tpl
@@ -1,0 +1,27 @@
+- name: scan-controllers-cve
+  decorate: true
+  interval: 12h
+  annotations:
+    description: Scans ack supported AWS service controllers for CVE's. If they exist, creates a github issue in commmunity repository
+    karpenter.sh/do-not-evict: "true"
+  extra_refs:
+  - org: aws-controllers-k8s
+    repo: test-infra
+    base_ref: main
+    workdir: true
+  labels:
+    preset-github-secrets: "true"
+  agent: kubernetes
+  spec:
+    serviceAccountName: periodic-service-account
+    containers:
+      - image: {{printf "%s:%s" $.ImageContext.ImageRepo (index $.ImageContext.Images "scan-controllers-cve") }}
+        resources:
+          limits:
+            cpu: 1
+            memory: "500Mi"
+          requests:
+            cpu: 1
+            memory: "500Mi"
+        command: ["ack-build-tools", "scan-controllers-cve", 
+            --jobs-config-path ./prow/jobs/jobs_config.yaml ]

--- a/prow/jobs/tools/cmd/command/github.go
+++ b/prow/jobs/tools/cmd/command/github.go
@@ -133,3 +133,25 @@ func createPR(ctx context.Context, client *github.Client, prSubject, commitBranc
 
 	return nil
 }
+
+func createGithubIssue(owner, repo, title, body string, labels []string) error {
+	token := os.Getenv("GITHUB_TOKEN")
+	if token == "" {
+		return fmt.Errorf("enviroment variable GITHUB_TOKEN is not provided")
+	}
+
+	client := github.NewClient(nil).WithAuthToken(token)
+	
+	newIssueRequest := &github.IssueRequest{
+		Title: github.String(title),
+		Body: github.String(body),
+		Labels: &labels,
+	}
+
+	_, _, err := client.Issues.Create(context.Background(), owner, repo, newIssueRequest)
+	if err != nil {
+		return err
+	}
+	
+	return nil
+}

--- a/prow/jobs/tools/cmd/command/scan_controllers_cve.go
+++ b/prow/jobs/tools/cmd/command/scan_controllers_cve.go
@@ -1,0 +1,89 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//     http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package command
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/spf13/cobra"
+)
+
+var scanCveCMD = &cobra.Command{
+	Use:   "scan-controllers-cve",
+	Short: "scan-controllers-cve - retrieves all ack controllers and scans them for CVE",
+	RunE:  scanControllersCve,
+}
+
+var (
+	OptGithubIssueOwner string
+	OptGithubIssueRepo  string
+)
+
+func init() {
+	scanCveCMD.PersistentFlags().StringVar(
+		&OptJobsConfigPath, "jobs-config-path", "jobs_config.yaml", "path to jobs_config.yaml where jobs configurations are stored",
+	)
+	scanCveCMD.PersistentFlags().StringVar(
+		&OptGithubIssueOwner, "github-issues-owner", "aws-controllers-k8s", "user/org that owns the github repository where CVE issue will be created",
+	)
+	scanCveCMD.PersistentFlags().StringVar(
+		&OptGithubIssueRepo, "github-issues-repo", "community", "repository where the github issue will be created",
+	)
+	rootCmd.AddCommand(scanCveCMD)
+}
+
+func scanControllersCve(cmd *cobra.Command, args []string) error {
+
+	log.Printf("Retreiving AWS services list from %s\n", OptJobsConfigPath)
+	services, err := getACKServices(OptJobsConfigPath)
+	if err != nil {
+		return err
+	}
+
+	log.Println("Retreiving service controller to latest tag map")
+	controllerTagsMap, err := getControllersLatestTags(services)
+	if err != nil {
+		return err
+	}
+
+	log.Println("Scanning All controllers for CVEs")
+	detectedVulnerabilities, cveSummaries, err := scanControllersForCves(controllerTagsMap)
+	if err != nil {
+		return err
+	}
+
+	log.Printf("We found %d unique CVEs across all the controllers\n", len(detectedVulnerabilities))
+	if len(detectedVulnerabilities) == 0 {
+		log.Println("exiting...")
+		return nil
+	}
+
+	log.Println("Preparing github Issue listing all CVEs")
+	githubIssueBody, err := prepareGithubIssueBody(detectedVulnerabilities, cveSummaries)
+	if err != nil {
+		return fmt.Errorf("error while preparing github issue body: %s", err)
+	}
+
+	log.Printf("Creating github issue to %s/%s repo\n", OptGithubIssueOwner, OptGithubIssueRepo)
+	title := "ACK Detected Controllers CVEs"
+	labels := []string{
+		"kind/cve",
+	}
+	if err = createGithubIssue(OptGithubIssueOwner, OptGithubIssueRepo, title, githubIssueBody, labels); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/prow/jobs/tools/cmd/command/scan_controllers_cve_helper.go
+++ b/prow/jobs/tools/cmd/command/scan_controllers_cve_helper.go
@@ -1,0 +1,215 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//     http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package command
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/aws-controllers-k8s/test-infra/prow/jobs/tools/cmd/command/generator"
+)
+
+// CHANGE when there's a new service controller
+var controllersCount = 43
+
+// This is the struct to unmarshall
+// trivy image scan output
+type TrivyOutput struct {
+	Results []Result `json:"Results"`
+}
+
+// Results is stored in TrivyOutput
+// It has the results of the scanned components
+type Result struct {
+	Vulnerabilities []Vulnerability `json:"Vulnerabilities"`
+
+	// Including type here to specify the type of the component
+	// being scanned
+	Type string `json:"Type"`
+}
+
+// With Vulnerability, we're extracting the components
+// we need to create a Github Issue
+type Vulnerability struct {
+	VulnerabilityId  string `json:"VulnerabilityID"`
+	InstalledVersion string `json:"InstalledVersion"`
+	FixedVersion     string `json:"FixedVersion"`
+	Severity         string `json:"Severity"`
+	Title            string `json:"Title"`
+}
+
+type CVESummary struct {
+	InstalledVersion string
+	FixedVersion     string
+	Severity         string
+	Title            string
+
+	// Type will be assigned from the Result
+	// that holds this vulnerability
+	Type string
+}
+
+const (
+	scanControllerImageFormat      = "public.ecr.aws/aws-controllers-k8s/%s-controller:%s"
+	ecrPublicControllerImageFormat = "v2/aws-controllers-k8s/%s-controller"
+)
+
+func getACKServices(configPath string) ([]string, error) {
+	fileData, err := os.ReadFile(configPath)
+	if err != nil {
+		return nil, err
+	}
+
+	var config *generator.Config
+	if err = yaml.Unmarshal(fileData, &config); err != nil {
+		return nil, err
+	}
+
+	return config.AWSServices, nil
+}
+
+// listRepositoryTagsWithRetries calls listRepositoryTags, which in turn queries ecrpublic for the list
+// of tags from given repository
+// If ecrpublic denies the request with HTTP status 429: Too Many Requests, it retries for maxRetries
+// or until timeout duration expires
+// For any other errors it returns a nil and an error
+// A successful listRepositoryTagsWithRetries will return the list of tags per repository and err == nil
+func listRepositoryTagsWithRetries(repository string, maxRetries int, timeout time.Duration) ([]string, error) {
+	retries := 0
+	start := time.Now()
+
+	for {
+		if time.Since(start) > timeout {
+			return nil, fmt.Errorf("timeout to get repository tags after %d seconds", timeout)
+		}
+		if retries > maxRetries {
+			return nil, fmt.Errorf("timeout to get repository tags after %d retries", retries)
+		}
+		tags, err := listRepositoryTags(repository)
+		time.Sleep(1 * time.Second)
+		if err != nil {
+			if strings.Contains(err.Error(), "429") {
+				retries++
+				continue
+			} else {
+				return nil, err
+			}
+		}
+		return tags, nil
+	}
+
+}
+
+func getControllersLatestTags(services []string) (map[string]string, error) {
+	controllerTagsMap := make(map[string]string)
+
+	for _, service := range services {
+		controllerRepoTags, err := listRepositoryTagsWithRetries(fmt.Sprintf(ecrPublicControllerImageFormat, service), 10, 1*time.Minute)
+		if err != nil {
+			if strings.Contains(err.Error(), "404") {
+				continue
+			}
+			return nil, err
+		}
+		latestControllerTag, err := findHighestTagVersion(controllerRepoTags)
+		if err != nil {
+			return nil, err
+		}
+		controllerTagsMap[service] = latestControllerTag
+	}
+	controllersCount = len(controllerTagsMap)
+
+	return controllerTagsMap, nil
+}
+
+func getCveSummaries(controller string, results []Result, cveSummaries map[string]CVESummary, detectedVulnerabilities map[string][]string) {
+	for _, result := range results {
+		for _, vulnerability := range result.Vulnerabilities {
+
+			cveSummaries[vulnerability.VulnerabilityId] = CVESummary{
+				InstalledVersion: vulnerability.InstalledVersion,
+				FixedVersion:     vulnerability.FixedVersion,
+				Severity:         vulnerability.Severity,
+				Title:            vulnerability.Title,
+				Type:             result.Type,
+			}
+			controllers, ok := detectedVulnerabilities[vulnerability.VulnerabilityId]
+			if ok {
+				detectedVulnerabilities[vulnerability.VulnerabilityId] = append(controllers, controller)
+			} else {
+				detectedVulnerabilities[vulnerability.VulnerabilityId] = []string{controller}
+			}
+		}
+	}
+}
+
+func scanControllersForCves(controllerTagsMap map[string]string) (map[string][]string, map[string]CVESummary, error) {
+
+	app := "trivy"
+
+	cveSummaries := make(map[string]CVESummary)
+	detectedVulnerabilities := make(map[string][]string)
+
+	for controller, tag := range controllerTagsMap {
+
+		args := []string{
+			"image",
+			"--format",
+			"json",
+			"-q",
+			fmt.Sprintf(scanControllerImageFormat, controller, tag),
+		}
+		cmd := exec.Command(app, args...)
+		stdout, err := cmd.CombinedOutput()
+		//TODO: return error for now, revist later
+		if err != nil {
+			return nil, nil, fmt.Errorf("%s\n%s", stdout, err)
+		}
+
+		var trivyOutput *TrivyOutput
+		if err = json.Unmarshal(stdout, &trivyOutput); err != nil {
+			return nil, nil, err
+		}
+		getCveSummaries(controller, trivyOutput.Results, cveSummaries, detectedVulnerabilities)
+	}
+	return detectedVulnerabilities, cveSummaries, nil
+}
+
+func prepareGithubIssueBody(controllersByVulnerabilities map[string][]string, cveSummaries map[string]CVESummary) (string, error) {
+
+	title := "| CVE ID | Type | Severity | Installed Version | Fixed Version | Affected Controllers | Title |"
+	tableFormat := "|---|---|---|---|---|---|---|"
+	const format = "|%s|%s|%s|%s|%s|%s|%s|\n"
+
+	var builder strings.Builder
+
+	for vulnerabilityId, cveSummary := range cveSummaries {
+		controllers := fmt.Sprintf("%s", controllersByVulnerabilities[vulnerabilityId])
+		if len(controllersByVulnerabilities[vulnerabilityId]) == controllersCount {
+			controllers = "ALL"
+		}
+		_, err := builder.WriteString(fmt.Sprintf(format, vulnerabilityId, cveSummary.Type, cveSummary.Severity, cveSummary.InstalledVersion, cveSummary.FixedVersion, controllers, cveSummary.Title))
+		if err != nil {
+			return "", err
+		}
+	}
+
+	return fmt.Sprintf("%s\n%s\n%s", title, tableFormat, builder.String()), nil
+}

--- a/prow/jobs/tools/cmd/command/scan_controllers_cve_tests.go
+++ b/prow/jobs/tools/cmd/command/scan_controllers_cve_tests.go
@@ -1,0 +1,120 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//     http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package command
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFindHighestTagVersion(t *testing.T) {
+	assert := assert.New(t)
+
+	type args struct {
+		tags []string
+	}
+
+	tests := []struct {
+		name        string
+		args        args
+		wantVersion string
+		wantErr     bool
+	}{
+		{
+			name:        "empty tags",
+			args:        args{[]string{}},
+			wantVersion: "",
+			wantErr:     true,
+		},
+		{
+			name:        "one tag",
+			args:        args{[]string{"1.23.0"}},
+			wantVersion: "1.23.0",
+			wantErr:     false,
+		},
+		{
+			name:        "malformed tag",
+			args:        args{[]string{"1.23.0", "1./3.3"}},
+			wantVersion: "",
+			wantErr:     true,
+		},
+		{
+			name:        "correct versions",
+			args:        args{[]string{"1.0.0", "1.1.1", "2.2.2", "0.10.1", "12.34.91", "12.34.92"}},
+			wantVersion: "12.34.92",
+			wantErr:     false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			version, err := findHighestTagVersion(tt.args.tags)
+			if (err != nil) != tt.wantErr {
+				assert.Fail(fmt.Sprintf("findHighestTags() error = %v, wantErr %v", err, tt.wantErr))
+			}
+			assert.Equal(tt.wantVersion, version)
+		})
+	}
+}
+
+func TestGetCveSummaries(t *testing.T) {
+
+	assert := assert.New(t)
+
+	type args struct {
+		controller              string
+		results             []Result
+		cveSummaries            map[string]CVESummary
+		detectedVulnerabilities map[string][]string
+	}
+
+	tests := []struct {
+		name                        string
+		args                        args
+		wantCveSummariesLength            int
+		wantDetectedVulnerabilitiesLength int
+	}{
+		{
+			name: "correct input",
+			args: args{
+				controller: "ec2",
+				results: []Result{{
+						[]Vulnerability{{
+							VulnerabilityId:  "CVE-2024-9805",
+							InstalledVersion: "1.22.2",
+							FixedVersion:     "1.23.0",
+							Severity:         "LOW",
+							Title:            "This is a title",
+						}},
+						"gobinary",
+					},
+				},
+				cveSummaries:            map[string]CVESummary{},
+				detectedVulnerabilities: map[string][]string{},
+			},
+			wantCveSummariesLength: 1,
+			wantDetectedVulnerabilitiesLength: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			getCveSummaries(tt.args.controller, tt.args.results, tt.args.cveSummaries, tt.args.detectedVulnerabilities)
+			assert.Len(tt.args.cveSummaries, tt.wantCveSummariesLength)
+			assert.Len(tt.args.detectedVulnerabilities, tt.wantDetectedVulnerabilitiesLength)
+		})
+	}
+}

--- a/prow/jobs/tools/cmd/command/upgrade_go_version.go
+++ b/prow/jobs/tools/cmd/command/upgrade_go_version.go
@@ -57,7 +57,7 @@ func runUpgradeGoVersion(cmd *cobra.Command, args []string) error {
 
 	log.Printf("Successfully listed go versions from %s\n", OptGoEcrRepository)
 
-	highestEcrGoVersion, err := findHighestGoVersion(ecrGoVersions)
+	highestEcrGoVersion, err := findHighestTagVersion(ecrGoVersions)
 	if err != nil {
 		return fmt.Errorf("%v", err)
 	}

--- a/prow/jobs/tools/cmd/command/upgrade_go_version_helper.go
+++ b/prow/jobs/tools/cmd/command/upgrade_go_version_helper.go
@@ -42,12 +42,12 @@ func listRepositoryTags(repository string) ([]string, error) {
 	client := ecrpublic.New()
 	tags, err := client.ListRepositoryTags(repository)
 	if err != nil {
-		return nil, fmt.Errorf("cannot list repositories in %s. %s", OptGoEcrRepository, err)
+		return nil, fmt.Errorf("cannot list repositories in %s. %s", repository, err)
 	}
 	return tags, nil
 }
 
-func findHighestGoVersion(tags []string) (string, error) {
+func findHighestTagVersion(tags []string) (string, error) {
 	versions := make([]semver.Version, 0, len(tags))
 	regex := regexp.MustCompile(`[a-z]`)
 


### PR DESCRIPTION
Description of changes:

Currently ACK does not have an automated way of detecting issues in our controllers.
This prow job will allow us to detect any vulnerabilities in our controller images 
and notify us early enough so we can take action on time.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
