### PR TITLE
fix: exclude bundled acktest tests from controller e2e collection

### DIFF
--- a/scripts/pytest-local-runner.sh
+++ b/scripts/pytest-local-runner.sh
@@ -48,7 +48,10 @@ run_python_tests() {
     done
 
     pushd "${SERVICE_CONTROLLER_E2E_TEST_PATH}" 1> /dev/null
-        pytest -n ${PYTEST_NUM_THREADS} --dist no -o log_cli=true ${markers_args} \
+        # The full test-infra repo is copied into the image as ./acktest (used
+        # to pip-install the library). Exclude it from collection so acktest's
+        # own unit tests are never discovered as part of a controller's e2e run.
+        pytest -n ${PYTEST_NUM_THREADS} --dist no -o log_cli=true --ignore=acktest ${markers_args} \
             ${method_args} --log-cli-level "${PYTEST_LOG_LEVEL}" \
             --log-level "${PYTEST_LOG_LEVEL}" .
         local test_exit_code=$?


### PR DESCRIPTION
**Description of changes:**

The pytest image copies the entire test-infra repo into each controller's e2e workdir as `./acktest` (used to `pip install` the library), and the shared runner runs `pytest .` from that directory. pytest then recursively collects acktest's own unit tests under `./acktest/test/`.

Those unit tests import modules from the *installed* acktest, which for most controllers is an older pinned commit. When the installed version doesn't yet contain a module the test imports (e.g. `acktest.aws.credentials`, added in #971), collection fails for the whole e2e run:

```
ImportError: cannot import name 'credentials' from 'acktest.aws'
```

This surfaced after #971 added `test/aws/test_credentials.py`; before that, test-infra shipped no `test_*.py` files so nothing was collected.

This change passes `--ignore=acktest` to the e2e pytest invocation so the bundled library tree is never collected as part of a controller's e2e run. acktest's own unit tests are still runnable directly (`PYTHONPATH=src pytest test/`).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
