### PR TITLE
Allow more than three args for open_pull_request

### DIFF
--- a/cd/lib/gh.sh
+++ b/cd/lib/gh.sh
@@ -69,7 +69,7 @@ open_gh_issue() {
 # Environment variables PR_SOURCE_BRANCH and PR_TARGET_BRANCH can be used to set
 # source and target GitHub branches for PR. Default value for both is 'main'
 open_pull_request() {
-  if [[ $# -ne 3 ]]; then
+  if [[ $# -lt 3 ]]; then
     echo "gh.sh][ERROR] open_pull_request requires three arguments, 'ORG_REPO', 'COMMIT_MSG' and 'PR_BODY_FILE_PATH'. But $# arguments were passed"
     return 1
   fi


### PR DESCRIPTION
Issue #, if available:

Description of changes:
- check for less than instead of not equal to in gh.sh open_pull_request

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
