### PR TITLE
feat(acktest): add wait_on_condition_after for fresh-reconcile waits

### DIFF
--- a/src/acktest/k8s/condition.py
+++ b/src/acktest/k8s/condition.py
@@ -15,6 +15,9 @@
 
 import pytest
 
+from datetime import datetime
+from typing import Optional
+
 from . import resource
 
 CONDITION_TYPE_ADOPTED = "ACK.Adopted"
@@ -113,6 +116,24 @@ def assert_synced(ref: resource.CustomResourceReference):
         a True status.
     """
     return assert_synced_status(ref, True)
+
+
+def get_synced_last_transition_time(
+    ref: resource.CustomResourceReference,
+) -> Optional[datetime]:
+    """Returns the lastTransitionTime of the ACK.ResourceSynced condition.
+
+    Returned as a timezone-aware datetime, or None if the resource has no
+    ACK.ResourceSynced condition (or it carries no lastTransitionTime).
+
+    ACK rewrites this timestamp on every reconcile (not only on status
+    transitions), so capturing it before patching a resource and then waiting
+    for a newer value is a reliable way to confirm the controller has reconciled
+    the change. Pair it with ``resource.wait_on_condition(...,
+    last_transition_after=<captured value>)``.
+    """
+    cond = resource.get_resource_condition(ref, CONDITION_TYPE_RESOURCE_SYNCED)
+    return resource.parse_condition_last_transition_time(cond)
 
 
 def assert_not_synced(ref: resource.CustomResourceReference):

--- a/src/acktest/k8s/resource.py
+++ b/src/acktest/k8s/resource.py
@@ -18,6 +18,7 @@ import logging
 import base64
 import os
 import distutils.util as util
+from datetime import datetime
 from pathlib import Path
 from time import sleep
 from typing import Dict, Optional, Union
@@ -334,6 +335,20 @@ def delete_secret(namespace: str,
     _api_client = _get_k8s_api_client()
     client.CoreV1Api(_api_client).delete_namespaced_secret(name.lower(), namespace.lower())
 
+def parse_condition_last_transition_time(condition) -> Optional[datetime]:
+    """Parses a condition's lastTransitionTime into a timezone-aware datetime.
+
+    Returns None if the condition is None or has no lastTransitionTime.
+    """
+    if condition is None:
+        return None
+    ts = condition.get('lastTransitionTime')
+    if ts is None:
+        return None
+    # Kubernetes serializes the timestamp as RFC3339 with a trailing 'Z'.
+    return datetime.fromisoformat(ts.replace("Z", "+00:00"))
+
+
 def wait_on_condition(reference: CustomResourceReference,
                       condition_name: str,
                       desired_condition_status: str,
@@ -362,6 +377,67 @@ def wait_on_condition(reference: CustomResourceReference,
         if desired_condition is not None and desired_condition['status'] == desired_condition_status:
             logging.info(f"Condition {condition_name} has status {desired_condition_status}, continuing...")
             return True
+
+        sleep(period_length)
+
+    if not desired_condition:
+        logging.error(f"Resource {reference} does not have a condition of type {condition_name}.")
+    else:
+        logging.error(f"Wait for condition {condition_name} to reach status {desired_condition_status} timed out. Condition has message '{desired_condition['message']}'")
+    return False
+
+
+def wait_on_condition_after(reference: CustomResourceReference,
+                            condition_name: str,
+                            desired_condition_status: str,
+                            last_transition_after: Optional[datetime] = None,
+                            wait_periods: int = 2,
+                            period_length: int = 60) -> bool:
+    """
+    Waits for the specified condition to reach the desired value via a reconcile
+    that happened after `last_transition_after`.
+
+    This is a timestamp-aware variant of `wait_on_condition`. It is a separate
+    function (rather than an extra argument on `wait_on_condition`) to avoid any
+    behavioral change for existing callers.
+
+    Precondition:
+        resource must be consumed by the controller (i.e. have a .status field)
+
+    Args:
+        last_transition_after: when provided, the condition is only considered
+            met once its lastTransitionTime is strictly newer than this value.
+            This guards against reading a stale condition left over from a
+            previous reconcile -- for example, right after patching a resource,
+            ACK.ResourceSynced can still read the desired status from the prior
+            reconcile. Capture the condition's lastTransitionTime before the
+            patch (see condition.get_synced_last_transition_time) and pass it
+            here to wait for a fresh reconcile. When None the timestamp check is
+            skipped, making this behave like `wait_on_condition`.
+
+    Returns:
+        False if the resource doesn't exist, have .status.conditions at all, have the requested
+            condition type, or if the wait times out. True otherwise.
+    """
+
+    if not get_resource_exists(reference):
+        logging.error(f"Resource {reference} does not exist")
+        return False
+
+    desired_condition = None
+    for i in range(wait_periods):
+        logging.debug(f"Waiting on condition {condition_name} to reach {desired_condition_status} for resource {reference} ({i})")
+
+        desired_condition = get_resource_condition(reference, condition_name)
+        if desired_condition is not None and desired_condition['status'] == desired_condition_status:
+            if last_transition_after is None:
+                logging.info(f"Condition {condition_name} has status {desired_condition_status}, continuing...")
+                return True
+
+            last_transition = parse_condition_last_transition_time(desired_condition)
+            if last_transition is not None and last_transition > last_transition_after:
+                logging.info(f"Condition {condition_name} has status {desired_condition_status} with a fresh lastTransitionTime ({last_transition}), continuing...")
+                return True
 
         sleep(period_length)
 


### PR DESCRIPTION
## Description

Adds a timestamp-aware way to wait for a Kubernetes condition, so e2e tests can wait for a **fresh** reconcile after patching a resource instead of matching a condition that may still carry the desired status from the *previous* reconcile.

### Motivation

A common e2e flake: after `patch_custom_resource(...)`, tests do `wait_on_condition(ref, ACK.ResourceSynced, "True")` and immediately assert on status. But ACK re-affirms `ACK.ResourceSynced=True` after every successful reconcile, so right after a patch the condition can still read `True` from the reconcile that ran *before* the patch. The wait becomes a no-op and the test reads stale status.

Generation-based checks don't help: ACK records no observed generation (the core `Condition` type has no `observedGeneration`), and `metadata.generation` is bumped by the API server the instant the spec is patched, before the controller observes it.

What does work: ACK's `SetSynced` rewrites `lastTransitionTime` to "now" on **every** reconcile (not only on status changes). So capturing that timestamp before the patch and waiting for a strictly newer one reliably detects that the controller reconciled the change.

### Changes

- `resource.wait_on_condition_after(...)` — a **new** function (not a change to `wait_on_condition`, so existing callers are unaffected) that treats a condition as met only once its `lastTransitionTime` is strictly newer than a supplied `last_transition_after`. When `last_transition_after` is `None` it behaves like `wait_on_condition`.
- `resource.parse_condition_last_transition_time(condition)` — parses a condition's `lastTransitionTime` into a timezone-aware `datetime`.
- `condition.get_synced_last_transition_time(ref)` — captures the `ACK.ResourceSynced` condition's `lastTransitionTime` for the pattern above.

### Usage

```python
synced_at = condition.get_synced_last_transition_time(ref)
k8s.patch_custom_resource(ref, updates)
assert k8s.wait_on_condition_after(
    ref, condition.CONDITION_TYPE_RESOURCE_SYNCED, "True",
    last_transition_after=synced_at,
)
```

Capture the timestamp **before** the patch: it gives a stable baseline that the patch's reconcile is guaranteed to exceed. (Capturing after the patch races the controller and can skip the very reconcile that processed the change.)

### Related

First consumer: aws-controllers-k8s/firehose-controller#24, which replaces fixed `time.sleep(...)` waits in the delivery stream e2e tests with this pattern.

### Testing

`py_compile` passes on both modified modules. Existing `wait_on_condition` behavior is unchanged (new function is additive).
