### PR TITLE
Update `verify-attribution` image and correct bash paths

### DIFF
--- a/prow/jobs/images_config.yaml
+++ b/prow/jobs/images_config.yaml
@@ -13,4 +13,4 @@ images:
     soak-test: prow-soak-0.0.7
     unit-test: prow-unit-0.0.8
     upgrade-go-version: prow-upgrade-go-version-0.0.8
-    verify-attribution: prow-verify-attribution-0.0.2
+    verify-attribution: prow-verify-attribution-0.0.3

--- a/prow/jobs/templates/presubmits/code_generator_tests.tpl
+++ b/prow/jobs/templates/presubmits/code_generator_tests.tpl
@@ -53,7 +53,7 @@
         - name: DEBUG
           value: "true"
         command:
-        - "bin/bash"
+        - "/bin/bash"
         - "-c"
         - "./cd/scripts/verify-attribution.sh"
 

--- a/prow/jobs/templates/presubmits/pkg_tests.tpl
+++ b/prow/jobs/templates/presubmits/pkg_tests.tpl
@@ -53,6 +53,6 @@
         - name: DEBUG
           value: "true"
         command:
-        - "bin/bash"
+        - "/bin/bash"
         - "-c"
         - "./cd/scripts/verify-attribution.sh"

--- a/prow/jobs/templates/presubmits/runtime_tests.tpl
+++ b/prow/jobs/templates/presubmits/runtime_tests.tpl
@@ -53,7 +53,7 @@
         - name: DEBUG
           value: "true"
         command:
-        - "bin/bash"
+        - "/bin/bash"
         - "-c"
         - "./cd/scripts/verify-attribution.sh"
 

--- a/prow/jobs/templates/presubmits/service_tests.tpl
+++ b/prow/jobs/templates/presubmits/service_tests.tpl
@@ -201,7 +201,7 @@
         - name: DEBUG
           value: "true"
         command:
-        - "bin/bash"
+        - "/bin/bash"
         - "-c"
         - "./cd/scripts/verify-attribution.sh"
 {{ end }}


### PR DESCRIPTION
- Update verify-attribution image to `0.0.3`
- Fix bash paths in multiple test templates

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
