### PR TITLE
soak: bump controllers to latest released versions

### DIFF
--- a/soak/run-all.sh
+++ b/soak/run-all.sh
@@ -19,16 +19,16 @@ MAX_PARALLEL=${MAX_PARALLEL:-5}
 
 # Define controllers to soak test: "service:version"
 CONTROLLERS=(
-  "opensearchserverless:v0.4.1"
-  "autoscaling:v0.2.0"
-  "emrserverless:v0.2.0"
-  "glue:v0.4.0"
-  "backup:v0.2.0"
-  "quicksight:v0.4.0"
+  "opensearchserverless:v0.4.3"
+  "autoscaling:v0.2.2"
+  "emrserverless:v0.2.1"
+  "glue:v0.4.1"
+  "backup:v0.3.0"
+  "quicksight:v0.4.1"
   "mwaa:v0.2.0"
-  "firehose:v0.3.0"
-  "dsql:v0.1.0"
-  "s3files:v0.2.0"
+  "firehose:v0.3.1"
+  "dsql:v0.1.1"
+  "s3files:v0.2.1"
 )
 
 LOG_DIR="/tmp/soak-logs"


### PR DESCRIPTION
## Summary

Updates the `run-all.sh` CONTROLLERS list so the batch soak runner uses each controller's **latest published release**.

| Controller | Before | After |
|-----------|--------|-------|
| opensearchserverless | v0.4.1 | **v0.4.3** |
| autoscaling | v0.2.0 | **v0.2.2** |
| emrserverless | v0.2.0 | **v0.2.1** |
| glue | v0.4.0 | **v0.4.1** |
| backup | v0.2.0 | **v0.3.0** |
| quicksight | v0.4.0 | **v0.4.1** |
| mwaa | v0.2.0 | v0.2.0 (unchanged) |
| firehose | v0.3.0 | **v0.3.1** |
| dsql | v0.1.0 | **v0.1.1** |
| s3files | v0.2.0 | **v0.2.1** |

Notably this picks up:
- **autoscaling v0.2.2** — reconciliation churn fix (late_initialize + VPCZoneIdentifier)
- **opensearchserverless v0.4.3** — collection e2e test timing fix

All referenced controller images were confirmed available on `public.ecr.aws/aws-controllers-k8s`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.