### PR TITLE
fix: write rotated credentials in-place for Docker bind mounts

### DIFF
--- a/scripts/controller-setup.sh
+++ b/scripts/controller-setup.sh
@@ -192,17 +192,16 @@ rotate_temp_creds() {
 
     aws_generate_temp_creds
 
-    # Refresh the bind-mounted test container credentials (atomic rename)
+    # Refresh the bind-mounted test container credentials in-place.
     local test_creds_file="$HOME/.aws/ack-test-credentials"
     local profile_name="${TEST_AWS_PROFILE_NAME:-ack-test}"
     if [[ -f "$test_creds_file" ]]; then
-        cat > "${test_creds_file}.tmp" <<EOF
+        cat > "$test_creds_file" <<EOF
 [$profile_name]
 aws_access_key_id=$AWS_ACCESS_KEY_ID
 aws_secret_access_key=$AWS_SECRET_ACCESS_KEY
 aws_session_token=$AWS_SESSION_TOKEN
 EOF
-        mv "${test_creds_file}.tmp" "$test_creds_file"
     fi
 
     kubectl -n $__controller_namespace set env deployment/$__deployment_name \


### PR DESCRIPTION
Description of changes:
The atomic rename (mv) created a new inode at the file path, but Docker
bind mounts track the original inode. The test container continued
reading the stale (expired) credentials from the old inode, causing
ExpiredToken failures during cleanup for long-running e2e jobs.

Writing directly to the file updates the same inode that Docker mounted.
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
