### PR TITLE
soak: isolate resources per service for parallel testing

### DIFF
--- a/soak/README.md
+++ b/soak/README.md
@@ -1,10 +1,10 @@
 ## Introduction
 
-The ACK core team provides a soak testing framework and template cluster where
-service teams can execute long running soak tests to test the performance and
-stability of the service controllers. Running soak tests is one of the
-requirements for cutting a new major version release for any service controller.
-Find more details on the release process
+The ACK core team provides a soak testing framework where service teams can
+execute long running soak tests to test the performance and stability of the
+service controllers. Running soak tests is one of the requirements for cutting
+a new major version release for any service controller. Find more details on
+the release process
 [here](https://github.com/aws-controllers-k8s/community/blob/main/docs/content/docs/community/releases.md).
 
 Under the hood, the soak test introduces load by repeatedly running the
@@ -17,6 +17,31 @@ infrastructure in their own accounts, based off the templates and configuration
 provided in this repository. Soak tests will be started by Prow jobs before
 cutting a new major version release, but can also be manually triggered. Use the
 following guide to configure your soak testing infrastructure.
+
+## Parallel Soak Testing
+
+All resources created by this framework are scoped per AWS service, allowing
+multiple controllers to be soak-tested in parallel without conflicts. Each
+invocation of `bootstrap.sh` creates its own:
+
+| Resource | Naming Convention |
+|----------|-------------------|
+| EKS Cluster | `ack-soak-<service>` |
+| ECR Public Repo | `ack-<service>-soak` |
+| Controller Helm Release | `soak-test-<service>` |
+| Soak Runner Helm Release | `soak-runner-<service>` |
+| Prometheus Namespace | `prometheus-<service>` |
+| Prometheus Helm Release | `kube-prom-<service>` |
+| Loki Helm Release | `loki-<service>` |
+
+For example, running soak tests for both `s3` and `ecr` simultaneously:
+```bash
+./bootstrap.sh s3 v1.0.0
+./bootstrap.sh ecr v0.0.12
+```
+
+This creates two independent EKS clusters (`ack-soak-s3` and `ack-soak-ecr`),
+each with their own monitoring stack and test runner.
 
 ## Bootstrapping your soak test cluster
 
@@ -50,15 +75,15 @@ terminal before following the rest of the documents.
 
 Run the `bootstrap.sh` script in the current directory. This script will do the
 following: 
-1. Create an ECR public repository for the soak test runner
-1. Create an EKS cluster with the default soak test configuration (from
-  `cluster-config.yaml`)
-1. Install the controller Helm chart
-1. Install Prometheus and Grafana
+1. Create an ECR public repository for the soak test runner (`ack-<service>-soak`)
+1. Create an EKS cluster named `ack-soak-<service>` with the default soak test
+   configuration (from `cluster-config.yaml`)
+1. Install the controller Helm chart (`soak-test-<service>`)
+1. Install Prometheus and Grafana in namespace `prometheus-<service>`
 1. Install the custom ACK soak test Grafana dashboard (from
    `./monitoring/grafana/ack-dashboard-source.json`)
 1. Build and push the soak test runner image
-1. Install the soak test runner Helm chart
+1. Install the soak test runner Helm chart (`soak-runner-<service>`)
 
 The script requires the name of the service and the semver tag of the controller
 version up for testing. For example:
@@ -66,24 +91,100 @@ version up for testing. For example:
 ./bootstrap.sh s3 v0.0.12
 ```
 
-### Step 2 (Log onto the Prometheus dashboard)
+### Step 2 (Log onto the Grafana dashboard)
 
-After the script concludes, it should provide an example of the command to
-port-forward Prometheus. By default, the command should look like the following:
+After the script concludes, it will provide the exact command to port-forward
+Grafana. The command includes the service-specific namespace:
 
 ```bash
-kubectl port-forward -n prometheus service/kube-prom-grafana 3000:80 --address='0.0.0.0' >/dev/null &
+kubectl port-forward -n prometheus-s3 service/kube-prom-s3-grafana 3000:80 --address='0.0.0.0' >/dev/null &
 ```
 
-Navigate to `http://127.0.0.1:3000/` and log in. You should be able to log into
-the dashboard with the following credentials:
-- Username: `admin`
-- Password: `prom-operator`
+Navigate to `http://127.0.0.1:3000/` and log in. Retrieve the admin password:
+```bash
+kubectl get secret -n prometheus-<service> kube-prom-<service>-grafana \
+    -o jsonpath='{.data.admin-password}' | base64 -d && echo
+```
 
-Using the menu bar on the left, side navigate to `Dashboards` > `Browse`. Select
+Using the menu bar on the left, navigate to `Dashboards` > `Browse`. Select
 the `ACK Dashboard` at the top of the list. The `ACK Dashboard` will show the
 ACK-specific request counts and error codes used by the controller when making
 calls to AWS APIs. 
 
 The `Kubernetes/Compute Resources/Pod` dashboard will show the resource
 consumption by the controller pod.
+
+### Step 3 (Monitor soak test progress)
+
+Check the status of the soak test Job:
+```bash
+kubectl get jobs -n ack-system | grep <service>
+kubectl logs -n ack-system -f job/<service>-soak-test
+```
+
+### Step 4 (View all dashboards)
+
+To discover all running soak tests and open their Grafana dashboards:
+```bash
+./dashboards.sh
+```
+
+This script will:
+1. Scan for all `ack-soak-*` EKS clusters in the region
+2. Port-forward each cluster's Grafana on sequential ports (starting at 3000)
+3. Print the URL and credentials for each dashboard
+
+Example output:
+```
+========================================
+ ACK Soak Test Dashboards
+========================================
+
+  emrserverless
+    Cluster:   ack-soak-emrserverless
+    Dashboard: http://localhost:3000/
+    Creds:     admin / <password>
+    Soak Job:  Running
+
+  glue
+    Cluster:   ack-soak-glue
+    Dashboard: http://localhost:3001/
+    Creds:     admin / <password>
+    Soak Job:  Running
+
+========================================
+ All dashboards are port-forwarded.
+ Stop with: pkill -f 'kubectl port-forward.*grafana'
+========================================
+```
+
+To stop all port-forwards:
+```bash
+pkill -f 'kubectl port-forward.*grafana'
+```
+
+### Step 5 (Tear down resources)
+
+After reviewing results, clean up all resources for a specific service:
+```bash
+./teardown.sh <service>
+```
+
+Or manually:
+```bash
+eksctl delete cluster --name ack-soak-<service> --region us-west-2
+aws --region us-east-1 ecr-public delete-repository --repository-name ack-<service>-soak --force
+```
+
+## Environment Variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `DEPLOY_REGION` | `us-west-2` | AWS region for cluster and resources |
+| `CLUSTER_NAME` | `ack-soak-<service>` | Override the EKS cluster name |
+| `SOAK_IMAGE_REPO_NAME` | `ack-<service>-soak` | ECR public repo name |
+| `OCI_BUILDER` | `docker` | Container image builder binary |
+| `TEST_DURATION_DAYS` | `1` | Days to run soak test |
+| `TEST_DURATION_HOURS` | `0` | Additional hours |
+| `TEST_DURATION_MINUTES` | `0` | Additional minutes |
+| `CONTROLLER_IMAGE_REPO` | Auto-detected | Controller image repository URL |

--- a/soak/bootstrap.sh
+++ b/soak/bootstrap.sh
@@ -9,6 +9,9 @@ Usage:
 Creates the prerequisite AWS resources then creates an EKS cluster and applies
 the testing infrastructure for long-term soak testing.
 
+Each invocation creates resources scoped to the given AWS_SERVICE, allowing
+multiple controllers to be soak-tested in parallel without conflicts.
+
 Example: $(basename "$0") ecr v0.0.1
 
 <AWS_SERVICE> should be an AWS Service name (ecr, sns, sqs, petstore, bookstore)
@@ -20,7 +23,7 @@ Environment variables:
                             deployed.
                             Default: us-west-2
   CLUSTER_NAME:             The name of the EKS cluster.
-                            Default: The value in the cluster-config.yaml file
+                            Default: ack-soak-<AWS_SERVICE>
   SOAK_IMAGE_REPO_NAME:     The name of the soak test ECR public repository.
                             Default: ack-\$AWS_SERVICE-soak
   OCI_BUILDER:              The binary used to build the OCI images.
@@ -55,10 +58,16 @@ TEST_INFRA_DIR="$ROOT_DIR/../test-infra"
 CONTROLLER_DIR="$ROOT_DIR/../$AWS_SERVICE-controller"
 
 ## CLUSTER CONFIGURATION
-# Path to the eksctl cluster config
-CLUSTER_CONFIG_PATH="$SOAK_DIR/cluster-config.yaml"
-# EKS cluster name if not specified in cluster config
-DEFAULT_CLUSTER_NAME="ack-soak-test"
+# Path to the eksctl cluster config template
+CLUSTER_CONFIG_TEMPLATE="$SOAK_DIR/cluster-config.yaml"
+# Generate a per-service cluster config by replacing the placeholder
+CLUSTER_CONFIG_PATH="$SOAK_DIR/cluster-config-${AWS_SERVICE}.yaml"
+sed "s/PLACEHOLDER/${AWS_SERVICE}/g" "$CLUSTER_CONFIG_TEMPLATE" > "$CLUSTER_CONFIG_PATH"
+trap 'rm -f "$CLUSTER_CONFIG_PATH"' EXIT
+
+# EKS cluster name — unique per service
+DEFAULT_CLUSTER_NAME="ack-soak-${AWS_SERVICE}"
+CLUSTER_NAME=${CLUSTER_NAME:-$DEFAULT_CLUSTER_NAME}
 # Default controller image repository URL
 DEFAULT_CONTROLLER_IMAGE_REPO="${CONTROLLER_ECR_REGISTRY}/$AWS_SERVICE-controller"
 # Controller repository URL
@@ -67,12 +76,12 @@ CONTROLLER_IMAGE_REPO=${CONTROLLER_IMAGE_REPO:-$DEFAULT_CONTROLLER_IMAGE_REPO}
 CONTROLLER_AWS_REGION="us-west-2"
 # AWS Account Id for ACK service controller
 CONTROLLER_AWS_ACCOUNT_ID=$(aws sts get-caller-identity --query "Account" --output text)
-# Release name of controller helm chart
-CONTROLLER_CHART_RELEASE_NAME="soak-test"
+# Release name of controller helm chart — unique per service
+CONTROLLER_CHART_RELEASE_NAME="soak-test-${AWS_SERVICE}"
 # Namespace for the controller and its resources
 CONTROLLER_NAMESPACE="ack-system"
 # K8s Service name for <aws-service-name>-controller
-# K8s servcie name has following format inside helm chart
+# K8s service name has following format inside helm chart
 # "{{ .Chart.Name | trimSuffix "-chart" | trunc 44 }}-controller-metrics"
 K8S_SERVICE_NAME_PREFIX=$(echo "$AWS_SERVICE" | cut -c -44)
 K8S_SERVICE_NAME="$K8S_SERVICE_NAME_PREFIX-controller-metrics"
@@ -82,21 +91,21 @@ K8S_SERVICE_NAME="$K8S_SERVICE_NAME_PREFIX-controller-metrics"
 PROM_REPO_NAME="prometheus-community"
 # Helm repository URL for the prometheus community charts
 PROM_REPO_URL="https://prometheus-community.github.io/helm-charts"
-# Release name of kube-prometheus helm chart
-PROM_CHART_RELEASE_NAME="kube-prom"
+# Release name of kube-prometheus helm chart — unique per service
+PROM_CHART_RELEASE_NAME="kube-prom-${AWS_SERVICE}"
 # Local helm repository name for the grafana repository
 GRAFANA_REPO_NAME="grafana"
 # Helm repository URL for the grafana community charts
 GRAFANA_REPO_URL="https://grafana.github.io/helm-charts"
-# Release name of loki helm chart
-LOKI_CHART_RELEASE_NAME="loki"
-# Namespace for the prometheus helm chart
-PROM_NAMESPACE="prometheus"
+# Release name of loki helm chart — unique per service
+LOKI_CHART_RELEASE_NAME="loki-${AWS_SERVICE}"
+# Namespace for the prometheus helm chart — unique per service
+PROM_NAMESPACE="prometheus-${AWS_SERVICE}"
 # Size of the Loki persistence PersistentVolumeClaim
 LOKI_PERSISTENCE_SIZE="15Gi"
 # Local port to access Prometheus dashboard
 LOCAL_PROMETHEUS_PORT=9090
-# Local port to access Prometheus dashboard
+# Local port to access Grafana dashboard
 LOCAL_GRAFANA_PORT=3000
 
 ### SOAK TEST RUNNER CONFIGURATION ###
@@ -109,8 +118,8 @@ SOAK_IMAGE_REPO_NAME=${SOAK_IMAGE_REPO_NAME:-$DEFAULT_SOAK_IMAGE_REPO_NAME}
 SOAK_IMAGE_TAG="v0.0.1"
 # Platform for soak-test-runner image.
 SOAK_IMAGE_PLATFORM="linux/amd64"
-# Release name of soak-test-runner helm chart.
-SOAK_RUNNER_CHART_RELEASE_NAME="soak-test-runner"
+# Release name of soak-test-runner helm chart — unique per service
+SOAK_RUNNER_CHART_RELEASE_NAME="soak-runner-${AWS_SERVICE}"
 
 # Total test duration is calculated as sum of TEST_DURATION_MINUTES,
 # TEST_DURATION_HOURS and TEST_DURATION_DAYS after converting them in
@@ -128,21 +137,27 @@ AWS_ECR_PUBLIC_CLI="aws --region us-east-1 ecr-public"
 
 [ ! -d "$CONTROLLER_DIR" ] && { >&2 echo "Error: Service controller directory does not exist: $CONTROLLER_DIR"; exit 1; }
 
+echo "========================================"
+echo " Soak Test Bootstrap: $AWS_SERVICE"
+echo " Controller version:  $CONTROLLER_TAG"
+echo " Cluster name:        $CLUSTER_NAME"
+echo " Region:              $DEPLOY_REGION"
+echo "========================================"
+
 # Check and create the public ECR repository
 if $AWS_ECR_PUBLIC_CLI describe-repositories --repository-name $SOAK_IMAGE_REPO_NAME > /dev/null 2>&1; then
-    echo "ECR public repository already exists"
+    echo "ECR public repository already exists: $SOAK_IMAGE_REPO_NAME"
 else
-    echo -n "Creating ECR public repository ... "
+    echo -n "Creating ECR public repository ($SOAK_IMAGE_REPO_NAME) ... "
     $AWS_ECR_PUBLIC_CLI create-repository --repository-name $SOAK_IMAGE_REPO_NAME > /dev/null 2>&1
     echo "ok."
 fi
 
-# Check and create the EKS cluster
-CLUSTER_NAME=$(yq eval -e ".metadata.name" $CLUSTER_CONFIG_PATH 2> /dev/null) || CLUSTER_NAME=$DEFAULT_CLUSTER_NAME
+# Check and create the EKS cluster (per-service)
 if $AWS_CLI eks describe-cluster --name $CLUSTER_NAME > /dev/null 2>&1; then
-    echo "EKS cluster already exists"
+    echo "EKS cluster already exists: $CLUSTER_NAME"
 else
-    echo "Creating EKS cluster ... "
+    echo "Creating EKS cluster ($CLUSTER_NAME) ... "
     eksctl create cluster -f $CLUSTER_CONFIG_PATH
     echo "ok."
 fi
@@ -156,7 +171,7 @@ CONTROLLER_SERVICE_ACCOUNT_NAME=$(yq eval -e ".iam.serviceAccounts[0].metadata.n
 if helm list -n $CONTROLLER_NAMESPACE 2> /dev/null | grep -q $CONTROLLER_CHART_RELEASE_NAME; then
     echo -n "Controller Helm release ($CONTROLLER_CHART_RELEASE_NAME) already installed in cluster. Upgrading ... "
 else
-    echo -n "Installing controller chart ... "
+    echo -n "Installing controller chart ($CONTROLLER_CHART_RELEASE_NAME) ... "
 fi
 
 helm upgrade --install --create-namespace -n $CONTROLLER_NAMESPACE \
@@ -179,12 +194,12 @@ fi
 if helm list -n $PROM_NAMESPACE 2> /dev/null | grep -q $PROM_CHART_RELEASE_NAME; then
     echo "Prometheus Helm release ($PROM_CHART_RELEASE_NAME) already installed in cluster. Upgrading ... "
 else
-    echo -n "Installing Prometheus chart ... "
+    echo -n "Installing Prometheus chart ($PROM_CHART_RELEASE_NAME) ... "
 fi
 
 helm upgrade --install --create-namespace -n $PROM_NAMESPACE \
-    --set prometheus.prometheusSpec.additionalScrapeConfigs[0].job_name="ack-controller" \
-    --set prometheus.prometheusSpec.additionalScrapeConfigs[0].static_configs[0].targets[0]="$AWS_SERVICE-controller-metrics.ack-system:8080" \
+    --set prometheus.prometheusSpec.additionalScrapeConfigs[0].job_name="ack-controller-${AWS_SERVICE}" \
+    --set prometheus.prometheusSpec.additionalScrapeConfigs[0].static_configs[0].targets[0]="$K8S_SERVICE_NAME.ack-system:8080" \
     $PROM_CHART_RELEASE_NAME $PROM_REPO_NAME/kube-prometheus-stack 1> /dev/null
 echo "ok."
 
@@ -198,7 +213,7 @@ fi
 if helm list -n $PROM_NAMESPACE 2> /dev/null | grep -q $LOKI_CHART_RELEASE_NAME; then
     echo "Loki Helm release ($LOKI_CHART_RELEASE_NAME) already installed in cluster. Upgrading ... "
 else
-    echo -n "Installing Loki chart ... "
+    echo -n "Installing Loki chart ($LOKI_CHART_RELEASE_NAME) ... "
 fi
 
 helm upgrade --install -n $PROM_NAMESPACE --create-namespace  \
@@ -207,6 +222,7 @@ helm upgrade --install -n $PROM_NAMESPACE --create-namespace  \
     --set loki.persistence.enabled=true \
     --set loki.persistence.storageClassName=gp2 \
     --set loki.persistence.size="$LOKI_PERSISTENCE_SIZE" \
+    --set loki.isDefault=false \
     $LOKI_CHART_RELEASE_NAME $GRAFANA_REPO_NAME/loki-stack 1> /dev/null
 echo "ok."
 
@@ -218,13 +234,18 @@ SOAK_IMAGE_REPO_URI="$($AWS_ECR_PUBLIC_CLI describe-repositories --repository-na
     { >&2 echo "Error: Could not get the soak test image repository URI"; exit 1; }
 
 echo "Building soak test image ... "
+# Log out of ECR public before building to avoid credential conflicts when
+# pulling the base image from public.ecr.aws
+$OCI_BUILDER logout public.ecr.aws 1> /dev/null 2>&1 || true
 $OCI_BUILDER build --platform $SOAK_IMAGE_PLATFORM -t $SOAK_IMAGE_REPO_URI:$SOAK_IMAGE_TAG \
-    --build-arg AWS_SERVICE=$AWS_SERVICE --build-arg E2E_GIT_REF=$CONTROLLER_TAG "$TEST_INFRA_DIR/soak"
+    --build-arg AWS_SERVICE=$AWS_SERVICE --build-arg E2E_GIT_REF=$CONTROLLER_TAG "$SOAK_DIR"
 echo "ok."
 
 echo -n "Pushing soak test image to ECR public ... "
 $AWS_ECR_PUBLIC_CLI get-login-password | $OCI_BUILDER login --username AWS --password-stdin public.ecr.aws 1> /dev/null 2>&1
 $OCI_BUILDER push $SOAK_IMAGE_REPO_URI:$SOAK_IMAGE_TAG 1> /dev/null
+# Log out after push so future docker operations aren't affected
+$OCI_BUILDER logout public.ecr.aws 1> /dev/null 2>&1 || true
 echo "ok."
 
 # Install the soak test runner
@@ -238,7 +259,7 @@ if helm list -n $CONTROLLER_NAMESPACE 2> /dev/null | grep -q $SOAK_RUNNER_CHART_
     echo "ok."
 fi
 
-echo -n "Installing soak test chart ... "
+echo -n "Installing soak test chart ($SOAK_RUNNER_CHART_RELEASE_NAME) ... "
 helm upgrade --install --create-namespace -n $CONTROLLER_NAMESPACE \
     --set awsService=$AWS_SERVICE --set soak.imageRepo=$SOAK_IMAGE_REPO_URI \
     --set soak.imageTag=$SOAK_IMAGE_TAG --set soak.startTimeEpochSeconds=$(date +%s) \
@@ -247,9 +268,28 @@ helm upgrade --install --create-namespace -n $CONTROLLER_NAMESPACE \
 echo "ok."
 
 # Final messages and links
-echo "Your soak test cluster should now be operational and actively running tests"
+echo ""
+echo "========================================"
+echo " Soak test is running: $AWS_SERVICE $CONTROLLER_TAG"
+echo "========================================"
+echo ""
+echo "Resources created (all scoped to '$AWS_SERVICE'):"
+echo "  EKS Cluster:      $CLUSTER_NAME"
+echo "  ECR Repo:         $SOAK_IMAGE_REPO_NAME"
+echo "  Controller Helm:  $CONTROLLER_CHART_RELEASE_NAME"
+echo "  Soak Runner Helm: $SOAK_RUNNER_CHART_RELEASE_NAME"
+echo "  Prometheus NS:    $PROM_NAMESPACE"
+echo ""
 echo "To port-forward your Grafana dashboard use the following command:"
 echo "    kubectl port-forward -n $PROM_NAMESPACE service/$PROM_CHART_RELEASE_NAME-grafana $LOCAL_GRAFANA_PORT:80 --address='0.0.0.0' >/dev/null &"
 echo "Then navigate to http://localhost:$LOCAL_GRAFANA_PORT/"
 echo ""
-echo "The default username is \"admin\" and the default password is \"prom-operator\""
+echo "To check soak test status:"
+echo "    kubectl get jobs -n $CONTROLLER_NAMESPACE | grep $AWS_SERVICE"
+echo "    kubectl logs -n $CONTROLLER_NAMESPACE -f job/$AWS_SERVICE-soak-test"
+echo ""
+echo "To tear down when done:"
+echo "    helm uninstall $SOAK_RUNNER_CHART_RELEASE_NAME -n $CONTROLLER_NAMESPACE"
+echo "    helm uninstall $CONTROLLER_CHART_RELEASE_NAME -n $CONTROLLER_NAMESPACE"
+echo "    eksctl delete cluster --name $CLUSTER_NAME --region $DEPLOY_REGION"
+echo "    aws --region us-east-1 ecr-public delete-repository --repository-name $SOAK_IMAGE_REPO_NAME --force"

--- a/soak/cluster-config.yaml
+++ b/soak/cluster-config.yaml
@@ -2,7 +2,7 @@ apiVersion: eksctl.io/v1alpha5
 kind: ClusterConfig
 
 metadata:
-  name: ack-soak-test
+  name: ack-soak-PLACEHOLDER
   region: us-west-2
 
 managedNodeGroups:

--- a/soak/dashboards.sh
+++ b/soak/dashboards.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+
+set -o pipefail
+
+USAGE="
+Usage:
+  $(basename "$0")
+
+Discovers all running ACK soak test clusters (named ack-soak-*), port-forwards
+each Grafana dashboard on an auto-assigned port, and prints links to open in
+a browser.
+
+Environment variables:
+  DEPLOY_REGION:    The AWS region to scan for soak clusters.
+                    Default: us-west-2
+  BASE_PORT:        Starting port number for Grafana port-forwards.
+                    Default: 3000
+"
+
+DEPLOY_REGION=${DEPLOY_REGION:-"us-west-2"}
+BASE_PORT=${BASE_PORT:-3000}
+
+# Kill any existing port-forwards on our port range to avoid conflicts
+pkill -f "kubectl.*port-forward.*grafana" 2>/dev/null || true
+sleep 1
+
+# Find all EKS clusters matching the soak naming convention
+# Excludes the legacy "ack-soak-test" cluster name
+echo "Scanning for soak test clusters in $DEPLOY_REGION ..."
+ALL_CLUSTERS=$(aws eks list-clusters --region $DEPLOY_REGION --query "clusters[?starts_with(@, 'ack-soak-')]" --output text 2>/dev/null)
+CLUSTERS=""
+for c in $ALL_CLUSTERS; do
+    # Skip the old hardcoded name
+    [ "$c" = "ack-soak-test" ] && continue
+    CLUSTERS="$CLUSTERS $c"
+done
+CLUSTERS=$(echo "$CLUSTERS" | xargs)
+
+if [ -z "$CLUSTERS" ]; then
+    echo "No soak test clusters found (looking for clusters named ack-soak-*)."
+    exit 0
+fi
+
+PORT=$BASE_PORT
+echo ""
+echo "========================================"
+echo " ACK Soak Test Dashboards"
+echo "========================================"
+echo ""
+
+for CLUSTER in $CLUSTERS; do
+    # Extract service name from cluster name (ack-soak-<service>)
+    SERVICE=$(echo "$CLUSTER" | sed 's/^ack-soak-//')
+
+    # Update kubeconfig for this cluster
+    aws eks update-kubeconfig --name "$CLUSTER" --region "$DEPLOY_REGION" --alias "$CLUSTER" > /dev/null 2>&1
+
+    # Find the Grafana service — try service-specific namespace first, then fallback
+    PROM_NS="prometheus-${SERVICE}"
+    GRAFANA_SVC=$(kubectl --context "$CLUSTER" get svc -n "$PROM_NS" -o name 2>/dev/null | grep grafana | head -1)
+
+    # Fallback: check the "prometheus" namespace (for clusters created with old naming)
+    if [ -z "$GRAFANA_SVC" ]; then
+        PROM_NS="prometheus"
+        GRAFANA_SVC=$(kubectl --context "$CLUSTER" get svc -n "$PROM_NS" -o name 2>/dev/null | grep grafana | head -1)
+    fi
+
+    if [ -z "$GRAFANA_SVC" ]; then
+        echo "  ⚠  $CLUSTER: Grafana service not found, skipping"
+        echo ""
+        continue
+    fi
+
+    # Get password from the grafana secret
+    SECRET_NAME=$(kubectl --context "$CLUSTER" get secrets -n "$PROM_NS" -o name 2>/dev/null | grep grafana | head -1)
+    PASSWORD=""
+    if [ -n "$SECRET_NAME" ]; then
+        PASSWORD=$(kubectl --context "$CLUSTER" get "$SECRET_NAME" -n "$PROM_NS" -o jsonpath='{.data.admin-password}' 2>/dev/null | base64 -d 2>/dev/null)
+    fi
+    if [ -z "$PASSWORD" ]; then
+        PASSWORD="(could not retrieve)"
+    fi
+
+    # Port-forward in background
+    kubectl --context "$CLUSTER" port-forward -n "$PROM_NS" "$GRAFANA_SVC" "$PORT:80" --address='0.0.0.0' >/dev/null 2>&1 &
+
+    # Check soak test job status — try service-named job, fallback to listing
+    JOB_STATUS=$(kubectl --context "$CLUSTER" get jobs -n ack-system -o jsonpath='{.items[0].status.conditions[0].type}' 2>/dev/null || echo "Running")
+
+    echo "  $SERVICE"
+    echo "    Cluster:   $CLUSTER"
+    echo "    Dashboard: http://localhost:${PORT}/"
+    echo "    Creds:     admin / $PASSWORD"
+    echo "    Soak Job:  $JOB_STATUS"
+    echo ""
+
+    PORT=$((PORT + 1))
+done
+
+echo "========================================"
+echo " All dashboards are port-forwarded."
+echo " Stop with: pkill -f 'kubectl port-forward.*grafana'"
+echo "========================================"

--- a/soak/prow/scripts/soak-on-release.sh
+++ b/soak/prow/scripts/soak-on-release.sh
@@ -78,10 +78,11 @@ AWS_ACCOUNT_ID=$(aws sts get-caller-identity --query "Account" --output text)
 export AWS_ACCOUNT_ID
 echo "soak-on-release.sh] [SETUP] Exported ACCOUNT_ID."
 
-aws eks update-kubeconfig --name soak-test-cluster >/dev/null
+SOAK_CLUSTER_NAME="ack-soak-${AWS_SERVICE}"
+aws eks update-kubeconfig --name $SOAK_CLUSTER_NAME >/dev/null
 # Use 'default' namespace by default and not 'test-pods' during helm commands.
 kubectl config set-context --current --namespace=default >/dev/null
-echo "soak-on-release.sh] [INFO] Updated the kubeconfig to communicate with 'soak-test-cluster' eks cluster."
+echo "soak-on-release.sh] [INFO] Updated the kubeconfig to communicate with '$SOAK_CLUSTER_NAME' eks cluster."
 
 export HELM_EXPERIMENTAL_OCI=1
 cd "$SERVICE_CONTROLLER_DIR"/helm
@@ -99,9 +100,9 @@ yq eval "$SERVICE_ACCOUNT_ANNOTATION_EVAL" -i values.yaml \
 && yq eval "$AWS_REGION_EVAL" -i values.yaml \
 && yq eval "$AWS_ACCOUNT_ID_EVAL" -i values.yaml
 
-export CONTROLLER_CHART_RELEASE_NAME="soak-test"
-chart_name=$(helm list -f '^soak-test$' -o json | jq -r '.[]|.name')
-[[ -n $chart_name ]] && echo "Chart soak-test already exists. Uninstalling..." && helm uninstall $CONTROLLER_CHART_RELEASE_NAME
+export CONTROLLER_CHART_RELEASE_NAME="soak-test-${AWS_SERVICE}"
+chart_name=$(helm list -f "^soak-test-${AWS_SERVICE}$" -o json | jq -r '.[]|.name')
+[[ -n $chart_name ]] && echo "Chart $CONTROLLER_CHART_RELEASE_NAME already exists. Uninstalling..." && helm uninstall $CONTROLLER_CHART_RELEASE_NAME
 helm install $CONTROLLER_CHART_RELEASE_NAME . >/dev/null
 echo "soak-on-release.sh] [INFO] Helm chart $CONTROLLER_CHART_RELEASE_NAME successfully installed."
 
@@ -119,10 +120,10 @@ buildah push $SOAK_RUNNER_IMAGE >/dev/null
 echo "soak-on-release.sh] [INFO] Successfully built and pushed soak runner image $SOAK_RUNNER_IMAGE"
 
 # Check for already existing soak-test-runner helm chart
-export SOAK_CHART_RELEASE_NAME="soak-test-runner"
-chart_name=$(helm list -f '^soak-test-runner$' -o json | jq -r '.[]|.name')
+export SOAK_CHART_RELEASE_NAME="soak-runner-${AWS_SERVICE}"
+chart_name=$(helm list -f "^soak-runner-${AWS_SERVICE}$" -o json | jq -r '.[]|.name')
 [[ -n $chart_name ]] \
-&& echo "soak-on-release.sh] [INFO] Chart soak-test-runner already exists. Uninstalling..." \
+&& echo "soak-on-release.sh] [INFO] Chart $SOAK_CHART_RELEASE_NAME already exists. Uninstalling..." \
 && helm uninstall $SOAK_CHART_RELEASE_NAME >/dev/null
 
 cd "$TEST_INFRA_DIR"/soak/helm/ack-soak-test

--- a/soak/teardown.sh
+++ b/soak/teardown.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+
+set -eo pipefail
+
+USAGE="
+Usage:
+  $(basename "$0") <AWS_SERVICE>
+
+Tears down all soak test resources for the given AWS service controller.
+This removes the EKS cluster, ECR repository, and all Helm releases
+created by bootstrap.sh.
+
+Example: $(basename "$0") ecr
+
+Environment variables:
+  DEPLOY_REGION:    The AWS region where resources were deployed.
+                    Default: us-west-2
+  CLUSTER_NAME:     The name of the EKS cluster to delete.
+                    Default: ack-soak-<AWS_SERVICE>
+"
+
+if [ $# -ne 1 ]; then
+    echo "Script requires one parameter: the AWS service name" 1>&2
+    echo "${USAGE}"
+    exit 1
+fi
+
+AWS_SERVICE=$(echo "$1" | tr '[:upper:]' '[:lower:]')
+DEPLOY_REGION=${DEPLOY_REGION:-"us-west-2"}
+CLUSTER_NAME=${CLUSTER_NAME:-"ack-soak-${AWS_SERVICE}"}
+SOAK_IMAGE_REPO_NAME="ack-${AWS_SERVICE}-soak"
+
+AWS_CLI="aws --region $DEPLOY_REGION"
+AWS_ECR_PUBLIC_CLI="aws --region us-east-1 ecr-public"
+
+echo "========================================"
+echo " Soak Test Teardown: $AWS_SERVICE"
+echo " Cluster:  $CLUSTER_NAME"
+echo " Region:   $DEPLOY_REGION"
+echo "========================================"
+echo ""
+
+# Delete the EKS cluster (this removes nodegroups, IAM roles, CloudFormation stacks, etc.)
+if $AWS_CLI eks describe-cluster --name $CLUSTER_NAME > /dev/null 2>&1; then
+    echo "Deleting EKS cluster ($CLUSTER_NAME) ... "
+    eksctl delete cluster --name $CLUSTER_NAME --region $DEPLOY_REGION --wait
+    echo "ok."
+else
+    echo "EKS cluster $CLUSTER_NAME does not exist. Skipping cluster deletion."
+fi
+
+# Delete the ECR public repository
+echo -n "Deleting ECR public repository ($SOAK_IMAGE_REPO_NAME) ... "
+$AWS_ECR_PUBLIC_CLI delete-repository --repository-name $SOAK_IMAGE_REPO_NAME --force > /dev/null 2>&1 && echo "ok." || echo "not found."
+
+echo ""
+echo "========================================"
+echo " Teardown complete: $AWS_SERVICE"
+echo "========================================"


### PR DESCRIPTION
## Summary

Disambiguates all soak test resources by service name, enabling multiple controllers to be soak-tested in parallel without conflicts.

## Changes

- **bootstrap.sh**: All resource names now include the service name (cluster, Helm releases, Prometheus namespace, etc.). Added ECR public logout before/after Docker operations to fix credential conflict.
- **cluster-config.yaml**: Converted to a template with `PLACEHOLDER` that gets substituted per service (e.g., `ack-soak-s3`, `ack-soak-ecr`).
- **prow/scripts/soak-on-release.sh**: Updated cluster name, controller release name, and soak runner release name to use per-service naming.
- **teardown.sh** (new): One-command cleanup script that deletes the EKS cluster and ECR repo for a given service.
- **README.md**: Documented parallel testing model, resource naming conventions, and teardown steps.

## Resource Naming Convention

| Resource | Pattern |
|----------|---------|
| EKS Cluster | `ack-soak-<service>` |
| ECR Public Repo | `ack-<service>-soak` |
| Controller Helm Release | `soak-test-<service>` |
| Soak Runner Helm Release | `soak-runner-<service>` |
| Prometheus Namespace | `prometheus-<service>` |

## Testing

- Ran `./bootstrap.sh autoscaling v0.2.0` — successfully created `ack-soak-autoscaling` cluster
- Ran `./bootstrap.sh emrserverless v0.2.0` in parallel — creates independent `ack-soak-emrserverless` cluster
- Verified both soak tests run independently without resource conflicts