### PR TITLE
fix: install controller-gen when generating release

### DIFF
--- a/cd/auto-generate/controller-release-pr.sh
+++ b/cd/auto-generate/controller-release-pr.sh
@@ -127,6 +127,8 @@ if ! make build-ack-generate >/dev/null 2>&1; then
   exit 1
 fi
 
+./scripts/install-controller-gen.sh
+
 if ! ./scripts/build-controller-release.sh "$AWS_SERVICE"; then
   echo "controller-release-pr.sh][ERROR] build-controller-release.sh failed"
   exit 1


### PR DESCRIPTION
fixes: https://prow-v2.ack.aws.dev/view/s3/ack-test-infra-prod-prow-logs-453735116143/logs/rds-controller-release-pr/2061877420109074432

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
