### PR TITLE
Upgrade boto3

### DIFF
--- a/tools/requirements.txt
+++ b/tools/requirements.txt
@@ -1,4 +1,4 @@
-boto3==1.21.8
+boto3==1.43.7
 GitPython==3.1.50
 PyYAML==6.0.1
 PyGitHub==1.55


### PR DESCRIPTION
## Upgrade boto3 to 1.43.7 for EKS Pod Identity support

The new test-infra cluster uses EKS Pod Identity for IAM credentials. The previous `boto3==1.21.8` (March 2022) does not support Pod Identity's container credential endpoint at `169.254.170.23`, failing with:

```
Unsupported host '169.254.170.23'. Can only retrieve metadata from these hosts: 169.254.170.2, localhost, 127.0.0.1
```

Pod Identity support was added in boto3 ~1.34.x. Upgrading to 1.43.7 allows `acktools` (used by docs-release and deploy-docs jobs) to authenticate via Pod Identity when calling STS AssumeRole and ECR Public APIs.

Grabbed latest version from the following

```
curl -s https://pypi.org/pypi/boto3/json | python3 -c "import sys,json; print(json.load(sys.stdin)['info']['version'])"

1.43.7
```

**Testing:**
- Verified initupload/sidecar S3 uploads work with Pod Identity
