### PR TITLE
Upgrade secrets-csi-driver addon to v3.1.1-eksbuild.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,16 @@ The script uses `aws eks describe-addon-versions` to discover versions and updat
 
 **Prerequisites:** AWS CLI (configured with EKS access), [yq](https://github.com/mikefarah/yq)
 
+Before running the script, ensure you have valid AWS credentials:
+
+```bash
+# Grab fresh credentials (e.g., via ada, isengard, or your preferred method)
+ada credentials update --account=<account-id> --role=<role-name> --provider=isengard
+
+# Verify credentials are working
+aws sts get-caller-identity
+```
+
 ## Contributing
 
 We welcome community contributions and pull requests.

--- a/README.md
+++ b/README.md
@@ -32,6 +32,28 @@ Once installed, methods and classes are accessed by referencing the
 import acktest
 ```
 
+## Upgrading EKS Addons
+
+The test clusters use EKS managed addons (secrets-store-csi-driver, external-dns, coredns) defined in `flux/ack/cluster/addons/addons.yaml`. To upgrade the `aws-secrets-store-csi-driver-provider` addon to the latest version:
+
+```bash
+# Auto-detect and apply the latest version
+./scripts/upgrade-secrets-csi-driver.sh
+
+# Preview changes without modifying files
+./scripts/upgrade-secrets-csi-driver.sh --dry-run
+
+# Pin to a specific version
+./scripts/upgrade-secrets-csi-driver.sh v1.0.0-eksbuild.1
+
+# Constrain to a specific Kubernetes version
+./scripts/upgrade-secrets-csi-driver.sh --kubernetes-version=1.31
+```
+
+The script uses `aws eks describe-addon-versions` to discover the latest compatible version and updates the `addonVersion` field in the Addon manifest. It also updates the `test-infra-upgrade` sibling repo if present.
+
+**Prerequisites:** AWS CLI (configured with EKS access), [yq](https://github.com/mikefarah/yq)
+
 ## Contributing
 
 We welcome community contributions and pull requests.

--- a/README.md
+++ b/README.md
@@ -34,23 +34,28 @@ import acktest
 
 ## Upgrading EKS Addons
 
-The test clusters use EKS managed addons (secrets-store-csi-driver, external-dns, coredns) defined in `flux/ack/cluster/addons/addons.yaml`. To upgrade the `aws-secrets-store-csi-driver-provider` addon to the latest version:
+The test clusters use EKS managed addons (secrets-store-csi-driver, external-dns, coredns) defined in `flux/ack/cluster/addons/addons.yaml`. To upgrade the `aws-secrets-store-csi-driver-provider` addon:
 
 ```bash
-# Auto-detect and apply the latest version
-./scripts/upgrade-secrets-csi-driver.sh
+# Recommended: use the EKS default version (stable, tested by EKS team)
+./scripts/upgrade-secrets-csi-driver.sh --default
+
+# Use the default version for a specific Kubernetes version
+./scripts/upgrade-secrets-csi-driver.sh --default --kubernetes-version=1.31
 
 # Preview changes without modifying files
-./scripts/upgrade-secrets-csi-driver.sh --dry-run
+./scripts/upgrade-secrets-csi-driver.sh --default --dry-run
+
+# Use the absolute latest version (may not be marked as default yet)
+./scripts/upgrade-secrets-csi-driver.sh
 
 # Pin to a specific version
 ./scripts/upgrade-secrets-csi-driver.sh v1.0.0-eksbuild.1
-
-# Constrain to a specific Kubernetes version
-./scripts/upgrade-secrets-csi-driver.sh --kubernetes-version=1.31
 ```
 
-The script uses `aws eks describe-addon-versions` to discover the latest compatible version and updates the `addonVersion` field in the Addon manifest. It also updates the `test-infra-upgrade` sibling repo if present.
+Using `--default` is recommended for upgrades because EKS marks a version as default only after it has been validated for stability and compatibility. The latest version may be newer but hasn't necessarily completed the EKS qualification process.
+
+The script uses `aws eks describe-addon-versions` to discover versions and updates the `addonVersion` field in the Addon manifest. It also updates the `test-infra-upgrade` sibling repo if present.
 
 **Prerequisites:** AWS CLI (configured with EKS access), [yq](https://github.com/mikefarah/yq)
 

--- a/flux/ack/cluster/addons/addons.yaml
+++ b/flux/ack/cluster/addons/addons.yaml
@@ -16,6 +16,7 @@ spec:
         }
       }
     }
+  addonVersion: v3.1.1-eksbuild.1
 ---
 apiVersion: eks.services.k8s.aws/v1alpha1
 kind: Addon

--- a/scripts/upgrade-secrets-csi-driver.sh
+++ b/scripts/upgrade-secrets-csi-driver.sh
@@ -9,6 +9,7 @@
 #
 # Usage:
 #   ./scripts/upgrade-secrets-csi-driver.sh              # auto-detect latest
+#   ./scripts/upgrade-secrets-csi-driver.sh --default    # use EKS default version (recommended)
 #   ./scripts/upgrade-secrets-csi-driver.sh <version>    # use specific version
 #   ./scripts/upgrade-secrets-csi-driver.sh --dry-run    # show what would change
 #
@@ -33,6 +34,7 @@ fi
 
 # --- Parse arguments ---
 DRY_RUN=false
+USE_DEFAULT=false
 TARGET_VERSION=""
 K8S_VERSION=""
 
@@ -41,12 +43,16 @@ for arg in "$@"; do
     --dry-run)
       DRY_RUN=true
       ;;
+    --default)
+      USE_DEFAULT=true
+      ;;
     --help|-h)
-      echo "Usage: $0 [--dry-run] [--kubernetes-version=X.XX] [<version>]"
+      echo "Usage: $0 [--dry-run] [--default] [--kubernetes-version=X.XX] [<version>]"
       echo ""
       echo "Upgrades the $ADDON_NAME EKS addon version."
       echo ""
       echo "Options:"
+      echo "  --default                  Use the EKS default version for the Kubernetes version (recommended)"
       echo "  --dry-run                  Show what would change without modifying files"
       echo "  --kubernetes-version=X.XX  Constrain to versions compatible with this K8s version"
       echo "  <version>                  Specific addon version (e.g., v1.0.0-eksbuild.1)"
@@ -80,29 +86,50 @@ if ! command -v yq >/dev/null 2>&1; then
 fi
 
 # ─────────────────────────────────────────────────────────────────────────────
-# Discover latest version
+# Discover version
 # ─────────────────────────────────────────────────────────────────────────────
 
 if [[ -z "$TARGET_VERSION" ]]; then
-  echo "Discovering latest $ADDON_NAME version..."
+  if [[ "$USE_DEFAULT" == "true" ]]; then
+    echo "Discovering default $ADDON_NAME version..."
 
-  EKS_ARGS=(eks describe-addon-versions --addon-name "$ADDON_NAME" --query 'addons[0].addonVersions[0].addonVersion' --output text)
+    # Query for the version marked as default for the given Kubernetes version.
+    # The defaultVersion field in compatibilities indicates EKS's recommended version.
+    EKS_ARGS=(eks describe-addon-versions --addon-name "$ADDON_NAME"
+      --query 'addons[0].addonVersions[?compatibilities[0].defaultVersion==`true`].addonVersion | [0]'
+      --output text)
 
-  if [[ -n "$K8S_VERSION" ]]; then
-    EKS_ARGS+=(--kubernetes-version "$K8S_VERSION")
-    echo "  Constraining to Kubernetes version: $K8S_VERSION"
+    if [[ -n "$K8S_VERSION" ]]; then
+      EKS_ARGS+=(--kubernetes-version "$K8S_VERSION")
+      echo "  Constraining to Kubernetes version: $K8S_VERSION"
+    fi
+  else
+    echo "Discovering latest $ADDON_NAME version..."
+
+    EKS_ARGS=(eks describe-addon-versions --addon-name "$ADDON_NAME"
+      --query 'addons[0].addonVersions[0].addonVersion'
+      --output text)
+
+    if [[ -n "$K8S_VERSION" ]]; then
+      EKS_ARGS+=(--kubernetes-version "$K8S_VERSION")
+      echo "  Constraining to Kubernetes version: $K8S_VERSION"
+    fi
   fi
 
   TARGET_VERSION=$(aws "${EKS_ARGS[@]}" 2>/dev/null)
 
   if [[ -z "$TARGET_VERSION" || "$TARGET_VERSION" == "None" ]]; then
-    echo "error: could not discover latest version for $ADDON_NAME" >&2
+    echo "error: could not discover version for $ADDON_NAME" >&2
     echo "  Ensure the AWS CLI is configured and has EKS access." >&2
     echo "  Or provide a version manually: $0 v1.0.0-eksbuild.1" >&2
     exit 1
   fi
 
-  echo "  Latest: $TARGET_VERSION"
+  if [[ "$USE_DEFAULT" == "true" ]]; then
+    echo "  Default: $TARGET_VERSION"
+  else
+    echo "  Latest: $TARGET_VERSION"
+  fi
 fi
 
 echo ""

--- a/scripts/upgrade-secrets-csi-driver.sh
+++ b/scripts/upgrade-secrets-csi-driver.sh
@@ -1,0 +1,152 @@
+#!/usr/bin/env bash
+#
+# Upgrades the aws-secrets-store-csi-driver-provider EKS addon version in
+# the ACK addon manifests.
+#
+# Discovers the latest addon version using `aws eks describe-addon-versions`
+# and updates the Addon resources in both test-infra and test-infra-upgrade
+# manifest files to pin that version.
+#
+# Usage:
+#   ./scripts/upgrade-secrets-csi-driver.sh              # auto-detect latest
+#   ./scripts/upgrade-secrets-csi-driver.sh <version>    # use specific version
+#   ./scripts/upgrade-secrets-csi-driver.sh --dry-run    # show what would change
+#
+# Requires: aws CLI, yq
+# Optional: --kubernetes-version flag to constrain compatibility
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+ADDON_NAME="aws-secrets-store-csi-driver-provider"
+ADDON_FILES=(
+  "$REPO_ROOT/flux/ack/cluster/addons/addons.yaml"
+)
+
+# Also update the upgrade test infra if it exists as a sibling repo
+UPGRADE_REPO="$(cd "$REPO_ROOT/../test-infra-upgrade" 2>/dev/null && pwd || echo "")"
+if [[ -n "$UPGRADE_REPO" && -f "$UPGRADE_REPO/flux/ack/cluster/addons/addons.yaml" ]]; then
+  ADDON_FILES+=("$UPGRADE_REPO/flux/ack/cluster/addons/addons.yaml")
+fi
+
+# --- Parse arguments ---
+DRY_RUN=false
+TARGET_VERSION=""
+K8S_VERSION=""
+
+for arg in "$@"; do
+  case "$arg" in
+    --dry-run)
+      DRY_RUN=true
+      ;;
+    --help|-h)
+      echo "Usage: $0 [--dry-run] [--kubernetes-version=X.XX] [<version>]"
+      echo ""
+      echo "Upgrades the $ADDON_NAME EKS addon version."
+      echo ""
+      echo "Options:"
+      echo "  --dry-run                  Show what would change without modifying files"
+      echo "  --kubernetes-version=X.XX  Constrain to versions compatible with this K8s version"
+      echo "  <version>                  Specific addon version (e.g., v1.0.0-eksbuild.1)"
+      exit 0
+      ;;
+    --kubernetes-version=*)
+      K8S_VERSION="${arg#--kubernetes-version=}"
+      ;;
+    v*)
+      TARGET_VERSION="$arg"
+      ;;
+    *)
+      echo "error: unknown argument: $arg" >&2
+      exit 1
+      ;;
+  esac
+done
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Prerequisites
+# ─────────────────────────────────────────────────────────────────────────────
+
+if ! command -v aws >/dev/null 2>&1; then
+  echo "error: aws CLI is required" >&2
+  exit 1
+fi
+
+if ! command -v yq >/dev/null 2>&1; then
+  echo "error: yq is required (https://github.com/mikefarah/yq)" >&2
+  exit 1
+fi
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Discover latest version
+# ─────────────────────────────────────────────────────────────────────────────
+
+if [[ -z "$TARGET_VERSION" ]]; then
+  echo "Discovering latest $ADDON_NAME version..."
+
+  EKS_ARGS=(eks describe-addon-versions --addon-name "$ADDON_NAME" --query 'addons[0].addonVersions[0].addonVersion' --output text)
+
+  if [[ -n "$K8S_VERSION" ]]; then
+    EKS_ARGS+=(--kubernetes-version "$K8S_VERSION")
+    echo "  Constraining to Kubernetes version: $K8S_VERSION"
+  fi
+
+  TARGET_VERSION=$(aws "${EKS_ARGS[@]}" 2>/dev/null)
+
+  if [[ -z "$TARGET_VERSION" || "$TARGET_VERSION" == "None" ]]; then
+    echo "error: could not discover latest version for $ADDON_NAME" >&2
+    echo "  Ensure the AWS CLI is configured and has EKS access." >&2
+    echo "  Or provide a version manually: $0 v1.0.0-eksbuild.1" >&2
+    exit 1
+  fi
+
+  echo "  Latest: $TARGET_VERSION"
+fi
+
+echo ""
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Update manifests
+# ─────────────────────────────────────────────────────────────────────────────
+
+for addon_file in "${ADDON_FILES[@]}"; do
+  if [[ ! -f "$addon_file" ]]; then
+    echo "  Skipping (not found): $addon_file"
+    continue
+  fi
+
+  echo "Processing: $addon_file"
+
+  # Find the document index for the secrets-store-csi addon
+  # The file contains multiple YAML documents separated by ---
+  doc_index=$(yq eval-all 'select(.metadata.name == "secrets-store-csi") | documentIndex' "$addon_file" 2>/dev/null)
+
+  if [[ -z "$doc_index" ]]; then
+    echo "  warning: no secrets-store-csi Addon found in $addon_file" >&2
+    continue
+  fi
+
+  # Check current version (may be empty if not pinned)
+  current_version=$(yq eval "select(documentIndex == $doc_index) | .spec.addonVersion // \"(not pinned)\"" "$addon_file")
+
+  if [[ "$current_version" == "$TARGET_VERSION" ]]; then
+    echo "  Already at $TARGET_VERSION — no change needed."
+    continue
+  fi
+
+  echo "  Current: $current_version"
+  echo "  Target:  $TARGET_VERSION"
+
+  if [[ "$DRY_RUN" == "false" ]]; then
+    yq eval -i "select(documentIndex == $doc_index) | .spec.addonVersion = \"$TARGET_VERSION\"" "$addon_file"
+    echo "  Updated."
+  else
+    echo "  [dry-run] Would set .spec.addonVersion = \"$TARGET_VERSION\""
+  fi
+
+  echo ""
+done
+
+echo "Done. Review with: git diff"

--- a/scripts/upgrade-secrets-csi-driver.sh
+++ b/scripts/upgrade-secrets-csi-driver.sh
@@ -13,7 +13,7 @@
 #   ./scripts/upgrade-secrets-csi-driver.sh <version>    # use specific version
 #   ./scripts/upgrade-secrets-csi-driver.sh --dry-run    # show what would change
 #
-# Requires: aws CLI, yq
+# Requires: aws CLI
 # Optional: --kubernetes-version flag to constrain compatibility
 
 set -euo pipefail
@@ -80,11 +80,6 @@ if ! command -v aws >/dev/null 2>&1; then
   exit 1
 fi
 
-if ! command -v yq >/dev/null 2>&1; then
-  echo "error: yq is required (https://github.com/mikefarah/yq)" >&2
-  exit 1
-fi
-
 # ─────────────────────────────────────────────────────────────────────────────
 # Discover version
 # ─────────────────────────────────────────────────────────────────────────────
@@ -92,28 +87,17 @@ fi
 if [[ -z "$TARGET_VERSION" ]]; then
   if [[ "$USE_DEFAULT" == "true" ]]; then
     echo "Discovering default $ADDON_NAME version..."
-
-    # Query for the version marked as default for the given Kubernetes version.
-    # The defaultVersion field in compatibilities indicates EKS's recommended version.
-    EKS_ARGS=(eks describe-addon-versions --addon-name "$ADDON_NAME"
-      --query 'addons[0].addonVersions[?compatibilities[0].defaultVersion==`true`].addonVersion | [0]'
-      --output text)
-
-    if [[ -n "$K8S_VERSION" ]]; then
-      EKS_ARGS+=(--kubernetes-version "$K8S_VERSION")
-      echo "  Constraining to Kubernetes version: $K8S_VERSION"
-    fi
+    QUERY='addons[0].addonVersions[?compatibilities[0].defaultVersion==`true`].addonVersion | [0]'
   else
     echo "Discovering latest $ADDON_NAME version..."
+    QUERY='addons[0].addonVersions[0].addonVersion'
+  fi
 
-    EKS_ARGS=(eks describe-addon-versions --addon-name "$ADDON_NAME"
-      --query 'addons[0].addonVersions[0].addonVersion'
-      --output text)
+  EKS_ARGS=(eks describe-addon-versions --addon-name "$ADDON_NAME" --query "$QUERY" --output text)
 
-    if [[ -n "$K8S_VERSION" ]]; then
-      EKS_ARGS+=(--kubernetes-version "$K8S_VERSION")
-      echo "  Constraining to Kubernetes version: $K8S_VERSION"
-    fi
+  if [[ -n "$K8S_VERSION" ]]; then
+    EKS_ARGS+=(--kubernetes-version "$K8S_VERSION")
+    echo "  Constraining to Kubernetes version: $K8S_VERSION"
   fi
 
   TARGET_VERSION=$(aws "${EKS_ARGS[@]}" 2>/dev/null)
@@ -146,17 +130,11 @@ for addon_file in "${ADDON_FILES[@]}"; do
 
   echo "Processing: $addon_file"
 
-  # Find the document index for the secrets-store-csi addon
-  # The file contains multiple YAML documents separated by ---
-  doc_index=$(yq eval-all 'select(.metadata.name == "secrets-store-csi") | documentIndex' "$addon_file" 2>/dev/null)
-
-  if [[ -z "$doc_index" ]]; then
-    echo "  warning: no secrets-store-csi Addon found in $addon_file" >&2
-    continue
+  # Check current version
+  current_version=$(grep -A 30 'name: secrets-store-csi' "$addon_file" | grep 'addonVersion:' | head -1 | awk '{print $2}' || true)
+  if [[ -z "$current_version" ]]; then
+    current_version="(not pinned)"
   fi
-
-  # Check current version (may be empty if not pinned)
-  current_version=$(yq eval "select(documentIndex == $doc_index) | .spec.addonVersion // \"(not pinned)\"" "$addon_file")
 
   if [[ "$current_version" == "$TARGET_VERSION" ]]; then
     echo "  Already at $TARGET_VERSION — no change needed."
@@ -167,7 +145,24 @@ for addon_file in "${ADDON_FILES[@]}"; do
   echo "  Target:  $TARGET_VERSION"
 
   if [[ "$DRY_RUN" == "false" ]]; then
-    yq eval -i "select(documentIndex == $doc_index) | .spec.addonVersion = \"$TARGET_VERSION\"" "$addon_file"
+    if [[ "$current_version" != "(not pinned)" ]]; then
+      # Replace existing addonVersion line within the secrets-store-csi document
+      awk -v ver="$TARGET_VERSION" '
+        /name: secrets-store-csi/ { in_target=1 }
+        /^---/ && in_target { in_target=0 }
+        in_target && /addonVersion:/ { sub(/addonVersion:.*/, "addonVersion: " ver) }
+        { print }
+      ' "$addon_file" > "${addon_file}.tmp" && mv "${addon_file}.tmp" "$addon_file"
+    else
+      # Insert addonVersion as the last field in the secrets-store-csi spec block
+      # (before the next --- separator)
+      awk -v ver="$TARGET_VERSION" '
+        /name: secrets-store-csi/ { in_target=1 }
+        in_target && /^---/ { print "  addonVersion: " ver; in_target=0 }
+        { print }
+        END { if (in_target) print "  addonVersion: " ver }
+      ' "$addon_file" > "${addon_file}.tmp" && mv "${addon_file}.tmp" "$addon_file"
+    fi
     echo "  Updated."
   else
     echo "  [dry-run] Would set .spec.addonVersion = \"$TARGET_VERSION\""


### PR DESCRIPTION
## Summary

Pin `aws-secrets-store-csi-driver-provider` EKS addon to `v3.1.1-eksbuild.1`, the EKS default version for Kubernetes 1.35.

## Changes

- **flux/ack/cluster/addons/addons.yaml**: Added `addonVersion: v3.1.1-eksbuild.1` to the secrets-store-csi Addon resource
- **scripts/upgrade-secrets-csi-driver.sh**: Added upgrade script that discovers versions via `aws eks describe-addon-versions` and updates manifests. Supports `--default`, `--dry-run`, `--kubernetes-version`, and manual version pinning.
- **README.md**: Added Upgrading EKS Addons section with usage examples and credential requirements

## Testing

Ran `./scripts/upgrade-secrets-csi-driver.sh --default --kubernetes-version=1.35` which discovered and applied `v3.1.1-eksbuild.1`.