### PR TITLE
On release, read `GOLANG_VERSION` from `build_config.yaml`

### DIFF
--- a/cd/scripts/release-controller.sh
+++ b/cd/scripts/release-controller.sh
@@ -113,9 +113,9 @@ if [[ $QUIET = "false" ]]; then
     echo " git commit: $SERVICE_CONTROLLER_GIT_COMMIT"
 fi
 
-pushd "$CODE_GEN_DIR" 1>/dev/null
-  # Get the golang version from the code-generator
-  GOLANG_VERSION=${GOLANG_VERSION:-"$(go list -f \{\{.GoVersion\}\} -m)"}
+pushd "$TEST_INFRA_DIR" 1>/dev/null
+  # Get the golang version from build_config.yaml
+  GOLANG_VERSION=$(cat build_config.yaml | yq .go_version)
 popd 1>/dev/null
 
 # Build amd64 controller image


### PR DESCRIPTION
Description of changes:

When building and releasing controllers, use 
the go version stored in `build_config.yaml` 
as that version is the latest one, retrieved by 
the `Update_Go_Version` prow job. This will 
ensure all our controllers will have the latest GO version.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
