### PR TITLE
fix: rotate test container credentials alongside controller

### DIFF
--- a/scripts/controller-setup.sh
+++ b/scripts/controller-setup.sh
@@ -192,6 +192,19 @@ rotate_temp_creds() {
 
     aws_generate_temp_creds
 
+    # Refresh the bind-mounted test container credentials (atomic rename)
+    local test_creds_file="$HOME/.aws/ack-test-credentials"
+    local profile_name="${TEST_AWS_PROFILE_NAME:-ack-test}"
+    if [[ -f "$test_creds_file" ]]; then
+        cat > "${test_creds_file}.tmp" <<EOF
+[$profile_name]
+aws_access_key_id=$AWS_ACCESS_KEY_ID
+aws_secret_access_key=$AWS_SECRET_ACCESS_KEY
+aws_session_token=$AWS_SESSION_TOKEN
+EOF
+        mv "${test_creds_file}.tmp" "$test_creds_file"
+    fi
+
     kubectl -n $__controller_namespace set env deployment/$__deployment_name \
         AWS_ACCESS_KEY_ID="$AWS_ACCESS_KEY_ID" \
         AWS_SECRET_ACCESS_KEY="$AWS_SECRET_ACCESS_KEY" \


### PR DESCRIPTION
Description of changes:
The credential rotation loop only refreshed the controller deployment's
env vars, leaving the test container's bind-mounted credential file
stale. For e2e runs exceeding 1 hour, cleanup fails with ExpiredToken.

https://prow.ack.aws.dev/view/s3/ack-test-infra-prod-prow-logs-453735116143/pr-logs/pull/aws-controllers-k8s_kafka-controller/100/kafka-kind-e2e/2062223383130542080

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
