### PR TITLE
Revert "Add larger `Karpenter/instance-size` options, remove smaller ones"

### DIFF
--- a/flux/karpenter-config/provisioner.yaml
+++ b/flux/karpenter-config/provisioner.yaml
@@ -18,7 +18,7 @@ spec:
   # Exclude small instance sizes
   - key: karpenter.k8s.aws/instance-size
     operator: In
-    values: [xlarge, 2xlarge, 4xlarge, 8xlarge, 12xlarge, 16xlarge]
+    values: [medium, large, xlarge, xlarge, 2xlarge, 4xlarge, 8xlarge]
   - key: kubernetes.io/arch
     operator: In
     values:


### PR DESCRIPTION
Reverts aws-controllers-k8s/test-infra#629