### PR TITLE
chore(prow): upgrade to v20260602-e7f2be80c

### DIFF
--- a/flux/prow/version/prow-version-configmap.yaml
+++ b/flux/prow/version/prow-version-configmap.yaml
@@ -6,5 +6,5 @@ metadata:
   name: prow-version
   namespace: flux-system
 data:
-  PROW_VERSION: "v20260519-c47e31ece"
+  PROW_VERSION: "v20260602-e7f2be80c"
   TOOLS_VERSION: "v20260515-778139c32d"

--- a/prow/config/Chart.yaml
+++ b/prow/config/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: prow-config
 description: Configuration for the ACK Prow cluster
 type: application
-version: 0.4.16
+version: 0.4.17
 appVersion: "1.16.0"


### PR DESCRIPTION
Upgrades Prow from `v20260519-c47e31ece` to `v20260602-e7f2be80c`.

Changes:
- Updated `flux/prow/version/prow-version-configmap.yaml` with new PROW_VERSION
- Bumped prow-config chart version from 0.4.16 to 0.4.17
- Tools (label_sync, commenter) already at latest (`v20260515-778139c32d`)
- ProwJob CRD already up to date

After merge, Flux reconciles: the mirror job copies new images from upstream to ECR, then Prow pods redeploy with the new version.

Generated with:
```bash
./scripts/upgrade-prow.sh
```