### PR TITLE
Fix KIND cluster creation for Kubernetes v1.30+

### DIFF
--- a/scripts/kind-configurations/kind-two-node-cluster.yaml
+++ b/scripts/kind-configurations/kind-two-node-cluster.yaml
@@ -1,6 +1,17 @@
 kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
+containerdConfigPatches:
+  - |-
+    [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc.options]
+      SystemdCgroup = false
 nodes:
   - role: control-plane
+    kubeadmConfigPatches:
+    - |
+      kind: KubeletConfiguration
+      cgroupDriver: cgroupfs
   - role: worker
-    
+    kubeadmConfigPatches:
+    - |
+      kind: KubeletConfiguration
+      cgroupDriver: cgroupfs


### PR DESCRIPTION
Description of changes:
Kubernetes 1.29+ defaults the kubelet cgroup driver to systemd,
which fails on cgroupv1 hosts running Docker-in-Docker. Configure
both containerd and kubelet to use the cgroupfs driver explicitly
in the KIND cluster configuration.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
