### PR TITLE
fix: refresh assumed-role creds before helm test phase

### DIFF
--- a/prow/jobs/images/wrapper.sh
+++ b/prow/jobs/images/wrapper.sh
@@ -134,6 +134,11 @@ export ASSUMED_ROLE_ARN
 
 ASSUME_COMMAND=$(aws sts assume-role --role-arn $ASSUMED_ROLE_ARN --role-session-name $PROW_JOB_ID --duration-seconds 3600 | jq -r '.Credentials | "export AWS_ACCESS_KEY_ID=\(.AccessKeyId)\nexport AWS_SECRET_ACCESS_KEY=\(.SecretAccessKey)\nexport AWS_SESSION_TOKEN=\(.SessionToken)\n"')
 eval $ASSUME_COMMAND
+# Preserve the Pod Identity reference before unsetting it. A later phase can
+# re-mint a fresh credential from it (see refresh_assumed_role_creds in
+# scripts/lib/aws.sh) once this 1-hour static credential lapses.
+export ACK_POD_IDENTITY_CREDENTIALS_FULL_URI="${AWS_CONTAINER_CREDENTIALS_FULL_URI:-}"
+export ACK_POD_IDENTITY_AUTHORIZATION_TOKEN_FILE="${AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE:-}"
 # Unset Pod Identity env vars so nested Docker containers use the static
 # credentials (AWS_ACCESS_KEY_ID/SECRET/TOKEN) instead of trying to use pod identity
 unset AWS_CONTAINER_CREDENTIALS_FULL_URI 2>/dev/null || true

--- a/scripts/lib/aws.sh
+++ b/scripts/lib/aws.sh
@@ -61,6 +61,36 @@ ensure_aws_credentials() {
         ( error_msg "No AWS credentials found. Please run \`aws configure\` to set up the CLI for your credentials" && exit 1)
 }
 
+# refresh_assumed_role_creds() re-mints the static credentials in the current
+# shell by assuming the service team role again from Pod Identity.
+#
+# wrapper.sh assumes the role once at job start; that credential is capped at 1
+# hour. In the code-generator core-validator the unit, e2e and helm phases run
+# back-to-back in a single pod, so a late phase (helm) can inherit an expired
+# credential. This re-mints from Pod Identity -- reachable only from the pod,
+# and non-expiring -- using the host aws CLI rather than daws, which runs in a
+# nested container that cannot reach the Pod Identity endpoint.
+#
+# No-op outside Prow, where the preserved Pod Identity reference is absent.
+refresh_assumed_role_creds() {
+    [[ -z "${ACK_POD_IDENTITY_CREDENTIALS_FULL_URI:-}" || -z "${ASSUMED_ROLE_ARN:-}" ]] && return 0
+
+    local json
+    json=$(env -u AWS_ACCESS_KEY_ID -u AWS_SECRET_ACCESS_KEY -u AWS_SESSION_TOKEN \
+           AWS_CONTAINER_CREDENTIALS_FULL_URI="${ACK_POD_IDENTITY_CREDENTIALS_FULL_URI}" \
+           AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE="${ACK_POD_IDENTITY_AUTHORIZATION_TOKEN_FILE}" \
+           aws sts assume-role \
+             --role-arn "${ASSUMED_ROLE_ARN}" \
+             --role-session-name "${PROW_JOB_ID:-refresh}" \
+             --duration-seconds 3600 \
+             --output json) || { error_msg "Unable to refresh assumed-role credentials"; return 1; }
+
+    export AWS_ACCESS_KEY_ID=$(echo "${json}" | jq --raw-output ".Credentials.AccessKeyId")
+    export AWS_SECRET_ACCESS_KEY=$(echo "${json}" | jq --raw-output ".Credentials.SecretAccessKey")
+    export AWS_SESSION_TOKEN=$(echo "${json}" | jq --raw-output ".Credentials.SessionToken")
+    info_msg "Refreshed assumed-role credentials"
+}
+
 # generate_aws_temp_creds function will generate temporary AWS credentials which
 # are valid for 3600 seconds
 aws_generate_temp_creds() {

--- a/scripts/run-helm-tests.sh
+++ b/scripts/run-helm-tests.sh
@@ -92,6 +92,12 @@ _cleanup_helm_chart() {
 }
 
 run() {
+    # This phase can start over an hour after wrapper.sh minted the job's
+    # static credentials (after a long e2e phase in the core-validator), by
+    # which point they have expired. Re-mint from Pod Identity first. No-op
+    # outside Prow.
+    refresh_assumed_role_creds
+
     ensure_aws_credentials
 
     ensure_cluster


### PR DESCRIPTION
Description of changes:
The code-generator core-validator runs unit, e2e and helm phases back-to-back
in one Prow pod. wrapper.sh mints a single 1-hour assume-role credential at job
start, so the helm phase -- starting after a long e2e phase -- inherits an
expired credential and fails with ExpiredToken. (Service repos don't hit this:
they run each phase as a separate pod with its own fresh credential.)

Preserve the Pod Identity reference in wrapper.sh and re-mint the credential
from it at the start of the helm phase. Pod Identity is reachable only from the
pod and does not expire, so the refresh always starts from a valid source.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
