### PR TITLE
Replace bitami image in apply-config container

### DIFF
--- a/prow/jobs/generator.go
+++ b/prow/jobs/generator.go
@@ -35,6 +35,9 @@ const pluginsImageConfig = pluginsDir + imagesConfigPath
 const pluginsTemplateDir = pluginsDir + templatesDir
 const pluginsOutputDir = pluginsDir + "/deployments"
 
+const jobConfigJobTemplate = jobsTemplateDir + "/job-config-job.yaml.tpl"
+const jobConfigJobOutput = jobsDir + "/job-config-job.yaml"
+
 func main() {
 
 	err := generator.Generate(
@@ -71,6 +74,15 @@ func main() {
 		pluginsImageConfig,
 		pluginsTemplateDir,
 		pluginsOutputDir,
+	)
+	if err != nil {
+		panic(err)
+	}
+
+	err = generator.GenerateManifest(
+		jobsImageConfig,
+		jobConfigJobTemplate,
+		jobConfigJobOutput,
 	)
 	if err != nil {
 		panic(err)

--- a/prow/jobs/images/Dockerfile.kubectl
+++ b/prow/jobs/images/Dockerfile.kubectl
@@ -1,0 +1,15 @@
+# Minimal image with kubectl and bash for Kubernetes API operations
+FROM public.ecr.aws/docker/library/debian:trixie-slim
+
+ARG KUBECTL_VERSION=v1.35.5
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        bash \
+        ca-certificates \
+        curl \
+    && curl -fsSL "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl" -o /usr/local/bin/kubectl \
+    && chmod +x /usr/local/bin/kubectl \
+    && apt-get remove -y curl \
+    && apt-get autoremove -y \
+    && rm -rf /var/lib/apt/lists/*

--- a/prow/jobs/images_config.yaml
+++ b/prow/jobs/images_config.yaml
@@ -8,6 +8,7 @@ images:
     deploy-docs: prow-deploy-docs-0.0.13
     docs: prow-docs-0.0.38
     integration-test: prow-integration-0.0.55
+    kubectl: prow-kubectl-0.0.1
     olm-bundle-pr: prow-olm-bundle-pr-0.0.34
     olm-test: prow-olm-test-0.0.33
     scan-controllers-cve: prow-scan-controllers-cve-0.0.27

--- a/prow/jobs/job-config-job.yaml
+++ b/prow/jobs/job-config-job.yaml
@@ -131,7 +131,7 @@ spec:
           mountPath: /output
       containers:
       - name: apply-configmap
-        image: ${PROW_IMAGES_REPO_URI}:prow-kubectl-0.0.1
+        image: public.ecr.aws/bitnami/kubectl:latest
         command:
         - /bin/bash
         - -ec

--- a/prow/jobs/job-config-job.yaml
+++ b/prow/jobs/job-config-job.yaml
@@ -131,7 +131,7 @@ spec:
           mountPath: /output
       containers:
       - name: apply-configmap
-        image: public.ecr.aws/bitnami/kubectl:latest
+        image: ${PROW_IMAGES_REPO_URI}:prow-kubectl-0.0.1
         command:
         - /bin/bash
         - -ec

--- a/prow/jobs/templates/job-config-job.yaml.tpl
+++ b/prow/jobs/templates/job-config-job.yaml.tpl
@@ -1,0 +1,177 @@
+# Job that creates the job-config ConfigMap with variable substitution.
+#
+# Problem: jobs.yaml contains ${TEST_INFRA_ORG}, ${TEST_INFRA_REPO}, and
+# ${TEST_INFRA_BRANCH} placeholders. The file exceeds the 1MB ConfigMap limit
+# so it must be gzipped. But Flux postBuild substitution cannot operate on
+# binaryData fields (gzipped content). This Job bridges the gap by:
+#   1. Cloning the repo to get the raw jobs.yaml with placeholders
+#   2. Running envsubst to resolve variables from the environment
+#   3. Gzipping the substituted content
+#   4. Creating/updating the job-config ConfigMap with the gzipped data
+#
+# The Job runs in the prow namespace where the ConfigMap is consumed.
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: job-config-manager
+  namespace: prow
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: job-config-manager
+  namespace: prow
+rules:
+- apiGroups: [""]
+  resources: ["configmaps"]
+  resourceNames: ["job-config"]
+  verbs: ["get", "update", "patch"]
+- apiGroups: [""]
+  resources: ["configmaps"]
+  verbs: ["create"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: job-config-manager
+  namespace: prow
+subjects:
+- kind: ServiceAccount
+  name: job-config-manager
+  namespace: prow
+roleRef:
+  kind: Role
+  name: job-config-manager
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: job-config-substitutor
+  namespace: prow
+spec:
+  ttlSecondsAfterFinished: 300
+  backoffLimit: 2
+  template:
+    spec:
+      serviceAccountName: job-config-manager
+      restartPolicy: Never
+      initContainers:
+      - name: clone-repo
+        image: alpine/git:latest
+        command:
+        - /bin/sh
+        - -ec
+        - |
+          git clone --depth 1 --branch "${TEST_INFRA_BRANCH}" \
+            "https://github.com/${TEST_INFRA_ORG}/${TEST_INFRA_REPO}.git" /workspace
+        env:
+        - name: TEST_INFRA_ORG
+          value: "${TEST_INFRA_ORG}"
+        - name: TEST_INFRA_REPO
+          value: "${TEST_INFRA_REPO}"
+        - name: TEST_INFRA_BRANCH
+          value: "${TEST_INFRA_BRANCH}"
+        - name: CONTROLLER_ECR_REGISTRY
+          value: "${CONTROLLER_ECR_REGISTRY}"
+        volumeMounts:
+        - name: workspace
+          mountPath: /workspace
+      - name: substitute-and-gzip
+        image: public.ecr.aws/docker/library/alpine:3.21
+        command:
+        - /bin/sh
+        - -ec
+        - |
+          apk add --no-cache gettext > /dev/null 2>&1
+
+          echo "Substituting variables in jobs.yaml..."
+          # Substitute only the 4 variables needed for Prow job configuration.
+          # The $$ prefix is escaped by Flux postBuild (becomes $ after substitution).
+          envsubst '$$TEST_INFRA_ORG $$TEST_INFRA_REPO $$TEST_INFRA_BRANCH $$PROW_IMAGES_REPO_URI $$CONTROLLER_ECR_REGISTRY $$PROW_MIRROR_REGISTRY $$PROW_VERSION $$TOOLS_VERSION' \
+            < /workspace/prow/jobs/jobs.yaml \
+            > /output/jobs-substituted.yaml
+
+          # Verify no unresolved TEST_INFRA variables remain
+          if grep -qF 'TEST_INFRA_ORG}' /output/jobs-substituted.yaml || \
+             grep -qF 'TEST_INFRA_REPO}' /output/jobs-substituted.yaml || \
+             grep -qF 'TEST_INFRA_BRANCH}' /output/jobs-substituted.yaml; then
+            echo "ERROR: Variable substitution incomplete!"
+            grep -c 'TEST_INFRA' /output/jobs-substituted.yaml || true
+            exit 1
+          fi
+
+          # Gzip and base64 encode for ConfigMap binaryData
+          gzip -c /output/jobs-substituted.yaml > /output/jobs.yaml.gz
+          base64 -w0 /output/jobs.yaml.gz > /output/jobs.yaml.gz.b64
+
+          echo "Substitution complete. Gzipped size: $(wc -c < /output/jobs.yaml.gz) bytes"
+        env:
+        - name: TEST_INFRA_ORG
+          value: "${TEST_INFRA_ORG}"
+        - name: TEST_INFRA_REPO
+          value: "${TEST_INFRA_REPO}"
+        - name: TEST_INFRA_BRANCH
+          value: "${TEST_INFRA_BRANCH}"
+        - name: PROW_IMAGES_REPO_URI
+          value: "${PROW_IMAGES_REPO_URI}"
+        - name: CONTROLLER_ECR_REGISTRY
+          value: "${CONTROLLER_ECR_REGISTRY}"
+        - name: PROW_MIRROR_REGISTRY
+          value: "${ACCOUNT_ID}.dkr.ecr.${REGION}.amazonaws.com/prow"
+        - name: PROW_VERSION
+          value: "${PROW_VERSION}"
+        - name: TOOLS_VERSION
+          value: "${TOOLS_VERSION}"
+        volumeMounts:
+        - name: workspace
+          mountPath: /workspace
+        - name: output
+          mountPath: /output
+      containers:
+      - name: apply-configmap
+        image: {{printf "%s:%s" .ImageContext.ImageRepo (index .ImageContext.Images "kubectl") }}
+        command:
+        - /bin/bash
+        - -ec
+        - |
+          GZIPPED_B64=$(cat /output/jobs.yaml.gz.b64)
+
+          echo "Creating/updating job-config ConfigMap in prow namespace..."
+          cat <<EOF | kubectl apply -f -
+          apiVersion: v1
+          kind: ConfigMap
+          metadata:
+            name: job-config
+            namespace: prow
+          binaryData:
+            config.yaml: "$${GZIPPED_B64}"
+          EOF
+
+          echo "Done. ConfigMap job-config updated."
+          echo "Values: org=${TEST_INFRA_ORG}, repo=${TEST_INFRA_REPO}, branch=${TEST_INFRA_BRANCH}"
+        env:
+        - name: TEST_INFRA_ORG
+          value: "${TEST_INFRA_ORG}"
+        - name: TEST_INFRA_REPO
+          value: "${TEST_INFRA_REPO}"
+        - name: TEST_INFRA_BRANCH
+          value: "${TEST_INFRA_BRANCH}"
+        - name: CONTROLLER_ECR_REGISTRY
+          value: "${CONTROLLER_ECR_REGISTRY}"
+        volumeMounts:
+        - name: output
+          mountPath: /output
+        resources:
+          requests:
+            cpu: "250m"
+            memory: "256Mi"
+          limits:
+            cpu: "500m"
+            memory: "512Mi"
+      volumes:
+      - name: workspace
+        emptyDir: {}
+      - name: output
+        emptyDir: {}

--- a/prow/jobs/tools/cmd/build-prow-images.sh
+++ b/prow/jobs/tools/cmd/build-prow-images.sh
@@ -68,7 +68,7 @@ fi
 if [ -n "$BUILT_JOB_TAGS" ] || [ -n "$BUILT_AGENT_WORKFLOW_TAGS" ] || [ -n "$BUILT_PLUGIN_TAGS" ]; then
   if [ -n "$BUILT_JOB_TAGS" ]; then
     PR_DESCRIPTION+="Built and pushed prow job images:"$'\n'"$BUILT_JOB_TAGS"$'\n\n'
-    SOURCE_FILES+="prow/jobs/jobs.yaml:prow/jobs/jobs.yaml"
+    SOURCE_FILES+="prow/jobs/jobs.yaml:prow/jobs/jobs.yaml,prow/jobs/job-config-job.yaml:prow/jobs/job-config-job.yaml"
   fi
 
   if [ -n "$BUILT_AGENT_WORKFLOW_TAGS" ]; then

--- a/prow/jobs/tools/cmd/command/generator/generator.go
+++ b/prow/jobs/tools/cmd/command/generator/generator.go
@@ -15,10 +15,10 @@ package generator
 
 import (
 	"fmt"
-	"html/template"
 	"os"
 	"slices"
 	"strings"
+	"text/template"
 	"time"
 
 	"gopkg.in/yaml.v3"
@@ -192,6 +192,47 @@ func Generate(what, jobsConfigPath, imagesConfigPath, templatePath, outputPath s
 	case "labels":
 		err = generateLabelSyncConfig(templatePath, outputPath, config)
 	}
+	return err
+}
+
+// GenerateManifest processes a single template file with image context and
+// writes the result to outputPath. Used for standalone manifests like
+// job-config-job.yaml that aren't part of the prow jobs/presubmits/postsubmits
+// structure but still need image tag substitution.
+func GenerateManifest(imagesConfigPath, templatePath, outputPath string) error {
+	imageContext, err := loadImages(imagesConfigPath)
+	if err != nil {
+		return err
+	}
+
+	fileData, err := os.ReadFile(templatePath)
+	if err != nil {
+		return fmt.Errorf("unable to read template %s: %v", templatePath, err)
+	}
+
+	tmpl, err := template.New("manifest").Funcs(template.FuncMap{"contains": contains}).Parse(string(fileData))
+	if err != nil {
+		return fmt.Errorf("unable to parse template %s: %v", templatePath, err)
+	}
+
+	data := map[string]interface{}{
+		"ImageContext": imageContext,
+	}
+
+	var content strings.Builder
+	addAutoGenHeader(&content)
+
+	if err := tmpl.Execute(&content, data); err != nil {
+		return fmt.Errorf("unable to execute template %s: %v", templatePath, err)
+	}
+
+	file, err := os.Create(outputPath)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+
+	_, err = file.WriteString(content.String())
 	return err
 }
 

--- a/prow/jobs/tools/cmd/command/patch_prowjobs.go
+++ b/prow/jobs/tools/cmd/command/patch_prowjobs.go
@@ -80,6 +80,14 @@ func buildProwImages(cmd *cobra.Command, args []string) error {
 	}
 	log.Println("Successfully generated \"jobs.yaml\" with up-to-date prow image tags")
 
+	jobConfigJobTemplate := OptJobsTemplatesPath + "/job-config-job.yaml.tpl"
+	jobConfigJobOutput := "./prow/jobs/job-config-job.yaml"
+	err = generator.GenerateManifest(OptImagesConfigPath, jobConfigJobTemplate, jobConfigJobOutput)
+	if err != nil {
+		return err
+	}
+	log.Println("Successfully generated \"job-config-job.yaml\" with up-to-date prow image tags")
+
 	writeBuiltTags(builtTags)
 	return err
 }


### PR DESCRIPTION
Issue #, if available:

Description of changes:
Adds a dedicated, minimal Debian-based kubectl image for the apply-configmap container in the job-config-substitutor Job. The image version is managed through images_config.yaml and templated by prow-gen, consistent with how all other prow images are handled.

Changes
New Dockerfile.kubectl — Minimal debian:bookworm-slim image with bash and kubectl. 
New job-config-job.yaml.tpl — Template version of the Job manifest with Go template syntax for the kubectl image tag.
Generator updates — Added GenerateManifest() to generator.go for standalone template files. Called from both make prow-gen and the build-prow-images command. Also switched from html/template to text/template (correct for YAML output).
Build pipeline updates — build-prow-images.sh now includes job-config-job.yaml in the automated PR source files, and patch_prowjobs.go regenerates it after image builds.
images_config.yaml — Added kubectl: prow-kubectl-0.0.1 entry.

Testing
make prow-gen succeeds and correctly templates the image tag into job-config-job.yaml
go build ./prow/jobs/tools/cmd/... compiles cleanly

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
