### PR TITLE
add kmod to integration test and always enable ipv6 in kernel

### DIFF
--- a/prow/jobs/images/Dockerfile.integration-test
+++ b/prow/jobs/images/Dockerfile.integration-test
@@ -24,6 +24,7 @@ RUN echo "Installing packages ..." \
         lsb-release \
         wget \
         jq \
+        kmod \
         uuid-runtime \
         apt-transport-https \
         unzip
@@ -46,9 +47,6 @@ RUN curl -fsSL https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip -o awscl
     && unzip awscliv2.zip \
     && aws/install \
     && export AWS_PAGER=""
-
-ARG DOCKER_VERSION=24.0.5
-ENV DOCKER_VERSION=${DOCKER_VERSION}
 
 RUN echo "Installing controller-gen v0.14.0..." \
     && go install "sigs.k8s.io/controller-tools/cmd/controller-gen@v0.14.0" \

--- a/prow/jobs/images/wrapper.sh
+++ b/prow/jobs/images/wrapper.sh
@@ -47,34 +47,15 @@ trap early_exit_handler TERM INT
 PROW_JOB_ID=${PROW_JOB_ID:-"unknown"}
 AWS_SERVICE=$(echo "$SERVICE" | tr '[:upper:]' '[:lower:]')
 
-# optionally enable ipv6 docker
-export DOCKER_IN_DOCKER_IPV6_ENABLED=${DOCKER_IN_DOCKER_IPV6_ENABLED:-false}
-if [[ "${DOCKER_IN_DOCKER_IPV6_ENABLED}" == "true" ]]; then
-  >&2 echo "wrapper.sh] [SETUP] Enabling IPv6 in Docker config ..."
+# Check if the job has opted-in to docker-in-docker
+export DOCKER_IN_DOCKER_ENABLED=${DOCKER_IN_DOCKER_ENABLED:-false}
+if [[ "${DOCKER_IN_DOCKER_ENABLED}" == "true" ]]; then
+  >&2 echo "wrapper.sh] [SETUP] Docker in Docker enabled, initializing ..."
   # enable ipv6
   sysctl net.ipv6.conf.all.disable_ipv6=0
   sysctl net.ipv6.conf.all.forwarding=1
   # enable ipv6 iptables
   modprobe -v ip6table_nat
-  >&2 echo "wrapper.sh] [SETUP] Done enabling IPv6 in Docker config."
-fi
-
-# optionally enable iptables-nft
-export DOCKER_IN_DOCKER_NFT_ENABLED=${DOCKER_IN_DOCKER_NFT_ENABLED:-false}
-if [[ "${DOCKER_IN_DOCKER_NFT_ENABLED}" == "true" ]]; then
-  >&2 echo "wrapper.sh] [SETUP] Enabling iptables-nft ..."
-  # enable iptables-nft
-  update-alternatives --set iptables /usr/sbin/iptables-nft
-  update-alternatives --set ip6tables /usr/sbin/ip6tables-nft
-  # enable nft iptables module
-  modprobe -v nf_tables
-  >&2 echo "wrapper.sh] [SETUP] Done enabling iptables-nft by default."
-fi
-
-# Check if the job has opted-in to docker-in-docker
-export DOCKER_IN_DOCKER_ENABLED=${DOCKER_IN_DOCKER_ENABLED:-false}
-if [[ "${DOCKER_IN_DOCKER_ENABLED}" == "true" ]]; then
-  >&2 echo "wrapper.sh] [SETUP] Docker in Docker enabled, initializing ..."
   # If we have opted in to docker in docker, start the docker daemon,
   service docker start
   # the service can be started but the docker socket not ready, wait for ready

--- a/prow/jobs/images_config.yaml
+++ b/prow/jobs/images_config.yaml
@@ -6,7 +6,7 @@ images:
     controller-release-tag: prow-controller-release-tag-0.0.5
     deploy: prow-deploy-0.0.19
     docs: prow-docs-0.0.14
-    integration-test: prow-integration-0.0.25
+    integration-test: prow-integration-0.0.26
     olm-bundle-pr: prow-olm-bundle-pr-0.0.9
     olm-test: prow-olm-test-0.0.8
     scan-controllers-cve: prow-scan-controllers-cve-0.0.2


### PR DESCRIPTION
Description of changes:
These changes prepare the cluster move from version 1.23

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
