### PR TITLE
Apply Github CLI workaround

### DIFF
--- a/cd/lib/gh.sh
+++ b/cd/lib/gh.sh
@@ -93,7 +93,7 @@ open_pull_request() {
 
   if [[ -z $__pr_number ]]; then
     echo -n "gh.sh][INFO] No Existing PRs found. Creating a new pull request for $__org_repo , from $__source_branch -> $__target_branch branch... "
-    if ! gh pr create -R "$__org_repo" -t "$__commit_msg" -F "$__pr_body_file_path" -B "$__target_branch" $__label_arg >/dev/null ; then
+    if ! gh pr create -R "$__org_repo" -t "$__commit_msg" -F "$__pr_body_file_path" -B "$__target_branch" $__label_arg --head $(git branch --show-current) >/dev/null ; then
       echo ""
       echo "gh.sh][ERROR] Failed to create pull request. Exiting... "
       return 1

--- a/prow/jobs/images/Dockerfile.auto-generate-controllers
+++ b/prow/jobs/images/Dockerfile.auto-generate-controllers
@@ -1,4 +1,4 @@
-FROM debian:buster-slim AS base
+FROM debian:bookworm-slim AS base
 
 ARG GOPROXY=https://proxy.golang.org|direct
 ENV GOPROXY=${GOPROXY}

--- a/prow/jobs/images/Dockerfile.auto-update-controllers
+++ b/prow/jobs/images/Dockerfile.auto-update-controllers
@@ -1,4 +1,4 @@
-FROM debian:buster-slim AS base
+FROM debian:bookworm-slim AS base
 
 ARG GOPROXY=https://proxy.golang.org|direct
 ENV GOPROXY=${GOPROXY}

--- a/prow/jobs/images/Dockerfile.controller-release-tag
+++ b/prow/jobs/images/Dockerfile.controller-release-tag
@@ -1,4 +1,4 @@
-FROM debian:buster-slim AS base
+FROM debian:bookworm-slim AS base
 
 RUN echo "Installing packages ..." \
     && apt-get update \

--- a/prow/jobs/images/Dockerfile.integration-test
+++ b/prow/jobs/images/Dockerfile.integration-test
@@ -1,5 +1,5 @@
 # Dockerfile for integration testing
-FROM debian:buster-slim
+FROM debian:bookworm-slim
 
 ARG GOPROXY=https://proxy.golang.org|direct
 ENV GOPROXY=${GOPROXY}

--- a/prow/jobs/images/Dockerfile.olm-bundle-pr
+++ b/prow/jobs/images/Dockerfile.olm-bundle-pr
@@ -1,4 +1,4 @@
-FROM debian:buster-slim AS base
+FROM debian:bookworm-slim AS base
 
 ARG GOPROXY=https://proxy.golang.org|direct
 ENV GOPROXY=${GOPROXY}

--- a/prow/jobs/images/Dockerfile.olm-test
+++ b/prow/jobs/images/Dockerfile.olm-test
@@ -1,4 +1,4 @@
-FROM debian:buster-slim AS base
+FROM debian:bookworm-slim AS base
 
 ARG GOPROXY=https://proxy.golang.org|direct
 ENV GOPROXY=${GOPROXY}

--- a/prow/jobs/images/Dockerfile.unit-test
+++ b/prow/jobs/images/Dockerfile.unit-test
@@ -1,5 +1,5 @@
 # Common Dockerfile for unit and integration test
-FROM debian:buster-slim
+FROM debian:bookworm-slim
 
 ARG GOPROXY=https://proxy.golang.org|direct
 ENV GOPROXY=${GOPROXY}

--- a/prow/jobs/images/Dockerfile.verify-attribution
+++ b/prow/jobs/images/Dockerfile.verify-attribution
@@ -13,7 +13,7 @@ RUN git clone https://github.com/awslabs/attribution-gen .
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o attribution-gen ./main.go
 
 # Start a new stage from scratch
-FROM debian:buster-slim
+FROM debian:bookworm-slim
 
 RUN apt-get update && apt-get install -y ca-certificates
 


### PR DESCRIPTION
Description of changes:
- Apply Github CLI workaround described in the issue.
- Upgrade debian base images to get latest Git version with support for `--show-current`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
