### PR TITLE
Pass the `LOCAL_MODULES` env to `build-controller-image.sh`

### DIFF
--- a/scripts/controller-setup.sh
+++ b/scripts/controller-setup.sh
@@ -48,9 +48,8 @@ _build_controller_image() {
     local __img_name=$1
 
     local local_build_default="$(get_is_local_build)"
-    LOCAL_MODULES=${LOCAL_MODULES:-$local_build_default}
 
-    AWS_SERVICE_DOCKER_IMG="$__img_name" ${CODE_GENERATOR_SCRIPTS_DIR}/build-controller-image.sh ${AWS_SERVICE} 1>/dev/null
+    LOCAL_MODULES=${LOCAL_MODULES:-$local_build_default} AWS_SERVICE_DOCKER_IMG="$__img_name" ${CODE_GENERATOR_SCRIPTS_DIR}/build-controller-image.sh ${AWS_SERVICE} 1>/dev/null
 }
 
 _load_controller_image() {


### PR DESCRIPTION
Currently, `LOCAL_MODULES` is not passed to the `build-controller-image.sh` and we cannot test the local `runtime` changes in order to build the controller's image with the `Dockerfile.local` file.

Putting it in front of the command, it will be passed to the `build-controller-image.sh` script and it will use the local `runtime` code.