### PR TITLE
Use AL2023 variant of eks-distro-build-tooling/eks-distro-minimal-base-nonroot

### DIFF
--- a/build_config.yaml
+++ b/build_config.yaml
@@ -1,2 +1,2 @@
 go_version: 1.26.4
-eks_distro_version: 2026-06-09-1781048472.2
+eks_distro_version: 2026-06-29-1782759668.2023

--- a/prow/jobs/images_config.yaml
+++ b/prow/jobs/images_config.yaml
@@ -14,5 +14,5 @@ images:
     scan-controllers-cve: prow-scan-controllers-cve-0.0.27
     soak-test: prow-soak-0.0.32
     unit-test: prow-unit-0.0.37
-    upgrade-go-version: prow-upgrade-go-version-0.0.34
+    upgrade-go-version: prow-upgrade-go-version-0.0.35
     verify-attribution: prow-verify-attribution-0.0.32

--- a/prow/jobs/tools/cmd/command/upgrade_eks_distro_version_helper.go
+++ b/prow/jobs/tools/cmd/command/upgrade_eks_distro_version_helper.go
@@ -22,7 +22,7 @@ const (
 // YYYY-MM-DD-TTMMSS000.2
 // This format of date can be compared using string comparison
 // In the future if the meaning or the standard of the version
-// changes, we need to change this function to reflect 
+// changes, we need to change this function to reflect
 // the comparison of eks-distro version
 func eksDistroVersionIsGreaterThan(v1 string, v2 string) bool {
 	return v1 > v2
@@ -31,11 +31,11 @@ func eksDistroVersionIsGreaterThan(v1 string, v2 string) bool {
 func findHighestEcrEksDistroVersion(tags []string) (string, error) {
 
 	regex := regexp.MustCompile(`[a-z]`)
-	max := "2000-08-13-1723575672.2"
+	max := "2000-08-13-1723575672.2023"
 
 	for _, tag := range tags {
 		temp := strings.Split(tag, ".")
-		if regex.MatchString(tag) || len(temp) != 2 || temp[1] != "2" {
+		if regex.MatchString(tag) || len(temp) != 2 || temp[1] != "2023" {
 			continue
 		}
 		if eksDistroVersionIsGreaterThan(tag, max) {


### PR DESCRIPTION
Issue #, if available: [2950](https://github.com/aws-controllers-k8s/community/issues/2950)

Description of changes:
Update image tag of eks-distro-build-tooling/eks-distro-minimal-base-nonroot used by ACK release images to latest AL2023 variant. Additionally, changes the ugrade-eks-distro-version periodic job to check `.2023` image variants. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
