### PR TITLE
Bump boto3 to 1.43.56

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-boto3==1.43.36
+boto3==1.43.56
 kubernetes==28.1.0
 PyYAML==6.0.1
 pytest-xdist==3.5.0


### PR DESCRIPTION
The CloudWatch alarm evaluation window fields (EvaluationWindow, WallClockWindow, SlidingWindow) are absent from the botocore model in 1.43.36, so describe_alarms silently drops them and service controller e2e tests cannot assert on them. botocore 1.43.56 includes them.

Issue #, if available:

N/A

Needed for e2e tests in aws-controllers-k8s/cloudwatch-controller#74

Description of changes:

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
