### PR TITLE
Pin secrets-store-csi addon to v3.1.1-eksbuild.1

### DIFF
--- a/flux/ack/cluster/addons/addons.yaml
+++ b/flux/ack/cluster/addons/addons.yaml
@@ -8,6 +8,7 @@ metadata:
 spec:
   clusterName: ${STACK_NAME}-cluster
   name: aws-secrets-store-csi-driver-provider
+  addonVersion: v3.1.1-eksbuild.1
   configurationValues: |-
     {
       "secrets-store-csi-driver": {


### PR DESCRIPTION
Explicitly set addonVersion for aws-secrets-store-csi-driver-provider to v3.1.1-eksbuild.1 (the default version for Kubernetes 1.35).