### PR TITLE
Add bedrockagent to exceptional service names

### DIFF
--- a/tools/ackdiscover/controller.py
+++ b/tools/ackdiscover/controller.py
@@ -50,6 +50,9 @@ exceptional_service_names = {
     "acm-pca": {
         "controller_name": "acmpca",
     },
+    "agentsforamazonbedrock": {
+        "controller_name": "bedrockagent"
+    }
 }
 
 @dataclasses.dataclass


### PR DESCRIPTION
Issue #, if available: 2501

Description of changes:
- Map aws-sdk-go "agentsforamazonbedrock" to "bedrockagent" controller name.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
