### PR TITLE
Temporarily remove `scan-controllers-cve` to allow `build-prow-images` build

### DIFF
--- a/prow/jobs/images_config.yaml
+++ b/prow/jobs/images_config.yaml
@@ -9,7 +9,7 @@ images:
     integration-test: prow-integration-0.0.24
     olm-bundle-pr: prow-olm-bundle-pr-0.0.4
     olm-test: prow-olm-test-0.0.5
-    scan-controllers-cve: prow-scan-controllers-cve-0.0.1
+    # scan-controllers-cve: prow-scan-controllers-cve-0.0.1
     soak-test: prow-soak-0.0.7
     unit-test: prow-unit-0.0.8
     upgrade-go-version: prow-upgrade-go-version-0.0.8


### PR DESCRIPTION
Description of changes:

We need to update `build-prow-images` and use the new 
image in a later PR to build `scan-controllers-cve`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
