### PR TITLE
Update OWNERS_ALIASES to include knottnt

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -7,6 +7,7 @@ aliases:
     - michaelhtm
     - TiberiuGC
     - rushmash91
+    - knottnt
   # emeritus-core-ack-team:
   #   - jaypipes
   #   - jljaco


### PR DESCRIPTION
Description of changes:
Update OWNER_ALIASES core-ack-team to include knottnt GitHub user.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
