### PR TITLE
feat(ack-discover): migrate to GraphQL API and enhance service mapping

### DIFF
--- a/tools/ackdiscover/service.py
+++ b/tools/ackdiscover/service.py
@@ -14,6 +14,7 @@
 import dataclasses
 import os
 import ijson
+import json
 
 @dataclasses.dataclass
 class Service:
@@ -22,7 +23,6 @@ class Service:
     full_name: str = None
     abbrev_name: str = None
     package_name: str = None
-
 
 def collect_all(writer, repo):
     """Returns a map, keyed by AWS *service package* name, of ServiceInfo

--- a/tools/cmd/ack-discover
+++ b/tools/cmd/ack-discover
@@ -43,7 +43,6 @@
 import argparse
 import os
 import pathlib
-import pprint
 import sys
 
 import github


### PR DESCRIPTION
TLDR: Fixes ACK docs generation

This patch enhances the ACK discovery tool to address some recent API
changes and improve our service coverage. Two major improvements have
been implemented:

1. GraphQL migration for `/Projects`
   We're transitionning from the Github REST API to their GraphQL API
   for project data fetching. This change was necessary due to GitHub
   deprecation of classic projects and lack of REST support for new
   projects. Now we use a single GraphQL query to fetch all required
   project data (replacing multiple REST api calls)

2. Enhanced service discovery by name
   We've addressed an issue where some AWS services have different
   names in AWS SDKs compared to their model files, causing some
   services to be missed in our documentation generation.

   - Introduced `exceptional_service_names` dictionary to map package
     names to correct controller names. This is a temporary solution
     More info about this in the code comments...

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
