### PR TITLE
Add MWAA bootstrapping helpers

### DIFF
--- a/src/acktest/bootstrapping/iam.py
+++ b/src/acktest/bootstrapping/iam.py
@@ -63,6 +63,7 @@ class Role(Bootstrappable):
     principal_service: str
     description: str = ""
     managed_policies: List[str] = field(default_factory=lambda: [])
+    additional_service_principals: List[str] = field(default_factory=lambda: [])
 
     # Subresources
     user_policies: UserPolicies = field(default=None)
@@ -78,6 +79,18 @@ class Role(Bootstrappable):
     def iam_client(self):
         return boto3.client("iam", region_name=self.region)
 
+    def _trust_policy_services(self):
+        """Returns the list of service principals for the trust policy.
+
+        When `additional_service_principals` is empty the IAM `Service` value
+        is emitted as a single string (preserving the wire format used by
+        single-principal roles); when it is non-empty the combined list is
+        emitted so IAM accepts it as a multi-principal trust.
+        """
+        if not self.additional_service_principals:
+            return self.principal_service
+        return [self.principal_service, *self.additional_service_principals]
+
     def bootstrap(self):
         """Creates an IAM role with an auto-generated name.
         """
@@ -91,7 +104,7 @@ class Role(Bootstrappable):
                     "Statement": [
                         {
                             "Effect": "Allow",
-                            "Principal": {"Service": self.principal_service},
+                            "Principal": {"Service": self._trust_policy_services()},
                             "Action": ["sts:AssumeRole", "sts:TagSession"],
                         }
                     ],

--- a/src/acktest/bootstrapping/s3.py
+++ b/src/acktest/bootstrapping/s3.py
@@ -2,6 +2,7 @@ import boto3
 import logging
 
 from dataclasses import dataclass, field
+from typing import List
 
 from . import Bootstrappable
 from .. import resources
@@ -13,6 +14,9 @@ class Bucket(Bootstrappable):
     enable_versioning: bool = False
     policy: str = ""
     policy_vars: dict = field(default_factory=dict)
+    # Optional list of object keys to pre-create as zero-byte objects
+    # after the bucket is created.
+    empty_objects: List[str] = field(default_factory=list)
 
     # Outputs
     name: str = field(init=False)
@@ -61,9 +65,37 @@ class Bucket(Bootstrappable):
                 Policy=self.policy,
             )
 
+        for key in self.empty_objects:
+            self.s3_client.put_object(Bucket=self.name, Key=key, Body=b"")
+            logging.info(f"Created empty object s3://{self.name}/{key}")
+
     def cleanup(self):
-        """Deletes an S3 bucket.
+        """Deletes an S3 bucket and its contents.
+
+        When versioning is enabled, `bucket.objects.all().delete()` only
+        removes the current versions; non-current versions and delete
+        markers are left behind and `DeleteBucket` then fails with
+        `BucketNotEmpty`. Purge every version and delete marker before
+        deleting the bucket so cleanup works for both versioned and
+        non-versioned buckets.
         """
         bucket = self.s3_resource.Bucket(self.name)
-        bucket.objects.all().delete()
+        if self.enable_versioning:
+            paginator = self.s3_client.get_paginator("list_object_versions")
+            for page in paginator.paginate(Bucket=self.name):
+                to_delete = []
+                for v in page.get("Versions", []) or []:
+                    to_delete.append({"Key": v["Key"], "VersionId": v["VersionId"]})
+                for m in page.get("DeleteMarkers", []) or []:
+                    to_delete.append({"Key": m["Key"], "VersionId": m["VersionId"]})
+                # `delete_objects` accepts up to 1000 keys per call; a single
+                # page is already capped at that, so one call per page is
+                # sufficient.
+                if to_delete:
+                    self.s3_client.delete_objects(
+                        Bucket=self.name,
+                        Delete={"Objects": to_delete, "Quiet": True},
+                    )
+        else:
+            bucket.objects.all().delete()
         bucket.delete()

--- a/src/acktest/bootstrapping/vpc.py
+++ b/src/acktest/bootstrapping/vpc.py
@@ -1,5 +1,6 @@
 from typing import List, Union
 import boto3
+import logging
 
 from dataclasses import dataclass, field
 
@@ -28,12 +29,12 @@ class TransitGateway(Bootstrappable):
         """
         transit_gateway = self.ec2_client.create_transit_gateway()
         self.transit_gateway_id = transit_gateway['TransitGateway']['TransitGatewayId']
-    
+
     def cleanup(self):
         """Deletes a transit gateway.
         """
         super().cleanup()
-        
+
         self.ec2_client.delete_transit_gateway(TransitGatewayId=self.transit_gateway_id)
 
 @dataclass
@@ -111,7 +112,7 @@ class RouteTable(Bootstrappable):
         """Deletes a route table.
         """
         super().cleanup()
-        
+
         self.ec2_client.delete_route_table(RouteTableId=self.route_table_id)
 
 @dataclass
