### PR TITLE
chore(prow): upgrade to v20260617-37d12bec7

### DIFF
--- a/flux/prow/crds/prowjob_customresourcedefinition.yaml
+++ b/flux/prow/crds/prowjob_customresourcedefinition.yaml
@@ -1623,6 +1623,18 @@ spec:
                 items:
                   description: Refs describes how the repo was constructed.
                   properties:
+                    auxiliary:
+                      description: |-
+                        Auxiliary indicates that the repository really only provides
+                        auxiliary files for the job and is not the main repository that is
+                        being tested.
+                        This is relevant when determining which version to record in a
+                        periodic job's started.json file: the first repository where
+                        Auxiliary is false or unset is considered the main repository
+                        and determines the version.
+                        In presubmit jobs the version always comes from the repository
+                        for which the job is defined.
+                      type: boolean
                     base_link:
                       description: BaseLink is a link to the commit identified by
                         BaseSHA.
@@ -9730,6 +9742,18 @@ spec:
                   Refs is the code under test, determined at
                   runtime by Prow itself
                 properties:
+                  auxiliary:
+                    description: |-
+                      Auxiliary indicates that the repository really only provides
+                      auxiliary files for the job and is not the main repository that is
+                      being tested.
+                      This is relevant when determining which version to record in a
+                      periodic job's started.json file: the first repository where
+                      Auxiliary is false or unset is considered the main repository
+                      and determines the version.
+                      In presubmit jobs the version always comes from the repository
+                      for which the job is defined.
+                    type: boolean
                   base_link:
                     description: BaseLink is a link to the commit identified by BaseSHA.
                     type: string

--- a/flux/prow/version/prow-version-configmap.yaml
+++ b/flux/prow/version/prow-version-configmap.yaml
@@ -6,5 +6,5 @@ metadata:
   name: prow-version
   namespace: flux-system
 data:
-  PROW_VERSION: "v20260602-e7f2be80c"
+  PROW_VERSION: "v20260617-37d12bec7"
   TOOLS_VERSION: "v20260515-778139c32d"

--- a/prow/config/Chart.yaml
+++ b/prow/config/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: prow-config
 description: Configuration for the ACK Prow cluster
 type: application
-version: 0.4.17
+version: 0.4.18
 appVersion: "1.16.0"


### PR DESCRIPTION
## Summary

Upgrades Prow core images to `v20260617-37d12bec7` (from `v20260602-e7f2be80c`).

## Changes

- **Prow version**: `v20260602-e7f2be80c` → `v20260617-37d12bec7`
- **ProwJob CRD**: Updated with new `auxiliary` field for refs (determines main repo vs auxiliary in periodic jobs)
- **Prow config chart**: `0.4.17` → `0.4.18`
- **Flux**: Already at latest (`2.18.4` / appVersion `2.8.8`) — no change needed

## How it was done

Followed the documented upgrade process in `bootstrap/README.md`:

```bash
./scripts/upgrade-prow.sh
git add flux/prow/ prow/config/
git commit -m "chore(prow): upgrade to v20260617-37d12bec7"
```

## Rollout

Flux reconciles automatically: the mirror job copies new images to ECR, then Prow redeploys.