### PR TITLE
Fix code-generator crd-compat-check missing Helm

### DIFF
--- a/cd/scripts/check-crd-compatibility-codegen.sh
+++ b/cd/scripts/check-crd-compatibility-codegen.sh
@@ -25,6 +25,7 @@ source "$TEST_INFRA_DIR/scripts/lib/logging.sh"
 
 check_is_installed git
 check_is_installed make
+check_is_installed helm
 
 if [ -z "$SERVICES" ]; then
     error_msg "SERVICES environment variable must be set"

--- a/prow/jobs/images/Dockerfile.unit-test
+++ b/prow/jobs/images/Dockerfile.unit-test
@@ -40,6 +40,12 @@ RUN echo "Installing Go ..." \
     && rm "${GO_TARBALL}"\
     && mkdir -p "${GOPATH}/bin"
 
+RUN echo "Installing Helm ... " \
+    && export HELM_TARBALL="helm.tar.gz" \
+    && curl -fsSL https://get.helm.sh/helm-v3.11.1-linux-amd64.tar.gz --output "${HELM_TARBALL}" \
+    && tar xzf "${HELM_TARBALL}" --strip-components 1 -C /usr/bin \
+    && rm "${HELM_TARBALL}"
+
 RUN curl -fsSL https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip -o awscliv2.zip \
     && unzip awscliv2.zip \
     && aws/install \

--- a/prow/jobs/images_config.yaml
+++ b/prow/jobs/images_config.yaml
@@ -12,6 +12,6 @@ images:
     olm-test: prow-olm-test-0.0.33
     scan-controllers-cve: prow-scan-controllers-cve-0.0.27
     soak-test: prow-soak-0.0.32
-    unit-test: prow-unit-0.0.36
+    unit-test: prow-unit-0.0.37
     upgrade-go-version: prow-upgrade-go-version-0.0.34
     verify-attribution: prow-verify-attribution-0.0.32

--- a/prow/jobs/templates/presubmits/code_generator_tests.tpl
+++ b/prow/jobs/templates/presubmits/code_generator_tests.tpl
@@ -102,7 +102,7 @@
         command: ["make", "build-controller"]
   - name: crd-compat-check
     decorate: true
-    optional: false
+    optional: true
     always_run: true
     annotations:
       # karpenter.sh/do-not-evict is deprecated: https://github.com/aws/karpenter-provider-aws/issues/5394


### PR DESCRIPTION
Issue #, if available:

Description of changes:
Fix failures in new crd-compat-check for code-generator due to missing Helm install when re-generating service controllers.
[Example failure](https://prow.ack.aws.dev/view/s3/ack-test-infra-prod-prow-logs-453735116143/pr-logs/pull/aws-controllers-k8s_code-generator/712/crd-compat-check/2063001320599588864)
- Add check_is_installed check for Helm to test script
- Update unit-test image to include Helm
- Make test optional

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
