### PR TITLE
Label all the generated prow job PRs and github issues with `prow/auto-gen`

### DIFF
--- a/prow/jobs/images_config.yaml
+++ b/prow/jobs/images_config.yaml
@@ -2,14 +2,14 @@ image_repo: public.ecr.aws/m5q3e4b2/prow
 images:
     auto-generate-controllers: prow-auto-generate-controllers-0.0.17
     auto-update-controllers: prow-auto-update-controllers-0.0.8
-    build-prow-images: prow-build-prow-images-0.0.38
+    build-prow-images: prow-build-prow-images-0.0.39
     controller-release-tag: prow-controller-release-tag-0.0.5
     deploy: prow-deploy-0.0.19
     docs: prow-docs-0.0.14
     integration-test: prow-integration-0.0.27
     olm-bundle-pr: prow-olm-bundle-pr-0.0.9
     olm-test: prow-olm-test-0.0.8
-    scan-controllers-cve: prow-scan-controllers-cve-0.0.2
+    scan-controllers-cve: prow-scan-controllers-cve-0.0.3
     soak-test: prow-soak-0.0.8
     unit-test: prow-unit-0.0.10
     upgrade-go-version: prow-upgrade-go-version-0.0.9

--- a/prow/jobs/tools/cmd/command/scan_controllers_cve.go
+++ b/prow/jobs/tools/cmd/command/scan_controllers_cve.go
@@ -80,6 +80,7 @@ func scanControllersCve(cmd *cobra.Command, args []string) error {
 	title := "ACK Detected Controllers CVEs"
 	labels := []string{
 		"kind/cve",
+		defaultProwAutoGenLabel,
 	}
 	if err = createGithubIssue(OptGithubIssueOwner, OptGithubIssueRepo, title, githubIssueBody, labels); err != nil {
 		return err


### PR DESCRIPTION
Inject `prow/auto-gen` to easily distinguish generated PR/Github issues from non
generated ones.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
