### PR TITLE
fix: refresh rotated shared credentials in long e2e runs

### DIFF
--- a/src/acktest/__init__.py
+++ b/src/acktest/__init__.py
@@ -10,3 +10,19 @@
 # on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
+
+# Keep the default boto3 session in sync with credentials that the test
+# harness rotates on disk during long-running e2e suites. This is a guarded
+# no-op outside of that scenario (see acktest.aws.credentials for details).
+try:
+    from .aws.credentials import install_refreshing_shared_credentials
+
+    install_refreshing_shared_credentials()
+except Exception:  # pragma: no cover - never block test imports on this
+    import logging
+
+    logging.getLogger(__name__).warning(
+        "acktest: could not install rotating credential provider; "
+        "falling back to default boto3 credential behavior",
+        exc_info=True,
+    )

--- a/src/acktest/aws/credentials.py
+++ b/src/acktest/aws/credentials.py
@@ -1,0 +1,160 @@
+# Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may
+# not use this file except in compliance with the License. A copy of the
+# License is located at
+#
+#	 http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+"""Keeps the default boto3 session in sync with rotated shared credentials.
+
+Long-running e2e suites (e.g. SageMaker Studio) run for well over an hour. In
+Prow the test container is given *static* temporary credentials (a profile with
+``aws_access_key_id``/``aws_secret_access_key``/``aws_session_token``) that are
+only valid for one hour. The host rotates those credentials in place every 50
+minutes, but botocore reads a static-key profile exactly once and caches the
+result for the lifetime of the process, so the rotated values are never picked
+up. Once the original credentials expire the tests fail with
+``ExpiredTokenException``.
+
+``install_refreshing_shared_credentials`` swaps the cached credentials on the
+default boto3 session for a ``RefreshableCredentials`` instance that re-reads the
+shared credentials file periodically, so every ``boto3.client(...)`` created by
+the tests transparently follows the rotation.
+
+This is a no-op (and safe) when:
+  * the shared credentials file does not exist,
+  * the active profile is an assume-role / web-identity profile (botocore
+    already refreshes those), or
+  * the ``ACKTEST_DISABLE_CREDENTIAL_REFRESH`` environment variable is set.
+"""
+
+import configparser
+import datetime
+import logging
+import os
+import threading
+
+import boto3
+import botocore.session
+from botocore.credentials import RefreshableCredentials
+
+# How long, in seconds, each set of file-sourced credentials is considered
+# valid before we re-read the file. botocore refreshes ~15 minutes before this
+# expiry, which yields a re-read cadence of roughly (TTL - 900s). With the
+# default below that is every 5 minutes, comfortably faster than the 50-minute
+# host rotation and the 60-minute credential lifetime.
+_DEFAULT_REFRESH_TTL_SECONDS = 20 * 60
+
+_DISABLE_ENV_VAR = "ACKTEST_DISABLE_CREDENTIAL_REFRESH"
+
+# Guards against installing the provider more than once per process.
+_install_lock = threading.Lock()
+_installed = False
+
+
+def _shared_credentials_path() -> str:
+    return os.environ.get(
+        "AWS_SHARED_CREDENTIALS_FILE",
+        os.path.expanduser(os.path.join("~", ".aws", "credentials")),
+    )
+
+
+def _active_profile() -> str:
+    return os.environ.get(
+        "AWS_PROFILE", os.environ.get("AWS_DEFAULT_PROFILE", "default")
+    )
+
+
+def _read_static_profile(creds_file: str, profile: str) -> dict:
+    """Returns the static keys for ``profile`` or an empty dict if absent."""
+    parser = configparser.ConfigParser()
+    parser.read(creds_file)
+    if not parser.has_section(profile):
+        return {}
+    section = parser[profile]
+    if "aws_access_key_id" not in section or "aws_secret_access_key" not in section:
+        return {}
+    return {
+        "access_key": section["aws_access_key_id"],
+        "secret_key": section["aws_secret_access_key"],
+        "token": section.get("aws_session_token"),
+    }
+
+
+def install_refreshing_shared_credentials(
+    refresh_ttl_seconds: int = _DEFAULT_REFRESH_TTL_SECONDS,
+) -> bool:
+    """Make the default boto3 session re-read rotated shared credentials.
+
+    Returns ``True`` if the refreshing provider was installed, ``False`` if the
+    current environment does not need it (in which case the default boto3
+    behavior is left untouched).
+    """
+    global _installed
+
+    if os.environ.get(_DISABLE_ENV_VAR):
+        return False
+
+    with _install_lock:
+        if _installed:
+            return True
+
+        creds_file = _shared_credentials_path()
+        profile = _active_profile()
+
+        if not os.path.isfile(creds_file):
+            return False
+
+        initial = _read_static_profile(creds_file, profile)
+        if not initial:
+            # Either the profile is missing or it is an assume-role /
+            # web-identity profile, both of which botocore already refreshes.
+            return False
+
+        def _build_metadata() -> dict:
+            keys = _read_static_profile(creds_file, profile)
+            if not keys:
+                # A rotation may briefly truncate the file. Retry soon rather
+                # than crash so we pick up the new values on the next read.
+                raise RuntimeError(
+                    f"could not read static credentials for profile "
+                    f"'{profile}' from '{creds_file}'"
+                )
+            expiry = datetime.datetime.now(
+                datetime.timezone.utc
+            ) + datetime.timedelta(seconds=refresh_ttl_seconds)
+            keys["expiry_time"] = expiry.isoformat()
+            return keys
+
+        credentials = RefreshableCredentials.create_from_metadata(
+            metadata=_build_metadata(),
+            refresh_using=_build_metadata,
+            method="acktest-rotating-shared-credentials",
+        )
+
+        botocore_session = botocore.session.Session(profile=profile)
+        botocore_session._credentials = credentials
+
+        region = (
+            botocore_session.get_config_variable("region")
+            or os.environ.get("AWS_DEFAULT_REGION")
+            or os.environ.get("AWS_REGION")
+        )
+        boto3.setup_default_session(
+            botocore_session=botocore_session, region_name=region
+        )
+
+        _installed = True
+        logging.info(
+            "acktest: installed rotating credential provider for profile "
+            "'%s' (re-reading '%s' every ~%ds)",
+            profile,
+            creds_file,
+            refresh_ttl_seconds,
+        )
+        return True

--- a/test/aws/test_credentials.py
+++ b/test/aws/test_credentials.py
@@ -1,0 +1,110 @@
+# Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may
+# not use this file except in compliance with the License. A copy of the
+# License is located at
+#
+#	 http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+"""Unit tests for acktest.aws.credentials."""
+
+import configparser
+import time
+
+import boto3
+import pytest
+
+from acktest.aws import credentials
+
+
+def _write_static_profile(path, profile, token):
+    parser = configparser.ConfigParser()
+    parser[profile] = {
+        "aws_access_key_id": f"AK_{token}",
+        "aws_secret_access_key": f"SK_{token}",
+        "aws_session_token": token,
+    }
+    with open(path, "w") as f:
+        parser.write(f)
+
+
+def _write_assume_role_profile(path, profile):
+    parser = configparser.ConfigParser()
+    parser[profile] = {
+        "role_arn": "arn:aws:iam::000000000000:role/example",
+        "source_profile": "base",
+    }
+    with open(path, "w") as f:
+        parser.write(f)
+
+
+@pytest.fixture(autouse=True)
+def reset_state(monkeypatch):
+    """Reset the one-time install guard and default boto3 session per test."""
+    monkeypatch.setattr(credentials, "_installed", False)
+    monkeypatch.setattr(boto3, "DEFAULT_SESSION", None)
+    monkeypatch.delenv(credentials._DISABLE_ENV_VAR, raising=False)
+    monkeypatch.setenv("AWS_DEFAULT_REGION", "us-west-2")
+    yield
+
+
+def test_picks_up_rotated_static_credentials(tmp_path, monkeypatch):
+    creds_file = tmp_path / "credentials"
+    _write_static_profile(creds_file, "ack-test", "token_v1")
+    monkeypatch.setenv("AWS_SHARED_CREDENTIALS_FILE", str(creds_file))
+    monkeypatch.setenv("AWS_PROFILE", "ack-test")
+
+    # Tiny TTL so the advisory refresh window triggers a re-read on each access.
+    assert credentials.install_refreshing_shared_credentials(refresh_ttl_seconds=1)
+
+    creds = boto3.DEFAULT_SESSION.get_credentials()
+    assert creds.method == "acktest-rotating-shared-credentials"
+    assert creds.get_frozen_credentials().token == "token_v1"
+
+    # Simulate the host rotating the credentials file in place.
+    _write_static_profile(creds_file, "ack-test", "token_v2")
+    time.sleep(1.2)
+
+    assert creds.get_frozen_credentials().token == "token_v2"
+
+
+def test_noop_for_assume_role_profile(tmp_path, monkeypatch):
+    creds_file = tmp_path / "credentials"
+    _write_assume_role_profile(creds_file, "ack-test")
+    monkeypatch.setenv("AWS_SHARED_CREDENTIALS_FILE", str(creds_file))
+    monkeypatch.setenv("AWS_PROFILE", "ack-test")
+
+    # Assume-role profiles are already refreshed by botocore; leave them alone.
+    assert credentials.install_refreshing_shared_credentials() is False
+
+
+def test_noop_when_credentials_file_missing(tmp_path, monkeypatch):
+    monkeypatch.setenv(
+        "AWS_SHARED_CREDENTIALS_FILE", str(tmp_path / "does-not-exist")
+    )
+    monkeypatch.setenv("AWS_PROFILE", "ack-test")
+
+    assert credentials.install_refreshing_shared_credentials() is False
+
+
+def test_noop_when_disabled_by_env(tmp_path, monkeypatch):
+    creds_file = tmp_path / "credentials"
+    _write_static_profile(creds_file, "ack-test", "token_v1")
+    monkeypatch.setenv("AWS_SHARED_CREDENTIALS_FILE", str(creds_file))
+    monkeypatch.setenv("AWS_PROFILE", "ack-test")
+    monkeypatch.setenv(credentials._DISABLE_ENV_VAR, "1")
+
+    assert credentials.install_refreshing_shared_credentials() is False
+
+
+def test_noop_when_profile_absent(tmp_path, monkeypatch):
+    creds_file = tmp_path / "credentials"
+    _write_static_profile(creds_file, "some-other-profile", "token_v1")
+    monkeypatch.setenv("AWS_SHARED_CREDENTIALS_FILE", str(creds_file))
+    monkeypatch.setenv("AWS_PROFILE", "ack-test")
+
+    assert credentials.install_refreshing_shared_credentials() is False


### PR DESCRIPTION
**Description of changes:**

Long-running e2e suites intermittently fail with `ExpiredTokenException` even though credentials are rotated during the run. Example: the `sagemaker-controller-test` suite runs ~1h44m and `test_studio` fails late in the run on `DescribeApp` with:

```
botocore.exceptions.ClientError: An error occurred (ExpiredTokenException) when calling the DescribeApp operation: The security token included in the request is expired
```

**Root cause**

In Prow, `pytest-image-runner.sh` writes *static* one-hour credentials into the `ack-test` profile of the credentials file bind-mounted into the test container, and the container runs with `AWS_PROFILE=ack-test`. The host rotates that file in place every 50 minutes (`controller-setup.sh`), and #966 fixed the inode bug so the in-container file genuinely updates.

However, botocore reads a *static-key* profile exactly once and caches the result for the lifetime of the process. The long-lived pytest process never re-reads the rotated file, so once the original credentials expire (~60 min) every subsequent AWS call fails. #966 fixed the file refresh; this change makes the Python process actually consume it.

**Fix**

Install a botocore `RefreshableCredentials` provider on the default boto3 session that periodically re-reads the shared credentials file, so every `boto3.client(...)` created by the tests transparently follows the rotation. This is done in `acktest` so all controllers benefit.

It is a guarded no-op when:

- the shared credentials file does not exist,
- the active profile is an assume-role / web-identity profile (already refreshed natively by botocore, so local runs are unaffected), or
- `ACKTEST_DISABLE_CREDENTIAL_REFRESH` is set.

**Testing**

Added unit tests in `test/aws/test_credentials.py` covering live rotation pickup and each no-op path. Run with:

```
PYTHONPATH=src pytest test/aws/test_credentials.py
```

All 5 tests pass against boto3 1.42.60.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
