### PR TITLE
soak: install EBS CSI driver so controller logs are persisted

### DIFF
--- a/soak/README.md
+++ b/soak/README.md
@@ -77,9 +77,11 @@ Run the `bootstrap.sh` script in the current directory. This script will do the
 following: 
 1. Create an ECR public repository for the soak test runner (`ack-<service>-soak`)
 1. Create an EKS cluster named `ack-soak-<service>` with the default soak test
-   configuration (from `cluster-config.yaml`)
+   configuration (from `cluster-config.yaml`). This includes the EBS CSI driver
+   addon (with an EKS Pod Identity association), which is required to provision
+   the persistent volume that stores controller logs in Loki.
 1. Install the controller Helm chart (`soak-test-<service>`)
-1. Install Prometheus and Grafana in namespace `prometheus-<service>`
+1. Install Prometheus, Grafana, and Loki in namespace `prometheus-<service>`
 1. Install the custom ACK soak test Grafana dashboard (from
    `./monitoring/grafana/ack-dashboard-source.json`)
 1. Build and push the soak test runner image
@@ -162,6 +164,62 @@ To stop all port-forwards:
 ```bash
 pkill -f 'kubectl port-forward.*grafana'
 ```
+
+### Investigating test failures
+
+Controller and test-runner logs are shipped by Promtail and stored in Loki on a
+persistent volume (provisioned by the EBS CSI driver installed with the
+cluster). Because the logs are persisted, you can investigate a failed test run
+even after the controller pod restarts — for the lifetime of the cluster.
+
+> **Note:** Logs live only as long as the cluster. The Loki volume uses
+> `reclaimPolicy: Delete`, so investigate before tearing the cluster down.
+
+**Option A — Grafana (Explore view):**
+
+1. Open the service's Grafana (see Step 2 or run `./dashboards.sh`).
+2. Go to `Explore` and select the `Loki` datasource.
+3. Run a LogQL query. Useful examples:
+   ```logql
+   # All controller logs
+   {namespace="ack-system", container="controller"}
+
+   # Only controller errors
+   {namespace="ack-system", container="controller"} |= "\"level\":\"error\""
+
+   # Test-runner (pytest) output
+   {namespace="ack-system", pod=~"<service>-soak-test.*"}
+   ```
+4. Use the time picker to narrow to the window of the failed iteration.
+
+**Option B — Loki API (scriptable):**
+
+Query Loki directly from inside the Loki pod (no extra port-forward needed):
+```bash
+NS=prometheus-<service>
+LOKI_POD=loki-<service>-0
+
+# Find the controller pod name
+CTRL_POD=$(kubectl get pods -n ack-system --no-headers | grep chart | awk '{print $1}')
+
+# Query the last 30 minutes of controller logs
+END=$(date +%s)000000000
+START=$(( $(date +%s) - 1800 ))000000000
+kubectl exec -n "$NS" "$LOKI_POD" -- \
+  wget -qO- "http://localhost:3100/loki/api/v1/query_range?query=%7Bpod%3D%22${CTRL_POD}%22%7D&start=${START}&end=${END}&limit=2000&direction=backward"
+```
+
+**Correlating a failed test with controller activity:**
+
+1. From the test-runner stream, find the timestamp of the failing iteration
+   (look for the pytest summary line, e.g. `1 failed, 2 passed ...`).
+2. Query the controller stream (`{pod="<controller-pod>"}`) for the same time
+   window to see exactly what the controller did — `created/updated/deleted
+   resource`, `desired resource state has changed` deltas, and any
+   `Reconciler error` / AWS API exceptions.
+
+This is the fastest way to root-cause issues like reconciliation churn, stuck
+resources, or AWS-side errors that surface as test failures.
 
 ### Step 5 (Tear down resources)
 

--- a/soak/cluster-config.yaml
+++ b/soak/cluster-config.yaml
@@ -25,3 +25,14 @@ iam:
       namespace: ack-system
     attachPolicyARNs:
     - "arn:aws:iam::aws:policy/AdministratorAccess"
+
+# The EBS CSI driver is required so the monitoring stack's Loki
+# PersistentVolumeClaim can be dynamically provisioned. Without it the Loki
+# pod stays Pending and controller logs are never persisted for the soak run.
+# Permissions are granted via an EKS Pod Identity association (eksctl
+# automatically installs the eks-pod-identity-agent addon as a prerequisite
+# and creates the IAM role using the well-known EBS CSI controller policy).
+addons:
+- name: eks-pod-identity-agent
+- name: aws-ebs-csi-driver
+  useDefaultPodIdentityAssociations: true


### PR DESCRIPTION
## Problem

The soak monitoring stack deploys Loki with a 15Gi `PersistentVolumeClaim` to persist controller and test-runner logs. But the soak EKS clusters had **no EBS CSI driver**, so the `gp2` PVC never bound — the Loki pod stayed `Pending` indefinitely and **no logs were persisted**.

The only logs available were ephemeral `kubectl logs`, which are lost when the controller pod restarts or the cluster is torn down. This makes it impossible to investigate a test failure after the fact.

Observed on running soak clusters:
```
$ kubectl get pvc -n prometheus-<service>
storage-loki-<service>-0   Pending   ...   gp2
$ kubectl get pods -n prometheus-<service> | grep loki
loki-<service>-0   0/1   Pending   0   2d21h
```
PVC events: `Waiting for a volume to be created ... by the external provisioner 'ebs.csi.aws.com'` — but the driver was never installed (EKS addons were only coredns, kube-proxy, metrics-server, vpc-cni).

## Fix

Add the `aws-ebs-csi-driver` addon to `cluster-config.yaml`, using an **EKS Pod Identity association** for its IAM permissions (`useDefaultPodIdentityAssociations: true`). The `eks-pod-identity-agent` addon is declared as the required prerequisite.

```yaml
addons:
- name: eks-pod-identity-agent
- name: aws-ebs-csi-driver
  useDefaultPodIdentityAssociations: true
```

With the CSI driver present, the Loki PVC binds, the Loki pod runs, and controller logs are persisted for the lifetime of the cluster.

Also documents in the README how to investigate test failures via Loki (Grafana Explore + Loki API), including correlating a failed test iteration with the controller's reconcile activity in the same time window.

## Testing

Verified end-to-end on a freshly bootstrapped `ack-soak-glue` cluster:
- `aws-ebs-csi-driver` addon **ACTIVE** with a pod identity association created
- `ebs-csi-controller` / `ebs-csi-node` / `eks-pod-identity-agent` pods Running
- Loki PVC **Bound** (15Gi gp2), Loki pod Running
- Controller log streams queryable from Loki, and a failed-iteration → controller-activity correlation confirmed working

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.