### PR TITLE
Update boto3 version to 1.43.36

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-boto3==1.42.60
+boto3==1.43.36
 kubernetes==28.1.0
 PyYAML==6.0.1
 pytest-xdist==3.5.0


### PR DESCRIPTION
Issue #, if available:

Description of changes:

Updating boto3 version from 1.42.60 to 1.43.36 to support Lambda MicroVMs

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
