### PR TITLE
fix: bump prow-config chart version to deploy #944 plugin changes

### DIFF
--- a/prow/config/Chart.yaml
+++ b/prow/config/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: prow-config
 description: Configuration for the ACK Prow cluster
 type: application
-version: 0.4.15
+version: 0.4.16
 appVersion: "1.16.0"


### PR DESCRIPTION
Description of changes:
Flux reconcileStrategy is ChartVersion, so the restricted_labels
config from #944 was never deployed.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
