### PR TITLE
fix: handle merge commits in release PR body generation

### DIFF
--- a/cd/auto-generate/controller-release-pr.sh
+++ b/cd/auto-generate/controller-release-pr.sh
@@ -159,9 +159,10 @@ fi
 PR_BODY_FILE=/tmp/release_pr_body
 {
   echo "Releasing changes:"
-  git log "$LATEST_TAG"..main --oneline --grep='(#' | grep -oE '\(#[0-9]+\)' | grep -oE '[0-9]+' | while read -r pr_num; do
+  # Support both squash-merge "Title (#123)" and merge-commit "Merge pull request #123" formats
+  git log "$LATEST_TAG"..main --oneline | grep -oE '(\(#[0-9]+\)|Merge pull request #[0-9]+)' | grep -oE '[0-9]+' | sort -u | while read -r pr_num; do
     echo "* https://github.com/$GITHUB_ORG/$CONTROLLER_NAME/pull/$pr_num"
-  done
+  done || true
 } > "$PR_BODY_FILE"
 
 open_pull_request "$GITHUB_ORG/$CONTROLLER_NAME" "$COMMIT_MSG" "$PR_BODY_FILE"


### PR DESCRIPTION
## Summary

Follow-up fix to #974. The release-pr job still fails when processing merge commits because the PR body generation pipeline also assumes squash-merge format.

## Problem

In `controller-release-pr.sh`, the PR body generation uses:
```bash
git log "$LATEST_TAG"..main --oneline --grep='(#' | grep -oE '\(#[0-9]+\)' | grep -oE '[0-9]+'
```

This only matches squash-merge titles containing `(#NNN)`. Merge commits use `Merge pull request #NNN from ...` which has no parentheses around the PR number. Under `set -eo pipefail`, the grep failure aborts the script after the push but before creating the release PR.

## Fix

- Removed `--grep='(#'` filter from git log
- Updated grep pattern to match both formats: `(\(#[0-9]+\)|Merge pull request #[0-9]+)`
- Added `|| true` to the pipeline so empty results don't abort the script
- Added `sort -u` to deduplicate PR numbers

## Testing

```bash
$ set -eo pipefail
$ git log v1.5.0..main --oneline | grep -oE '(\(#[0-9]+\)|Merge pull request #[0-9]+)' | grep -oE '[0-9]+' | sort -u
108
```