### PR TITLE
Move configure_logging to utils

### DIFF
--- a/experimental/agents/ack_builder_agent/__main__.py
+++ b/experimental/agents/ack_builder_agent/__main__.py
@@ -11,12 +11,9 @@
 """Main entry point for the ACK agent CLI."""
 
 import argparse
-import logging
-import warnings
 
 from rich.console import Console
 from rich.panel import Panel
-from strands import Agent
 
 from ack_builder_agent.prompts import ACK_BUILDER_SYSTEM_PROMPT
 from ack_builder_agent.tools import (
@@ -33,25 +30,9 @@ from config.defaults import (
 )
 from utils.bedrock import create_enhanced_agent
 from utils.formatting import pretty_markdown
+from utils.logging import configure_logging
 
 console = Console()
-
-
-def configure_logging(debug=False):
-    """Configure logging for the application.
-
-    Args:
-        debug: Whether to enable debug logging
-    """
-    log_level = logging.DEBUG if debug else logging.INFO
-    logging.basicConfig(level=log_level, format="%(levelname)s | %(name)s | %(message)s")
-
-    # Always enable Strands debug logs if debug is enabled
-    if debug:
-        logging.getLogger("strands").setLevel(logging.DEBUG)
-
-    # Suppress deprecation warnings from botocore about datetime.utcnow()
-    warnings.filterwarnings("ignore", category=DeprecationWarning, module="botocore")
 
 
 def run_agent_cli():

--- a/experimental/agents/ack_generator_agent/__main__.py
+++ b/experimental/agents/ack_generator_agent/__main__.py
@@ -11,12 +11,9 @@
 """Main entry point for the ACK Generator agent CLI."""
 
 import argparse
-import logging
-import warnings
 
 from rich.console import Console
 from rich.panel import Panel
-from strands import Agent
 
 from ack_generator_agent.prompts import ACK_GENERATOR_SYSTEM_PROMPT
 from ack_generator_agent.tools import (
@@ -40,25 +37,9 @@ from config.defaults import (
 )
 from utils.bedrock import create_enhanced_agent
 from utils.formatting import pretty_markdown
+from utils.logging import configure_logging
 
 console = Console()
-
-
-def configure_logging(debug=False):
-    """Configure logging for the application.
-
-    Args:
-        debug: Whether to enable debug logging
-    """
-    log_level = logging.DEBUG if debug else logging.INFO
-    logging.basicConfig(level=log_level, format="%(levelname)s | %(name)s | %(message)s")
-
-    # Always enable Strands debug logs if debug is enabled
-    if debug:
-        logging.getLogger("strands").setLevel(logging.DEBUG)
-
-    # Suppress deprecation warnings from botocore about datetime.utcnow()
-    warnings.filterwarnings("ignore", category=DeprecationWarning, module="botocore")
 
 
 def run_agent_cli():

--- a/experimental/agents/ack_model_agent/__main__.py
+++ b/experimental/agents/ack_model_agent/__main__.py
@@ -11,12 +11,9 @@
 """Main entry point for the ACK Model agent CLI."""
 
 import argparse
-import logging
-import warnings
 
 from rich.console import Console
 from rich.panel import Panel
-from strands import Agent
 
 from ack_model_agent.prompt import ACK_MODEL_AGENT_SYSTEM_PROMPT
 from ack_model_agent.tools import (
@@ -35,25 +32,9 @@ from config.defaults import (
 )
 from utils.bedrock import create_enhanced_agent
 from utils.formatting import pretty_markdown
+from utils.logging import configure_logging
 
 console = Console()
-
-
-def configure_logging(debug=False):
-    """Configure logging for the application.
-
-    Args:
-        debug: Whether to enable debug logging
-    """
-    log_level = logging.DEBUG if debug else logging.INFO
-    logging.basicConfig(level=log_level, format="%(levelname)s | %(name)s | %(message)s")
-
-    # Always enable Strands debug logs if debug is enabled
-    if debug:
-        logging.getLogger("strands").setLevel(logging.DEBUG)
-
-    # Suppress deprecation warnings from botocore about datetime.utcnow()
-    warnings.filterwarnings("ignore", category=DeprecationWarning, module="botocore")
 
 
 def run_agent_cli():

--- a/experimental/agents/utils/logging.py
+++ b/experimental/agents/utils/logging.py
@@ -1,0 +1,30 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+# with the License. A copy of the License is located at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# or in the 'license' file accompanying this file. This file is distributed on an 'AS IS' BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions
+# and limitations under the License.
+"""Utilities for setting up Agent logging."""
+
+import logging
+import warnings
+
+def configure_logging(debug=False):
+    """Configure logging for the application.
+
+    Args:
+        debug: Whether to enable debug logging
+    """
+    log_level = logging.DEBUG if debug else logging.INFO
+    logging.basicConfig(level=log_level, format="%(levelname)s | %(name)s | %(message)s")
+
+    # Always enable Strands debug logs if debug is enabled
+    if debug:
+        logging.getLogger("strands").setLevel(logging.DEBUG)
+
+    # Suppress deprecation warnings from botocore about datetime.utcnow()
+    warnings.filterwarnings("ignore", category=DeprecationWarning, module="botocore")


### PR DESCRIPTION
Issue #, if available:

Description of changes:
- Add configure_logging to utils/logging.py
- Update agents to use configure_logging utility

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
