### PR TITLE
Force controller-gen v0.16.2 for all controller

### DIFF
--- a/prow/jobs/images/Dockerfile.integration-test
+++ b/prow/jobs/images/Dockerfile.integration-test
@@ -48,8 +48,8 @@ RUN curl -fsSL https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip -o awscl
     && aws/install \
     && export AWS_PAGER=""
 
-RUN echo "Installing controller-gen v0.14.0..." \
-    && go install "sigs.k8s.io/controller-tools/cmd/controller-gen@v0.14.0" \
+RUN echo "Installing controller-gen v0.16.2..." \
+    && go install "sigs.k8s.io/controller-tools/cmd/controller-gen@v0.16.2" \
     && mv $GOPATH/bin/controller-gen /usr/bin/controller-gen
 
 RUN echo "Installing Kustomize ..." \

--- a/prow/jobs/images/Dockerfile.olm-bundle-pr
+++ b/prow/jobs/images/Dockerfile.olm-bundle-pr
@@ -61,10 +61,10 @@ RUN echo "Installing Kustomize v4.1.2 ..." \
     && tar xzf "${KUSTOMIZE_TARBALL}" -C /usr/bin \
     && rm "${KUSTOMIZE_TARBALL}"
 
-RUN echo "Installing controller-gen v0.14.0 ..." \
+RUN echo "Installing controller-gen v0.16.2 ..." \
     && cd $(mktemp -d /tmp/controller-gen-XXX) \
     && go mod init tmp \
-    && go get -d "sigs.k8s.io/controller-tools/cmd/controller-gen@v0.14.0" \
+    && go get -d "sigs.k8s.io/controller-tools/cmd/controller-gen@v0.16.2" \
     && go build -o "/usr/local/bin/controller-gen" sigs.k8s.io/controller-tools/cmd/controller-gen
 
 RUN echo "Installing yq ... " \

--- a/prow/jobs/images_config.yaml
+++ b/prow/jobs/images_config.yaml
@@ -6,11 +6,11 @@ images:
     controller-release-tag: prow-controller-release-tag-0.0.5
     deploy: prow-deploy-0.0.19
     docs: prow-docs-0.0.14
-    integration-test: prow-integration-0.0.26
+    integration-test: prow-integration-0.0.27
     olm-bundle-pr: prow-olm-bundle-pr-0.0.9
     olm-test: prow-olm-test-0.0.8
     scan-controllers-cve: prow-scan-controllers-cve-0.0.2
     soak-test: prow-soak-0.0.8
-    unit-test: prow-unit-0.0.9
+    unit-test: prow-unit-0.0.10
     upgrade-go-version: prow-upgrade-go-version-0.0.9
     verify-attribution: prow-verify-attribution-0.0.5


### PR DESCRIPTION
Looks like controller builds will start failing once we move to controller-runtime v0.19.0
Just trying to stay ahead of the dependencies here

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
