### PR TITLE
Change base image for `verify-attribution` job to debian

### DIFF
--- a/cd/scripts/verify-attribution.sh
+++ b/cd/scripts/verify-attribution.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 set -eo pipefail
 

--- a/prow/jobs/images/Dockerfile.verify-attribution
+++ b/prow/jobs/images/Dockerfile.verify-attribution
@@ -13,10 +13,9 @@ RUN git clone https://github.com/awslabs/attribution-gen .
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o attribution-gen ./cmd
 
 # Start a new stage from scratch
-FROM alpine:latest  
+FROM debian:buster-slim
 
 COPY --from=builder /app/attribution-gen /usr/local/bin/
-COPY wrapper.sh /usr/local/bin/
 
 RUN chmod +x /usr/local/bin/attribution-gen
 

--- a/prow/jobs/templates/presubmits/code_generator_tests.tpl
+++ b/prow/jobs/templates/presubmits/code_generator_tests.tpl
@@ -53,6 +53,8 @@
         - name: DEBUG
           value: "true"
         command:
+        - "bin/bash"
+        - "-c"
         - "./cd/scripts/verify-attribution.sh"
 
   - name: s3-olm-test

--- a/prow/jobs/templates/presubmits/pkg_tests.tpl
+++ b/prow/jobs/templates/presubmits/pkg_tests.tpl
@@ -53,4 +53,6 @@
         - name: DEBUG
           value: "true"
         command:
+        - "bin/bash"
+        - "-c"
         - "./cd/scripts/verify-attribution.sh"

--- a/prow/jobs/templates/presubmits/runtime_tests.tpl
+++ b/prow/jobs/templates/presubmits/runtime_tests.tpl
@@ -53,6 +53,8 @@
         - name: DEBUG
           value: "true"
         command:
+        - "bin/bash"
+        - "-c"
         - "./cd/scripts/verify-attribution.sh"
 
 {{ range $_, $service := .Config.RuntimePresubmitServices }}

--- a/prow/jobs/templates/presubmits/service_tests.tpl
+++ b/prow/jobs/templates/presubmits/service_tests.tpl
@@ -201,5 +201,7 @@
         - name: DEBUG
           value: "true"
         command:
+        - "bin/bash"
+        - "-c"
         - "./cd/scripts/verify-attribution.sh"
 {{ end }}


### PR DESCRIPTION
Description of changes:

Some commands in the script don't work in sh
So we're reverting back to bash and we need debian to solve this issue

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
