### PR TITLE
Add jobs-config ConfigMap for configured aws services

### DIFF
--- a/prow/jobs/kustomization.yaml
+++ b/prow/jobs/kustomization.yaml
@@ -21,3 +21,8 @@ configMapGenerator:
   behavior: create
   files:
   - labels.yaml
+- name: jobs-config
+  namespace: test-pods
+  behavior: create
+  files:
+  - jobs_config.yaml


### PR DESCRIPTION
Issue #, if available:

Description of changes:
- Publish jobs_config.yaml as a Configmap

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
