### PR TITLE
fix: keep ${PROW_IMAGES_REPO_URI} variable in generated prow manifests

### DIFF
--- a/prow/jobs/tools/cmd/build-prow-images.sh
+++ b/prow/jobs/tools/cmd/build-prow-images.sh
@@ -22,8 +22,13 @@ envsubst < ./prow/plugins/images_config.yaml > /tmp/plugins_images_config.yaml
 envsubst < ./prow/agent-workflows/images_config.yaml > /tmp/agent_workflows_images_config.yaml
 
 # Build Prow Jobs
+# --images-config-path is the RESOLVED config (real ECR URI) used for building
+# and pushing images. --images-generate-config-path is the RAW config so the
+# generated jobs.yaml / job-config-job.yaml keep ${PROW_IMAGES_REPO_URI},
+# matching what `make prow-gen` produces (avoids churn).
 BUILT_JOB_TAGS=$(ack-build-tools build-prow-images \
   --images-config-path /tmp/images_config.yaml \
+  --images-generate-config-path ./prow/jobs/images_config.yaml \
   --jobs-config-path ./prow/jobs/jobs_config.yaml \
   --jobs-templates-path ./prow/jobs/templates/ \
   --jobs-output-path ./prow/jobs/jobs.yaml \
@@ -35,8 +40,10 @@ if [ $? -ne 0 ]; then
 fi
 
 # Build Prow Agent Workflows
+# Resolved config for build/push, raw config for generation (keeps the variable).
 BUILT_AGENT_WORKFLOW_TAGS=$(ack-build-tools build-prow-agent-workflow-images \
   --images-config-path /tmp/agent_workflows_images_config.yaml \
+  --images-generate-config-path ./prow/agent-workflows/images_config.yaml \
   --prow-ecr-repository "$PROW_ECR_REPO_NAME" \
   --agent-workflows-templates-path ./prow/agent-workflows/templates \
   --agent-workflows-output-path ./prow/agent-workflows/agent-workflows.yaml)

--- a/prow/jobs/tools/cmd/command/patch_prow_agent_workflows.go
+++ b/prow/jobs/tools/cmd/command/patch_prow_agent_workflows.go
@@ -71,8 +71,12 @@ func buildProwAgentWorkflowImages(cmd *cobra.Command, args []string) error {
 		return nil
 	}
 
+	// Build/push uses OptImagesConfigPath (resolved ECR URI), but generation
+	// must use the raw config so manifests keep ${PROW_IMAGES_REPO_URI}.
+	generateConfigPath := resolveGenerateConfigPath(OptImagesGenerateConfigPath, OptImagesConfigPath)
+
 	err = generator.GenerateAgentWorkflows(
-		OptImagesConfigPath,
+		generateConfigPath,
 		OptAgentWorkflowsTemplatesPath,
 		OptAgentWorkflowsOutputPath,
 	)

--- a/prow/jobs/tools/cmd/command/patch_prowjobs.go
+++ b/prow/jobs/tools/cmd/command/patch_prowjobs.go
@@ -74,7 +74,11 @@ func buildProwImages(cmd *cobra.Command, args []string) error {
 		return nil
 	}
 
-	err = generator.Generate("jobs", OptJobsConfigPath, OptImagesConfigPath, OptJobsTemplatesPath, OptJobsOutputPath)
+	// Build/push uses OptImagesConfigPath (resolved ECR URI), but generation
+	// must use the raw config so manifests keep ${PROW_IMAGES_REPO_URI}.
+	generateConfigPath := resolveGenerateConfigPath(OptImagesGenerateConfigPath, OptImagesConfigPath)
+
+	err = generator.Generate("jobs", OptJobsConfigPath, generateConfigPath, OptJobsTemplatesPath, OptJobsOutputPath)
 	if err != nil {
 		return err
 	}
@@ -82,7 +86,7 @@ func buildProwImages(cmd *cobra.Command, args []string) error {
 
 	jobConfigJobTemplate := OptJobsTemplatesPath + "/job-config-job.yaml.tpl"
 	jobConfigJobOutput := "./prow/jobs/job-config-job.yaml"
-	err = generator.GenerateManifest(OptImagesConfigPath, jobConfigJobTemplate, jobConfigJobOutput)
+	err = generator.GenerateManifest(generateConfigPath, jobConfigJobTemplate, jobConfigJobOutput)
 	if err != nil {
 		return err
 	}

--- a/prow/jobs/tools/cmd/command/patch_prowjobs_helper.go
+++ b/prow/jobs/tools/cmd/command/patch_prowjobs_helper.go
@@ -40,7 +40,7 @@ func validateBooleanFlag(flag string, flagName string) (bool, error) {
 	if flag == "true" || flag == "false" {
 		return flag == "true", nil
 	}
-	return false, fmt.Errorf("invalid value for boolean flag %s: %v. Only accepts true or false", flagName, createPR)
+	return false, fmt.Errorf("invalid value for boolean flag %s: %v. Only accepts true or false", flagName, flag)
 }
 
 func listEcrProwImageDetails(repositoryName string) ([]types.ImageDetail, error) {

--- a/prow/jobs/tools/cmd/command/patch_prowjobs_test.go
+++ b/prow/jobs/tools/cmd/command/patch_prowjobs_test.go
@@ -15,10 +15,15 @@ package command
 
 import (
 	"fmt"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/service/ecrpublic/types"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/aws-controllers-k8s/test-infra/prow/jobs/tools/cmd/command/generator"
 )
 
 func TestCleanECRConfigVersionList(t *testing.T) {
@@ -165,4 +170,91 @@ func TestCompareImageVersions(t *testing.T) {
 			assert.Len(tagsToBuild, tt.wantLenTagsToBuild)
 		})
 	}
+}
+
+// TestResolveGenerateConfigPath verifies that the generation-config path
+// falls back to the build/push config path when unset (backward compatible),
+// and otherwise routes to the explicitly provided raw-config path.
+func TestResolveGenerateConfigPath(t *testing.T) {
+	assert := assert.New(t)
+
+	tests := []struct {
+		name               string
+		generateConfigPath string
+		imagesConfigPath   string
+		want               string
+	}{
+		{
+			name:               "empty generate path falls back to images config path",
+			generateConfigPath: "",
+			imagesConfigPath:   "/tmp/images_config.yaml",
+			want:               "/tmp/images_config.yaml",
+		},
+		{
+			name:               "explicit generate path is used verbatim",
+			generateConfigPath: "./prow/jobs/images_config.yaml",
+			imagesConfigPath:   "/tmp/images_config.yaml",
+			want:               "./prow/jobs/images_config.yaml",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := resolveGenerateConfigPath(tt.generateConfigPath, tt.imagesConfigPath)
+			assert.Equal(tt.want, got)
+		})
+	}
+}
+
+// TestGenerateManifestKeepsRepoVariable proves the core fix: when the generator
+// is fed the RAW images_config.yaml (image_repo: ${PROW_IMAGES_REPO_URI}), the
+// rendered manifest keeps the ${PROW_IMAGES_REPO_URI} variable rather than
+// baking in a resolved ECR URI. This is what eliminates the ~1000-line churn
+// diff between the bot output and `make prow-gen` output.
+func TestGenerateManifestKeepsRepoVariable(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+
+	dir := t.TempDir()
+
+	// RAW config: image_repo is the unresolved variable.
+	rawConfigPath := filepath.Join(dir, "images_config.yaml")
+	rawConfig := "image_repo: ${PROW_IMAGES_REPO_URI}\n" +
+		"images:\n" +
+		"    kubectl: prow-kubectl-0.0.2\n"
+	require.NoError(os.WriteFile(rawConfigPath, []byte(rawConfig), 0o644))
+
+	// RESOLVED config: image_repo is the concrete ECR URI (as envsubst would
+	// produce in the bot). Used to prove the OLD behavior would hardcode it.
+	resolvedConfigPath := filepath.Join(dir, "images_config_resolved.yaml")
+	resolvedConfig := "image_repo: public.ecr.aws/m5q3e4b2/ack-test-infra-prod-prow-images\n" +
+		"images:\n" +
+		"    kubectl: prow-kubectl-0.0.2\n"
+	require.NoError(os.WriteFile(resolvedConfigPath, []byte(resolvedConfig), 0o644))
+
+	// A minimal template that renders "<image_repo>:<tag>", exactly the shape
+	// the real job-config-job.yaml.tpl uses for the kubectl image.
+	templatePath := filepath.Join(dir, "manifest.tpl")
+	template := `image: {{printf "%s:%s" .ImageContext.ImageRepo (index .ImageContext.Images "kubectl") }}` + "\n"
+	require.NoError(os.WriteFile(templatePath, []byte(template), 0o644))
+
+	// Generation with RAW config must retain the variable form.
+	rawOut := filepath.Join(dir, "raw_out.yaml")
+	require.NoError(generator.GenerateManifest(rawConfigPath, templatePath, rawOut))
+	rawBytes, err := os.ReadFile(rawOut)
+	require.NoError(err)
+	rawStr := string(rawBytes)
+	assert.Contains(rawStr, "${PROW_IMAGES_REPO_URI}:prow-kubectl-0.0.2",
+		"raw-config generation must keep the ${PROW_IMAGES_REPO_URI} variable")
+	assert.NotContains(rawStr, "public.ecr.aws/m5q3e4b2",
+		"raw-config generation must NOT hardcode a resolved ECR URI")
+
+	// Sanity: with the resolved config the manifest hardcodes the URI. This is
+	// the churn the fix avoids by routing generation through the raw config.
+	resolvedOut := filepath.Join(dir, "resolved_out.yaml")
+	require.NoError(generator.GenerateManifest(resolvedConfigPath, templatePath, resolvedOut))
+	resolvedBytes, err := os.ReadFile(resolvedOut)
+	require.NoError(err)
+	assert.Contains(string(resolvedBytes), "public.ecr.aws/m5q3e4b2",
+		"resolved-config generation hardcodes the URI (the old churn-causing behavior)")
 }

