### PR TITLE
Enhance `scan-controllers-cve` unit-tests

### DIFF
--- a/prow/jobs/images_config.yaml
+++ b/prow/jobs/images_config.yaml
@@ -9,7 +9,7 @@ images:
     integration-test: prow-integration-0.0.24
     olm-bundle-pr: prow-olm-bundle-pr-0.0.4
     olm-test: prow-olm-test-0.0.7
-    # scan-controllers-cve: prow-scan-controllers-cve-0.0.1
+    scan-controllers-cve: prow-scan-controllers-cve-0.0.1
     soak-test: prow-soak-0.0.7
     unit-test: prow-unit-0.0.8
     upgrade-go-version: prow-upgrade-go-version-0.0.8

--- a/prow/jobs/tools/cmd/command/scan_controllers_cve_helper.go
+++ b/prow/jobs/tools/cmd/command/scan_controllers_cve_helper.go
@@ -103,9 +103,9 @@ func listRepositoryTagsWithRetries(repository string, maxRetries int, timeout ti
 			return nil, fmt.Errorf("timeout to get repository tags after %d retries", retries)
 		}
 		tags, err := listRepositoryTags(repository)
-		time.Sleep(1 * time.Second)
 		if err != nil {
 			if strings.Contains(err.Error(), "429") {
+				time.Sleep(1 * time.Second)
 				retries++
 				continue
 			} else {

--- a/prow/jobs/tools/cmd/command/scan_controllers_cve_tests.go
+++ b/prow/jobs/tools/cmd/command/scan_controllers_cve_tests.go
@@ -76,37 +76,87 @@ func TestGetCveSummaries(t *testing.T) {
 
 	type args struct {
 		controller              string
-		results             []Result
+		results                 []Result
 		cveSummaries            map[string]CVESummary
 		detectedVulnerabilities map[string][]string
 	}
 
 	tests := []struct {
-		name                        string
-		args                        args
+		name                              string
+		args                              args
 		wantCveSummariesLength            int
 		wantDetectedVulnerabilitiesLength int
 	}{
 		{
-			name: "correct input",
+			name: "single CVE",
 			args: args{
 				controller: "ec2",
 				results: []Result{{
-						[]Vulnerability{{
-							VulnerabilityId:  "CVE-2024-9805",
-							InstalledVersion: "1.22.2",
-							FixedVersion:     "1.23.0",
-							Severity:         "LOW",
-							Title:            "This is a title",
-						}},
-						"gobinary",
-					},
+					[]Vulnerability{{
+						VulnerabilityId:  "CVE-2024-9805",
+						InstalledVersion: "1.22.2",
+						FixedVersion:     "1.23.0",
+						Severity:         "LOW",
+						Title:            "This is a title",
+					}},
+					"gobinary",
+				},
 				},
 				cveSummaries:            map[string]CVESummary{},
 				detectedVulnerabilities: map[string][]string{},
 			},
-			wantCveSummariesLength: 1,
+			wantCveSummariesLength:            1,
 			wantDetectedVulnerabilitiesLength: 1,
+		},
+		{
+			name: "aggregate CVEs",
+			args: args{
+				controller: "ec2",
+				results: []Result{{
+					[]Vulnerability{{
+						VulnerabilityId:  "CVE-2024-9805",
+						InstalledVersion: "1.22.2",
+						FixedVersion:     "1.23.0",
+						Severity:         "LOW",
+						Title:            "This is a title",
+					}},
+					"gobinary",
+				},
+				},
+				cveSummaries: map[string]CVESummary{
+					"CVE-2024-9805": {"1.22.2", "1.23.0", "LOW", "Some title", "gobinary"},
+				},
+				detectedVulnerabilities: map[string][]string{
+					"CVE-2024-9805": {"lambda", "s3", "sns", "sqs", "rds"},
+				},
+			},
+			wantCveSummariesLength:            1,
+			wantDetectedVulnerabilitiesLength: 1,
+		},
+		{
+			name: "unique CVEs",
+			args: args{
+				controller: "ec2",
+				results: []Result{{
+					[]Vulnerability{{
+						VulnerabilityId:  "CVE-2024-1000",
+						InstalledVersion: "1.22.2",
+						FixedVersion:     "1.23.0",
+						Severity:         "LOW",
+						Title:            "This is a title",
+					}},
+					"gobinary",
+				},
+				},
+				cveSummaries: map[string]CVESummary{
+					"CVE-2024-9805": {"1.22.2", "1.23.0", "LOW", "Some title", "gobinary"},
+				},
+				detectedVulnerabilities: map[string][]string{
+					"CVE-2024-9805": {"lambda"},
+				},
+			},
+			wantCveSummariesLength:            2,
+			wantDetectedVulnerabilitiesLength: 2,
 		},
 	}
 


### PR DESCRIPTION
Description of changes:
Added back `scan-controllers-cve` image version to `images_config.yaml`
Addressed comments left by @a-hilaly on original [PR](https://github.com/aws-controllers-k8s/test-infra/pull/532):
* Run gofmt against the Go code
* Properly sleep only when a 429 error is return when calling `listRepositoryTagsWithRetries`


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
