### PR TITLE
fix: bump all prow job image versions to trigger rebuild

### DIFF
--- a/prow/jobs/images_config.yaml
+++ b/prow/jobs/images_config.yaml
@@ -1,17 +1,17 @@
 image_repo: ${PROW_IMAGES_REPO_URI}
 images:
-    auto-generate-controllers: prow-auto-generate-controllers-0.0.40
-    auto-update-controllers: prow-auto-update-controllers-0.0.31
+    auto-generate-controllers: prow-auto-generate-controllers-0.0.41
+    auto-update-controllers: prow-auto-update-controllers-0.0.32
     build-prow-images: prow-build-prow-images-0.0.68
-    controller-release-tag: prow-controller-release-tag-0.0.31
-    deploy: prow-deploy-0.0.42
-    deploy-docs: prow-deploy-docs-0.0.11
-    docs: prow-docs-0.0.36
-    integration-test: prow-integration-0.0.53
-    olm-bundle-pr: prow-olm-bundle-pr-0.0.32
-    olm-test: prow-olm-test-0.0.31
-    scan-controllers-cve: prow-scan-controllers-cve-0.0.25
-    soak-test: prow-soak-0.0.30
-    unit-test: prow-unit-0.0.34
-    upgrade-go-version: prow-upgrade-go-version-0.0.32
-    verify-attribution: prow-verify-attribution-0.0.30
+    controller-release-tag: prow-controller-release-tag-0.0.32
+    deploy: prow-deploy-0.0.43
+    deploy-docs: prow-deploy-docs-0.0.12
+    docs: prow-docs-0.0.37
+    integration-test: prow-integration-0.0.54
+    olm-bundle-pr: prow-olm-bundle-pr-0.0.33
+    olm-test: prow-olm-test-0.0.32
+    scan-controllers-cve: prow-scan-controllers-cve-0.0.26
+    soak-test: prow-soak-0.0.31
+    unit-test: prow-unit-0.0.35
+    upgrade-go-version: prow-upgrade-go-version-0.0.33
+    verify-attribution: prow-verify-attribution-0.0.31


### PR DESCRIPTION
Bumps all prow job image versions (except `build-prow-images` which was already bumped in #948) to trigger a full rebuild of all job images from the current source code.

This ensures all images pick up the latest changes from the Flux v2 migration merge.