@@ -171,13 +172,18 @@ class Subnets(Bootstrappable):
     def get_availability_zone_names(self):
         zones = self.ec2_client.describe_availability_zones()
         return list(map(lambda x: x['ZoneName'], zones['AvailabilityZones']))
-    
+
 @dataclass
 class SecurityGroup(Bootstrappable):
     # Inputs
     vpc_id: str
     name_prefix: str = "test"
     description: str = ""
+    # When True, a self-referencing inbound rule (source = this SG) is added
+    # after the group is created.
+    self_referencing_ingress: bool = False
+    # IP protocol used when `self_referencing_ingress` is True.
+    self_referencing_ingress_protocol: str = "-1"
 
     # Outputs
     group_id: str = field(init=False)
@@ -186,7 +192,7 @@ class SecurityGroup(Bootstrappable):
     def __post_init__(self):
         self.name = resources.random_suffix_name(self.name_prefix, 24)
         self.description = resources.random_suffix_name("description-", 34)
-    
+
     @property
     def ec2_client(self):
         return boto3.client("ec2", region_name=self.region)
@@ -205,6 +211,32 @@ class SecurityGroup(Bootstrappable):
         )
         self.group_id = group.id
         self.arn = "arn:aws:ec2:{region}:{accId}:security-group/{sgId}".format(region=self.region, accId=self.account_id, sgId=self.group_id)
+
+        if self.self_referencing_ingress:
+            self._authorize_self_referencing_ingress()
+
+    def _authorize_self_referencing_ingress(self):
+        """Authorizes ingress from this security group to itself.
+
+        Tolerates `InvalidPermission.Duplicate` so the call is idempotent if
+        the rule is already present (e.g. the SG is being reused across
+        bootstrap attempts).
+        """
+        try:
+            self.ec2_client.authorize_security_group_ingress(
+                GroupId=self.group_id,
+                IpPermissions=[{
+                    "IpProtocol": self.self_referencing_ingress_protocol,
+                    "UserIdGroupPairs": [{"GroupId": self.group_id}],
+                }],
+            )
+        except self.ec2_client.exceptions.ClientError as e:
+            if "InvalidPermission.Duplicate" not in str(e):
+                raise
+            logging.info(
+                f"Self-referencing ingress already present on "
+                f"{self.group_id}; continuing"
+            )
 
     def cleanup(self):
         """Deletes the subnets.
@@ -225,6 +257,9 @@ class VPC(Bootstrappable):
     vpc_cidr_block: str = field(default=VPC_CIDR_BLOCK)
     public_subnet_cidr_blocks: Union[List[str], None] = field(default=None)
     private_subnet_cidr_blocks: Union[List[str], None] = field(default=None)
+    # Propagated to the auto-created `security_group`. When True, the VPC's
+    # default security group is created with a self-referencing inbound rule.
+    security_group_self_referencing_ingress: bool = False
 
     # Subresources
     public_subnets: Subnets = field(init=False, default=None)
@@ -267,10 +302,13 @@ class VPC(Bootstrappable):
             self.ec2_client.create_tags(Resources=[self.vpc_id], Tags=[{'Key': 'Name', 'Value': self.name}])
 
         if self.num_private_subnet > 0:
-            self.private_subnets = Subnets(self.vpc_id, self.private_subnet_cidr_blocks, is_public=False, num_subnets=self.num_private_subnet)
+            self.private_subnets = Subnets(self.vpc_id, self.private_subnet_cidr_blocks, is_public=False, map_public_ip=False, num_subnets=self.num_private_subnet)
         if self.num_public_subnet > 0:
             self.public_subnets = Subnets(self.vpc_id, self.public_subnet_cidr_blocks, is_public=True, num_subnets=self.num_public_subnet)
-        self.security_group = SecurityGroup(vpc_id=self.vpc_id)
+        self.security_group = SecurityGroup(
+            vpc_id=self.vpc_id,
+            self_referencing_ingress=self.security_group_self_referencing_ingress,
+        )
 
         # Because we require the VPC to be generated before generating other
         # resources, if the subresources fail while bootstrapping, we need to


### PR DESCRIPTION
Issue #, if available: aws-controllers-k8s/community#2761

Description of changes: Adds opt-in parameters to existing `acktest.bootstrapping` primitives so [MWAA](https://github.com/aws-controllers-k8s/mwaa-controller/pull/3) e2e tests can bootstrap with the stock helpers. All defaults preserve existing behavior.

  - `iam.Role`: new `additional_service_principals: List[str]` for roles that need multiple trusted services (MWAA requires both `airflow.amazonaws.com` and `airflow-env.amazonaws.com`).
  - `s3.Bucket`:
    - new `empty_objects: List[str]` to pre-create zero-byte objects after the bucket is created (MWAA `CreateEnvironment` validates that the DAGs prefix exists).
    - `cleanup()` now purges all object versions and delete markers when `enable_versioning=True`, so teardown succeeds for versioned buckets instead of failing with `BucketNotEmpty`.
  - `vpc.SecurityGroup`: new `self_referencing_ingress: bool` that adds an idempotent self-referencing inbound rule (required for MWAA worker-to-worker traffic).


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
