### PR TITLE
fix: bump build-prow-images to 0.0.68

### DIFF
--- a/prow/jobs/images_config.yaml
+++ b/prow/jobs/images_config.yaml
@@ -2,7 +2,7 @@ image_repo: ${PROW_IMAGES_REPO_URI}
 images:
     auto-generate-controllers: prow-auto-generate-controllers-0.0.40
     auto-update-controllers: prow-auto-update-controllers-0.0.31
-    build-prow-images: prow-build-prow-images-0.0.67
+    build-prow-images: prow-build-prow-images-0.0.68
     controller-release-tag: prow-controller-release-tag-0.0.31
     deploy: prow-deploy-0.0.42
     deploy-docs: prow-deploy-docs-0.0.11


### PR DESCRIPTION
## Problem

The `build-prow-images` job is failing with:
```
Error: unknown flag: --base-branch
```

## Root Cause

Commit `a10d5ec` ("Flux v2 api upgrade merge #943") added the `--base-branch` flag to both `publish_pr.go` and `build-prow-images.sh`, but did not bump the image version. The running image (`0.0.67`) was built from older source code (commit `c8c2dc6`) that does not include the `--base-branch` flag in the compiled `ack-build-tools` binary.

When Prow runs the job, it uses the old image (old binary) but clones current source (new script that passes `--base-branch`), causing the flag mismatch.

## Fix

Bump `build-prow-images` version from `0.0.67` to `0.0.68` to trigger a rebuild of the image from the current source code, which includes the `--base-branch` flag in `ack-build-tools`.

## Testing

Once merged, the postsubmit `build-prow-images` job will rebuild all images (including itself) with the updated Go binary.