### PR TITLE
Upgrade Python Docker images to 3.11

### DIFF
--- a/scripts/Dockerfile.pytest-image
+++ b/scripts/Dockerfile.pytest-image
@@ -1,4 +1,4 @@
-FROM python:3.8-alpine
+FROM python:3.12-alpine
 
 # Persist build arguments into environment variables
 ARG AWS_SERVICE

--- a/scripts/Dockerfile.pytest-image
+++ b/scripts/Dockerfile.pytest-image
@@ -1,4 +1,4 @@
-FROM python:3.12-alpine
+FROM python:3.11-alpine
 
 # Persist build arguments into environment variables
 ARG AWS_SERVICE

--- a/soak/Dockerfile
+++ b/soak/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/library/python:3.8-alpine
+FROM docker.io/library/python:3.12-alpine
 
 # Persist build arguments into environment variables
 ARG AWS_SERVICE

--- a/soak/Dockerfile
+++ b/soak/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/library/python:3.12-alpine
+FROM docker.io/library/python:3.11-alpine
 
 # Persist build arguments into environment variables
 ARG AWS_SERVICE


### PR DESCRIPTION
Description of changes:
- Upgrade Dockerfile.pytest-image to 3.11
- Upgrade soak Dockerfile to python 3.11

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
