### PR TITLE
Bump boto3 version to 1.38.15

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-boto3==1.37.38
+boto3==1.38.15
 kubernetes==28.1.0
 PyYAML==6.0.1
 pytest-xdist==3.5.0


### PR DESCRIPTION
Issue #2479, if available: https://github.com/aws-controllers-k8s/community/issues/2479

Description of changes:
Bumping boto3 version to add more test cases for keyspaces-controller.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
