### PR TITLE
Fix olm-bundle-pr job failing when ci.yaml missing

### DIFF
--- a/cd/olm/olm-bundle-pr.sh
+++ b/cd/olm/olm-bundle-pr.sh
@@ -164,8 +164,12 @@ do
     yq -i '.updateGraph="semver-mode"' ci.yaml
     yq -i '.reviewers[0]="ack-bot"' ci.yaml
     echo "" >> ci.yaml
+
+    # Return to original working directory
+    cd "$WORKSPACE_DIR/$OH_REPO"
   fi
 
+  echo "olm-bundle-pr.sh][INFO] Creating $PWD/operators/ack-$CONTROLLER_NAME/$OLM_BUNDLE_VERSION"
   mkdir -p "operators/ack-$CONTROLLER_NAME/$OLM_BUNDLE_VERSION"
   cd "$WORKSPACE_DIR/$OH_REPO/operators/ack-$CONTROLLER_NAME/$OLM_BUNDLE_VERSION"
   cp -R "$WORKSPACE_DIR/$CONTROLLER_NAME/olm/bundle/manifests" . >/dev/null


### PR DESCRIPTION
Issue #, if available:

Description of changes:
- Return to OH_REPO directory after creating the missing ci.yaml file.
- Add logging for creation of the $OLM_BUNDLE_VERSION directory

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
