### PR TITLE
fix: handle merge commit format in extract_pr_number

### DIFF
--- a/cd/lib/gh.sh
+++ b/cd/lib/gh.sh
@@ -1,12 +1,24 @@
 #!/usr/bin/env bash
 
-# extract_pr_number extracts a PR number from a squash-merge commit title.
-# Squash merges use the format "Title (#123)".
+# extract_pr_number extracts a PR number from a merge commit title.
+# Handles both squash-merge format "Title (#123)" and merge-commit format
+# "Merge pull request #123 from ...".
 # Usage:
 #
 # pr_number=$(extract_pr_number "$commit_title")
 extract_pr_number() {
-    echo "$1" | grep -oE '\(#[0-9]+\)$' | grep -oE '[0-9]+'
+    local title="$1"
+    local pr_num=""
+
+    # Try squash-merge format: "Title (#123)"
+    pr_num=$(echo "$title" | grep -oE '\(#[0-9]+\)$' | grep -oE '[0-9]+' || true)
+
+    # Try merge-commit format: "Merge pull request #123 from ..."
+    if [[ -z "$pr_num" ]]; then
+        pr_num=$(echo "$title" | grep -oE '^Merge pull request #[0-9]+' | grep -oE '[0-9]+' || true)
+    fi
+
+    echo "$pr_num"
 }
 
 # get_pr_labels fetches the labels of a PR from a GitHub repository.


### PR DESCRIPTION
## Summary

Fixes the `release-pr` postsubmit prow job failure when a PR is merged using GitHub's merge commit strategy (instead of squash merge).

## Problem

The `extract_pr_number` function in `cd/lib/gh.sh` only handled squash-merge commit titles (`Title (#123)`) using the regex `\(#[0-9]+\)$`. When a PR is merged with a merge commit, the title is `Merge pull request #123 from org/branch`, which doesn't match.

Under `set -eo pipefail` (set at the top of `controller-release-pr.sh`), the grep failure (exit code 1) propagates through the pipeline and aborts the script before the empty-string guard can handle it gracefully.

## Fix

- Added support for the merge-commit format: `^Merge pull request #[0-9]+`
- Added `|| true` to both grep pipelines to prevent non-zero exit codes from propagating through pipefail
- The function now returns empty string (no error) when neither format matches, allowing the caller's existing guard to handle it

## Testing

```bash
$ extract_pr_number 'fix: something (#108)'         # -> 108
$ extract_pr_number 'Merge pull request #108 from org/branch'  # -> 108  
$ extract_pr_number 'random commit'                 # -> (empty, no error)
```

All tested under `set -eo pipefail` — no failures.