### PR TITLE
Add environment variable for path to jobs_config.yaml for add-resource workflow

### DIFF
--- a/prow/agent-workflows/agents/workflows/ack_resource_workflow.py
+++ b/prow/agent-workflows/agents/workflows/ack_resource_workflow.py
@@ -75,8 +75,13 @@ class ACKResourceWorkflow:
     def _load_supported_services(self) -> List[str]:
         """Load the list of supported AWS services from jobs_config.yaml."""
         try:
-            # Go up to test-infra root, then to prow/jobs/jobs_config.yaml
-            config_path = Path(__file__).parent.parent.parent.parent / "jobs" / "jobs_config.yaml"
+            # Use JOBS_CONFIG_PATH env var if set (e.g. in ProwJob), otherwise
+            # fall back to the relative path from the source tree.
+            env_path = os.environ.get("JOBS_CONFIG_PATH")
+            if env_path:
+                config_path = Path(env_path)
+            else:
+                config_path = Path(__file__).parent.parent.parent.parent / "jobs" / "jobs_config.yaml"
             
             with open(config_path, 'r') as f:
                 config = yaml.safe_load(f)

--- a/prow/agent-workflows/images_config.yaml
+++ b/prow/agent-workflows/images_config.yaml
@@ -1,3 +1,3 @@
 image_repo: public.ecr.aws/m5q3e4b2/prow
 images:
-    add-resource: add-resource-0.0.4
+    add-resource: add-resource-0.0.5

--- a/prow/agent-workflows/templates/add-resource.tpl
+++ b/prow/agent-workflows/templates/add-resource.tpl
@@ -8,6 +8,7 @@
             GITHUB_ORG: aws-controllers-k8s
             GITHUB_EMAIL_PREFIX: "82905295"
             GITHUB_ACTOR: ack-bot
+            JOBS_CONFIG_PATH: "/prow/jobs/jobs_config.yaml"
         environmentFromSecrets:
             GITHUB_TOKEN:
                 name: prowjob-github-pat-token


### PR DESCRIPTION
Issue #, if available:

Description of changes:
Fix issue resolving path for jobs_config.yaml when validating `--service` flag value.

- Update ack_resource_workflow.py to first pull path to jobs_config.yaml from environment variable. Falls back to relative test-infra path when not set.
- Add env var to workflow template
- Bump image version for add-resource workflow

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
