### PR TITLE
Add build-args when building prow images

### DIFF
--- a/prow/jobs/images_config.yaml
+++ b/prow/jobs/images_config.yaml
@@ -2,7 +2,7 @@ image_repo: public.ecr.aws/m5q3e4b2/prow
 images: 
     auto-generate-controllers: prow-auto-generate-controllers-0.0.16
     auto-update-controllers: prow-auto-update-controllers-0.0.7
-    build-prow-images: prow-build-prow-images-0.0.36
+    build-prow-images: prow-build-prow-images-0.0.37
     controller-release-tag: prow-controller-release-tag-0.0.4
     deploy: prow-deploy-0.0.17
     docs: prow-docs-0.0.13

--- a/prow/jobs/tools/cmd/command/patch_prowjobs.go
+++ b/prow/jobs/tools/cmd/command/patch_prowjobs.go
@@ -93,8 +93,14 @@ func buildProwImages(cmd *cobra.Command, args []string) error {
 		return nil
 	}
 
+	buildConfigData, err := readBuildConfigFile(OptBuildConfigPath)
+	if err != nil {
+		return err
+	}
+
 	log.Printf("Tags to build:\n %v\n", tagsToBuild)
-	if err = buildImages(tagsToBuild); err != nil {
+	log.Printf("Building images with GO_VERSION %s and EKS_DISTRO_VERSION %s\n", buildConfigData.GoVersion, buildConfigData.EksDistroVersion)
+	if err = buildImages(tagsToBuild, buildConfigData); err != nil {
 		return err
 	}
 	log.Println("Successfully built all images")

--- a/prow/jobs/tools/cmd/command/patch_prowjobs_helper.go
+++ b/prow/jobs/tools/cmd/command/patch_prowjobs_helper.go
@@ -139,7 +139,7 @@ func compareImageVersions(configTagsMap, ecrTagsMap map[string]string) (map[stri
 	return tagsToBuild, nil
 }
 
-func buildImages(tagsToBuild map[string]string) error {
+func buildImages(tagsToBuild map[string]string, buildArgs *BuildConfig) error {
 	// BuildImage("my-app", "my-app-0.0.9")
 	app := "buildah"
 	imagesDir := "./prow/jobs/images"
@@ -149,6 +149,8 @@ func buildImages(tagsToBuild map[string]string) error {
 		sortedTagKeys = append(sortedTagKeys, key)
 	}
 	sort.Strings(sortedTagKeys)
+	goVersion := buildArgs.GoVersion
+	eksDistroVersion := fmt.Sprintf("public.ecr.aws/eks-distro-build-tooling/eks-distro-minimal-base-nonroot:%s",buildArgs.EksDistroVersion)
 
 	for _, postfix := range sortedTagKeys {
 		
@@ -171,6 +173,10 @@ func buildImages(tagsToBuild map[string]string) error {
 			tag,
 			"--arch",
 			"amd64",
+			"--build-arg",
+			fmt.Sprintf("GO_VERSION=%s", goVersion),
+			"--build-arg",
+			fmt.Sprintf("BASE_IMAGE=%s", eksDistroVersion),
 			context,
 		}
 		cmd := exec.Command(app, args...)


### PR DESCRIPTION
Description of changes:

We are adding `GO_VERSION` and `EKS_DISTRO_VERSION` 
build args when building our prow images. These build args will 
be used by the `deploy` image to build and release controllers 
with the updated given versions.

Later we need to make a change to `release_controller.sh` 
to allow it to pass EKS_DISTRO_VERSION as a build arg when 
building our controllers

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
