### PR TITLE
Update controller-gen version to v0.19.0

### DIFF
--- a/prow/jobs/images/Dockerfile.integration-test
+++ b/prow/jobs/images/Dockerfile.integration-test
@@ -48,8 +48,8 @@ RUN curl -fsSL https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip -o awscl
     && aws/install \
     && export AWS_PAGER=""
 
-RUN echo "Installing controller-gen v0.16.2..." \
-    && go install "sigs.k8s.io/controller-tools/cmd/controller-gen@v0.16.2" \
+RUN echo "Installing controller-gen v0.19.0..." \
+    && go install "sigs.k8s.io/controller-tools/cmd/controller-gen@v0.19.0" \
     && mv $GOPATH/bin/controller-gen /usr/bin/controller-gen
 
 RUN echo "Installing Kustomize ..." \

--- a/prow/jobs/images/Dockerfile.olm-bundle-pr
+++ b/prow/jobs/images/Dockerfile.olm-bundle-pr
@@ -61,10 +61,10 @@ RUN echo "Installing Kustomize v4.1.2 ..." \
     && tar xzf "${KUSTOMIZE_TARBALL}" -C /usr/bin \
     && rm "${KUSTOMIZE_TARBALL}"
 
-RUN echo "Installing controller-gen v0.16.2 ..." \
+RUN echo "Installing controller-gen v0.19.0 ..." \
     && cd $(mktemp -d /tmp/controller-gen-XXX) \
     && go mod init tmp \
-    && go get -d "sigs.k8s.io/controller-tools/cmd/controller-gen@v0.16.2" \
+    && go get -d "sigs.k8s.io/controller-tools/cmd/controller-gen@v0.19.0" \
     && go build -o "/usr/local/bin/controller-gen" sigs.k8s.io/controller-tools/cmd/controller-gen
 
 RUN echo "Installing yq ... " \

--- a/prow/jobs/images_config.yaml
+++ b/prow/jobs/images_config.yaml
@@ -1,16 +1,16 @@
 image_repo: public.ecr.aws/m5q3e4b2/prow
 images:
-    auto-generate-controllers: prow-auto-generate-controllers-0.0.32
-    auto-update-controllers: prow-auto-update-controllers-0.0.23
-    build-prow-images: prow-build-prow-images-0.0.55
-    controller-release-tag: prow-controller-release-tag-0.0.21
-    deploy: prow-deploy-0.0.34
-    docs: prow-docs-0.0.28
-    integration-test: prow-integration-0.0.42
-    olm-bundle-pr: prow-olm-bundle-pr-0.0.24
-    olm-test: prow-olm-test-0.0.23
-    scan-controllers-cve: prow-scan-controllers-cve-0.0.17
-    soak-test: prow-soak-0.0.22
-    unit-test: prow-unit-0.0.25
-    upgrade-go-version: prow-upgrade-go-version-0.0.23
-    verify-attribution: prow-verify-attribution-0.0.22
+    auto-generate-controllers: prow-auto-generate-controllers-0.0.31
+    auto-update-controllers: prow-auto-update-controllers-0.0.22
+    build-prow-images: prow-build-prow-images-0.0.54
+    controller-release-tag: prow-controller-release-tag-0.0.20
+    deploy: prow-deploy-0.0.33
+    docs: prow-docs-0.0.27
+    integration-test: prow-integration-0.0.41
+    olm-bundle-pr: prow-olm-bundle-pr-0.0.23
+    olm-test: prow-olm-test-0.0.22
+    scan-controllers-cve: prow-scan-controllers-cve-0.0.16
+    soak-test: prow-soak-0.0.21
+    unit-test: prow-unit-0.0.24
+    upgrade-go-version: prow-upgrade-go-version-0.0.22
+    verify-attribution: prow-verify-attribution-0.0.21


### PR DESCRIPTION
Issue #, if available:

Description of changes:
- Upgrade controller-gen in Dockerfile.olm-bundle-pr
- Upgrade controller-gen in Dockerfile.integration-test
- decrement prow job image tags by one (two failed Go version updates occurred. This effectively increments the tags in ECR by one)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
