### PR TITLE
Bump all prow job image versions

### DIFF
--- a/prow/jobs/images_config.yaml
+++ b/prow/jobs/images_config.yaml
@@ -1,17 +1,17 @@
 image_repo: public.ecr.aws/m5q3e4b2/prow
 images:
-    auto-generate-controllers: prow-auto-generate-controllers-0.0.39
-    auto-update-controllers: prow-auto-update-controllers-0.0.30
-    build-prow-images: prow-build-prow-images-0.0.66
-    controller-release-tag: prow-controller-release-tag-0.0.30
-    deploy: prow-deploy-0.0.41
-    deploy-docs: prow-deploy-docs-0.0.10
-    docs: prow-docs-0.0.35
-    integration-test: prow-integration-0.0.52
-    olm-bundle-pr: prow-olm-bundle-pr-0.0.31
-    olm-test: prow-olm-test-0.0.30
-    scan-controllers-cve: prow-scan-controllers-cve-0.0.24
-    soak-test: prow-soak-0.0.29
-    unit-test: prow-unit-0.0.33
-    upgrade-go-version: prow-upgrade-go-version-0.0.31
-    verify-attribution: prow-verify-attribution-0.0.29
+    auto-generate-controllers: prow-auto-generate-controllers-0.0.40
+    auto-update-controllers: prow-auto-update-controllers-0.0.31
+    build-prow-images: prow-build-prow-images-0.0.67
+    controller-release-tag: prow-controller-release-tag-0.0.31
+    deploy: prow-deploy-0.0.42
+    deploy-docs: prow-deploy-docs-0.0.11
+    docs: prow-docs-0.0.36
+    integration-test: prow-integration-0.0.53
+    olm-bundle-pr: prow-olm-bundle-pr-0.0.32
+    olm-test: prow-olm-test-0.0.31
+    scan-controllers-cve: prow-scan-controllers-cve-0.0.25
+    soak-test: prow-soak-0.0.30
+    unit-test: prow-unit-0.0.34
+    upgrade-go-version: prow-upgrade-go-version-0.0.32
+    verify-attribution: prow-verify-attribution-0.0.30


### PR DESCRIPTION
Rebuild all prow job images with new tags to restore production images that were accidentally overwritten by a staging build.

All image patch versions bumped by 1:
- auto-generate-controllers: 0.0.39 → 0.0.40
- auto-update-controllers: 0.0.30 → 0.0.31
- build-prow-images: 0.0.66 → 0.0.67
- controller-release-tag: 0.0.30 → 0.0.31
- deploy: 0.0.41 → 0.0.42
- deploy-docs: 0.0.10 → 0.0.11
- docs: 0.0.35 → 0.0.36
- integration-test: 0.0.52 → 0.0.53
- olm-bundle-pr: 0.0.31 → 0.0.32
- olm-test: 0.0.30 → 0.0.31
- scan-controllers-cve: 0.0.24 → 0.0.25
- soak-test: 0.0.29 → 0.0.30
- unit-test: 0.0.33 → 0.0.34
- upgrade-go-version: 0.0.31 → 0.0.32
- verify-attribution: 0.0.29 → 0.0.30