--- a/prow/jobs/tools/cmd/command/root.go
+++ b/prow/jobs/tools/cmd/command/root.go
@@ -26,13 +26,30 @@ const (
 )
 
 var (
-	OptImagesConfigPath  string
-	OptSourceOwner       string
-	OptSourceRepo        string
-	OptProwEcrRepository string
-	OptCreatePR          string
-	OptPushImages        string
+	OptImagesConfigPath         string
+	OptImagesGenerateConfigPath string
+	OptSourceOwner              string
+	OptSourceRepo               string
+	OptProwEcrRepository        string
+	OptCreatePR                 string
+	OptPushImages               string
 )
+
+// resolveGenerateConfigPath returns the config path to use for GENERATION of
+// deployment manifests (jobs.yaml, job-config-job.yaml, agent-workflows.yaml).
+//
+// The build/push step needs a config whose image_repo is resolved to the real
+// ECR URI (produced by envsubst into /tmp), but generation must emit the raw
+// ${PROW_IMAGES_REPO_URI} variable so the committed manifests match what
+// `make prow-gen` produces (which reads the raw config). Callers pass the
+// generation-config flag value; when it is empty we fall back to the
+// build/push config path to preserve backward-compatible behavior.
+func resolveGenerateConfigPath(generateConfigPath, imagesConfigPath string) string {
+	if generateConfigPath == "" {
+		return imagesConfigPath
+	}
+	return generateConfigPath
+}
 
 var rootCmd = &cobra.Command{
 	Use:          appName,
@@ -44,6 +61,9 @@ var rootCmd = &cobra.Command{
 func init() {
 	rootCmd.PersistentFlags().StringVar(
 		&OptImagesConfigPath, "images-config-path", "images_config.yaml", "path to images_config.yaml, where prow job image versions are stored",
+	)
+	rootCmd.PersistentFlags().StringVar(
+		&OptImagesGenerateConfigPath, "images-generate-config-path", "", "path to the images_config.yaml used when GENERATING deployment manifests (jobs.yaml, job-config-job.yaml, agent-workflows.yaml). Defaults to --images-config-path when empty. Pass the RAW config (with ${PROW_IMAGES_REPO_URI}) here so generated manifests keep the variable, while --images-config-path stays resolved for the build/push step.",
 	)
 	rootCmd.PersistentFlags().StringVar(
 		&OptSourceOwner, "source-owner", "aws-controllers-k8s", "Name of the owner of the repo to create the commit in.",


### PR DESCRIPTION
The `build-prow-images` bot resolves `image_repo` to a hardcoded ECR URI before generating `jobs.yaml`/`job-config-job.yaml`, so every `make prow-gen` run produces ~1000 lines of churn flipping between the variable and the literal URI.

Split the config inputs: build/push keeps the resolved config (real ECR URI, needed for buildah push), while generation uses a new `--images-generate-config-path` pointing at the raw config so manifests retain `${PROW_IMAGES_REPO_URI}` (matching `make prow-gen`). Mirrors the existing plugins path. The flag defaults to `--images-config-path` when unset, so behavior is unchanged if not passed.