### PR TITLE
chore(prow): Upgrade Prow to v20260702-fff8399c7

### DIFF
--- a/flux/prow/version/prow-version-configmap.yaml
+++ b/flux/prow/version/prow-version-configmap.yaml
@@ -6,5 +6,5 @@ metadata:
   name: prow-version
   namespace: flux-system
 data:
-  PROW_VERSION: "v20260617-37d12bec7"
+  PROW_VERSION: "v20260702-fff8399c7"
   TOOLS_VERSION: "v20260515-778139c32d"

--- a/prow/config/Chart.yaml
+++ b/prow/config/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: prow-config
 description: Configuration for the ACK Prow cluster
 type: application
-version: 0.4.19
+version: 0.4.20
 appVersion: "1.16.0"


### PR DESCRIPTION
## Description

Upgrades the pinned Prow control-plane version using `./scripts/upgrade-prow.sh`.

- `flux/prow/version/prow-version-configmap.yaml`: `PROW_VERSION` bumped `v20260617-37d12bec7` → `v20260702-fff8399c7`
- `prow/config/Chart.yaml`: chart version bumped `0.4.19` → `0.4.20` so Flux re-applies the HelmRelease

All Prow component images use Flux variable substitution (`${PROW_IMAGE_REGISTRY}/<component>:${PROW_VERSION}`), so updating the ConfigMap alone rolls out the new images. `TOOLS_VERSION` was already at the latest tag, and the ProwJob CRD was already up to date.

## Testing

- Ran `./scripts/upgrade-prow.sh --dry-run` to preview
- Ran `./scripts/upgrade-prow.sh` to apply
- Reviewed `git diff` (only the two expected files changed)