### PR TITLE
Bump image versions of Prow jobs with Debian image updates.

### DIFF
--- a/prow/jobs/images_config.yaml
+++ b/prow/jobs/images_config.yaml
@@ -1,16 +1,16 @@
 image_repo: public.ecr.aws/m5q3e4b2/prow
 images:
-    auto-generate-controllers: prow-auto-generate-controllers-0.0.25
-    auto-update-controllers: prow-auto-update-controllers-0.0.17
+    auto-generate-controllers: prow-auto-generate-controllers-0.0.27
+    auto-update-controllers: prow-auto-update-controllers-0.0.18
     build-prow-images: prow-build-prow-images-0.0.48
-    controller-release-tag: prow-controller-release-tag-0.0.15
+    controller-release-tag: prow-controller-release-tag-0.0.16
     deploy: prow-deploy-0.0.29
     docs: prow-docs-0.0.23
-    integration-test: prow-integration-0.0.36
-    olm-bundle-pr: prow-olm-bundle-pr-0.0.18
-    olm-test: prow-olm-test-0.0.17
+    integration-test: prow-integration-0.0.37
+    olm-bundle-pr: prow-olm-bundle-pr-0.0.19
+    olm-test: prow-olm-test-0.0.18
     scan-controllers-cve: prow-scan-controllers-cve-0.0.12
     soak-test: prow-soak-0.0.17
-    unit-test: prow-unit-0.0.19
+    unit-test: prow-unit-0.0.20
     upgrade-go-version: prow-upgrade-go-version-0.0.18
-    verify-attribution: prow-verify-attribution-0.0.16
+    verify-attribution: prow-verify-attribution-0.0.17


### PR DESCRIPTION
Issue #, if available:

Description of changes:
- Bump `prow-auto-generate-controllers` to version `0.0.27`
- Bump `prow-auto-update-controllers` to version `0.0.18`
- Bump `prow-controller-release-tag` to version `0.0.16`
- Bump `prow-integration` to version `0.0.37`
- Bump `prow-olm-bundle-pr` to version `0.0.19`
- Bump `prow-olm-test` to version `0.0.18`
- Bump `prow-unit-test` to version `0.0.20`
- Bump `prow-verify-attribution` to version `0.0.17`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
