### PR TITLE
fix(prow): lower control-plane NodePool expireAfter to 168h

### DIFF
--- a/flux/ack/cluster/nodepool-control-plane.yaml
+++ b/flux/ack/cluster/nodepool-control-plane.yaml
@@ -22,9 +22,10 @@ spec:
         - key: ack.aws.dev/control-plane
           value: "true"
           effect: NoSchedule
-      # Long expiry: the control plane should not be recycled on the same
-      # aggressive 10h cadence as the e2e compute pool.
-      expireAfter: 720h
+      # Longer expiry than the e2e pool's 10h so the control plane isn't
+      # recycled aggressively, while staying within Karpenter's limit that
+      # expireAfter + terminationGracePeriod (default 24h) must be <= 21 days.
+      expireAfter: 168h
       requirements:
         - key: "eks.amazonaws.com/instance-family"
           operator: In


### PR DESCRIPTION
## Description

Fix-forward for #997. The `prow-control-plane` NodePool was created with
`expireAfter: 720h`, which Karpenter v1 rejects: `expireAfter +
terminationGracePeriod` (defaulted to 24h) may not exceed 21 days.

As a result the `ack-cluster` Flux Kustomization failed its dry-run apply and
never created the NodePool, and the failure cascaded to every Kustomization
that depends on `ack-cluster` (`ack-addons`, `ack-pod-identities`, `prow-crds`,
`prow-mirror`, `prow-charts`, `prometheus`, `secrets`), which were stuck on the
prior revision. The deck/hook PDBs from #997 also did not deploy because
`prow-charts` was blocked.

## Change

`expireAfter: 720h` -> `168h` (7 days) on the `prow-control-plane` NodePool.

- Within Karpenter's limit (168h + 24h = 192h, well under 21 days).
- Still far less churn than the e2e pool's `10h`.
- Keeps control-plane nodes patched on a weekly cadence (720h/30d was longer
  than desirable for OS freshness anyway).

## Observed before fix

```
ack-cluster  Ready=False
  NodePool "prow-control-plane" is invalid: spec.template.spec:
  the sum of expireAfter and terminationGracePeriod (defaulted to 24h)
  may not exceed 21 days
```
NodePools present: only `general-purpose` and `prow-compute` (no
`prow-control-plane`).

## Testing
- `kubectl kustomize flux/ack/cluster` renders cleanly.

## Rollout
Once merged and reconciled, `ack-cluster` should apply successfully, create the
`prow-control-plane` NodePool, and unblock the dependent Kustomizations
(including `prow-charts`, which deploys the deck/hook PDBs).
