### PR TITLE
fix: align kubelet and containerd on cgroupfs for KIND on cgroup v1 hosts

### DIFF
--- a/scripts/kind-configurations/kind-two-node-cluster.yaml
+++ b/scripts/kind-configurations/kind-two-node-cluster.yaml
@@ -1,6 +1,22 @@
 kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
+# Host (AL2 Cloud Desktop) runs cgroup v1; align kubelet AND containerd on the
+# cgroupfs driver. KinD's systemd default leaves the kubelet unhealthy, and a
+# kubelet-only cgroupfs override mismatches containerd (runc: "expected
+# cgroupsPath to be of format slice:prefix:name").
+containerdConfigPatches:
+  - |-
+    [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc.options]
+      SystemdCgroup = false
 nodes:
   - role: control-plane
+    kubeadmConfigPatches:
+      - |
+        kind: KubeletConfiguration
+        cgroupDriver: cgroupfs
   - role: worker
+    kubeadmConfigPatches:
+      - |
+        kind: KubeletConfiguration
+        cgroupDriver: cgroupfs
     


### PR DESCRIPTION
On cgroup v1 hosts (e.g. AL2 dev desktops), `make kind-test` fails because the default KIND config
  leaves the kubelet unhealthy, and a kubelet-only cgroupfs override mismatches containerd (`runc: expected
  cgroupsPath to be of format slice:prefix:name`). This sets both kubelet and containerd to the cgroupfs driver so
  the control plane initializes.
  
  Opening for discussion — happy to make this conditional on the host cgroup version if preferred, since cgroup v2
  hosts typically default to the systemd driver.