### PR TITLE
fix: acktest bootstrapping tgw delete_resource parameter

### DIFF
--- a/src/acktest/bootstrapping/vpc.py
+++ b/src/acktest/bootstrapping/vpc.py
@@ -34,7 +34,7 @@ class TransitGateway(Bootstrappable):
         """
         super().cleanup()
         
-        self.ec2_client.delete_transit_gateway(TransitGatewayAttachmentId=self.transit_gateway_id)
+        self.ec2_client.delete_transit_gateway(TransitGatewayId=self.transit_gateway_id)
 
 @dataclass
 class InternetGateway(Bootstrappable):


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
