### PR TITLE
Add larger `Karpenter/instance-size` options, remove smaller ones

### DIFF
--- a/flux/karpenter-config/provisioner.yaml
+++ b/flux/karpenter-config/provisioner.yaml
@@ -18,7 +18,7 @@ spec:
   # Exclude small instance sizes
   - key: karpenter.k8s.aws/instance-size
     operator: In
-    values: [medium, large, xlarge, xlarge, 2xlarge, 4xlarge, 8xlarge]
+    values: [xlarge, 2xlarge, 4xlarge, 8xlarge, 12xlarge, 16xlarge]
   - key: kubernetes.io/arch
     operator: In
     values:


### PR DESCRIPTION
Description of changes:
Adding 12xlarge and 16xlarge options, to ensure our tests run properly

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
