### PR TITLE
Automate `OWNERS_ALIASES` and `OWNERS` file updates in all controllers

### DIFF
--- a/cd/auto-generate/auto-generate-controllers.sh
+++ b/cd/auto-generate/auto-generate-controllers.sh
@@ -206,6 +206,12 @@ for CONTROLLER_NAME in $CONTROLLER_NAMES; do
     continue
   fi
 
+  echo "auto-generate-controllers.sh][INFO] Update OWNERS_ALIASES file from test-infra"
+  pushd "$TEST_INFRA_DIR" >/dev/null
+    cp OWNERS_ALIASES "$CONTROLLER_DIR"
+    cp OWNERS "$CONTROLLER_DIR"
+  popd >/dev/null
+
   # Since there are no failures, print make build output in prowjob logs
   cat "$MAKE_BUILD_OUTPUT_FILE"
   pushd "$CONTROLLER_DIR" >/dev/null


### PR DESCRIPTION
Description of changes:
This files look at test-infra as their source of truth

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
