### PR TITLE
fix: add max_prowjob_age and align sinker config with upstream

### DIFF
--- a/prow/config/templates/config-ConfigMap.yaml
+++ b/prow/config/templates/config-ConfigMap.yaml
@@ -25,9 +25,10 @@ data:
       # defaults to 1 hour
       resync_period: 2m
       # defaults to 1 day
-      max_pod_age: 12h
+      max_pod_age: 48h
       # defaults to max_pod_age
       terminated_pod_ttl: 5m
+      max_prowjob_age: 48h
 
     branch-protection:
       required_pull_request_reviews:


### PR DESCRIPTION
Description of changes:
Without max_prowjob_age, sinker only garbage-collects test pods but never
deletes completed ProwJob CRs. Over time they accumulate (624+ observed),
causing prow-controller-manager to hit client-side API throttling on
startup, starving leader lease renewal and crash-looping.

Aligns sinker configuration with upstream kubernetes/test-infra:
https://github.com/kubernetes/test-infra/blob/master/config/prow/config.yaml#L56

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
