### PR TITLE
Change `scan-controllers-cve` image build context

### DIFF
--- a/prow/jobs/images_config.yaml
+++ b/prow/jobs/images_config.yaml
@@ -2,7 +2,7 @@ image_repo: public.ecr.aws/m5q3e4b2/prow
 images: 
     auto-generate-controllers: prow-auto-generate-controllers-0.0.16
     auto-update-controllers: prow-auto-update-controllers-0.0.7
-    build-prow-images: prow-build-prow-images-0.0.35
+    build-prow-images: prow-build-prow-images-0.0.36
     controller-release-tag: prow-controller-release-tag-0.0.4
     deploy: prow-deploy-0.0.17
     docs: prow-docs-0.0.13

--- a/prow/jobs/tools/cmd/command/patch_prowjobs_helper.go
+++ b/prow/jobs/tools/cmd/command/patch_prowjobs_helper.go
@@ -154,7 +154,12 @@ func buildImages(tagsToBuild map[string]string) error {
 		
 		tag := fmt.Sprintf("prow/%s", postfix)
 		context := "./prow/jobs/images"
-		if postfix == "build-prow-images" || postfix == "upgrade-go-version" {
+		// in the future, we would want to 
+		// store the context in the images_config.yaml
+		// and unmarshall it in a struct
+		if postfix == "build-prow-images" || 
+			postfix == "upgrade-go-version" || 
+			postfix == "scan-controllers-cve" {
 			context = "."
 		}
 


### PR DESCRIPTION
Description of changes:

Currently `prow/jobs/images` is the default prow image
build context directory. Prow images that use the `ack-build-tools`
command use the repo home directory as their build context, 
so whenever we add a command we have to change the code 
logic to include this image with the current ones that are being 
built in the `test-infra` root directory.

In the future, we want to start including the build context of the 
images we're building as part of the `images_config.yaml` file, 
as well as any other image specific information we may use.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
