### PR TITLE
Patch OS CVEs in Prow and job images to clear container findings

### DIFF
--- a/bootstrap/README.md
+++ b/bootstrap/README.md
@@ -141,8 +141,19 @@ git push
 
 ## Upgrading Prow
 
-Prow images are mirrored from upstream into a private ECR registry. The version
-is controlled by a single ConfigMap (`flux/prow/version/prow-version-configmap.yaml`).
+Prow images are mirrored from upstream into a private ECR registry **and rebuilt
+with current OS packages** on the way through. Upstream Prow pins its ko base
+images in `.ko.yaml` and only refreshes that pin every few months, so even the
+newest Prow release ships stale `expat`/`openssl`/`curl`. The `prow-mirror` Job
+runs `apk upgrade` over each image and publishes it as
+`<upstream-tag>-ack.<PROW_PATCH_REVISION>`, plus the bare `<upstream-tag>` as a
+compatibility alias carrying the same patched content. The suffixed tag is what
+`prow-config` pins, so bumping the revision is what triggers a rollout; the bare
+alias means a reference that has not moved to the suffixed tag still gets patched
+packages rather than silently staying vulnerable.
+
+Both the version and the patch revision live in a single ConfigMap
+(`flux/prow/version/prow-version-configmap.yaml`).
 
 ```bash
 # Auto-detect latest tags for both Prow core and tools, update CRD
@@ -154,16 +165,74 @@ is controlled by a single ConfigMap (`flux/prow/version/prow-version-configmap.y
 # Preview changes without modifying files
 ./scripts/upgrade-prow.sh --dry-run
 
+# Re-patch the CURRENT Prow version against newly published OS security
+# updates, without moving to a new upstream release. Increments
+# PROW_PATCH_REVISION, which is what makes the mirror Job rebuild.
+./scripts/upgrade-prow.sh --bump-patch
+
 # Commit and push
 git add flux/prow/ prow/config/
 git commit -m "chore(prow): upgrade to <tag>"
 git push
-# Flux reconciles: mirror job copies new images to ECR, then Prow redeploys
+# Flux reconciles: mirror job rebuilds patched images into ECR, then Prow redeploys
 ```
+
+`PROW_PATCH_REVISION` is a monotonic counter and is never reset. `PROW_VERSION`
+and `TOOLS_VERSION` move independently but share the one suffix, so resetting it
+on a version change would repoint the untouched tag at a revision that already
+exists in ECR — the mirror would skip the rebuild and that component would
+silently roll back to its least-patched build.
 
 Image sources:
 - Prow core: `us-docker.pkg.dev/k8s-infra-prow/images` (13 images)
 - Tools (`label_sync`, `commenter`): `gcr.io/k8s-staging-test-infra`
+
+The mirror Job refuses to publish an image whose base has no `apk`, rather than
+silently shipping it unpatched. If upstream moves a component to a distroless
+base, that component will fail loudly and needs a different patch strategy.
+
+### Reacting to an image vulnerability report
+
+**Mirrored Prow components** (`.../prow/<component>`) are almost always outdated
+OS packages in the upstream base image, not a Prow defect. Bumping the Prow
+version alone usually does **not** fix them. Run
+`./scripts/upgrade-prow.sh --bump-patch`, push, then force-reconcile
+`prow-mirror`.
+
+**Our own job images** (`public.ecr.aws/<alias>/...-prow-images:*`) apply OS
+updates at build time, so they only need a tag bump to be rebuilt. Note the
+two-phase flow — do not shortcut it:
+
+1. In your PR, bump the tag in `prow/jobs/images_config.yaml` (or the
+   `prow/plugins/` / `prow/agent-workflows/` equivalent) and **nothing else**.
+   `compareImageVersions` only builds a tag strictly greater than what is in
+   ECR, so an unchanged tag is never rebuilt.
+2. On merge, the `build-prow-images` postsubmit builds and pushes the new tags.
+3. A bot PR then commits the regenerated `jobs.yaml` / `job-config-job.yaml` /
+   `agent-workflows.yaml` / `prow/plugins/deployments/`.
+
+Do not run `make prow-gen` and commit its output in step 1. `job-config-job.yaml`
+is applied directly by the `prow-jobs` Kustomization (`interval: 5m`,
+`force: true`), so committing a tag before the image exists makes Flux recreate
+`job-config-substitutor` on a missing image within minutes of merge, halting
+`job-config` refreshes until the postsubmit lands.
+
+#### Exceptions the generator does not cover
+
+- **`build-prow-images` is safe to bump on its own.** It is the image the
+  postsubmit itself runs as, but the running pod resolves it from the
+  already-applied `job-config` ConfigMap, not from `images_config.yaml`. So the
+  job builds its own successor. This only holds while step 1 above is respected;
+  hand-committing a regenerated `jobs.yaml` would point the job at the image it
+  has not built yet.
+- **`flux/prow/build-cluster-connection/job.yaml`** pins a `prow-kubectl` tag
+  but is not in the generator's output set, so `make prow-gen` will never update
+  it. Bump it by hand once the new tag is in ECR, or its OS packages silently
+  stay behind.
+
+Keep notes like these here rather than as comments in `images_config.yaml`: the
+`upgrade-go-version` periodic rewrites that file through a typed struct and a
+YAML encoder, which strips comments.
 
 ## Re-running Terraform
 
@@ -234,6 +303,8 @@ Common kustomization names:
 | `ack-prow` | Prow AWS resources (S3, Route53) |
 | `ack-flux` | ECR pull-through cache |
 | `prow-crds` | Prow CRDs |
+| `prow-version` | `prow-version` ConfigMap (Prow/tools versions + patch revision) |
+| `prow-mirror` | Job that rebuilds upstream Prow images with current OS packages |
 | `prow-charts` | Prow Helm releases |
 
 If a kustomization shows `dependency '<name>' is not ready`, trigger the

--- a/flux/ack/cluster/addons/addons.yaml
+++ b/flux/ack/cluster/addons/addons.yaml
@@ -8,7 +8,13 @@ metadata:
 spec:
   clusterName: ${STACK_NAME}-cluster
   name: aws-secrets-store-csi-driver-provider
-  addonVersion: v3.1.1-eksbuild.1
+  # Keep this at the newest published version. The addon bundles the upstream
+  # secrets-store-csi-driver image, so an old bundle leaves the driver DaemonSet
+  # running outdated OS packages. Check for newer versions with:
+  #   aws eks describe-addon-versions \
+  #     --addon-name aws-secrets-store-csi-driver-provider \
+  #     --kubernetes-version 1.35 --region us-west-2
+  addonVersion: v3.1.2-eksbuild.1
   configurationValues: |-
     {
       "secrets-store-csi-driver": {

--- a/flux/prow.yaml
+++ b/flux/prow.yaml
@@ -57,6 +57,14 @@ spec:
   path: ./flux/prow/mirror
   prune: false
   force: true
+  # Wait for the Job to COMPLETE, not just apply. prow-charts depends on this
+  # Kustomization and pins the -ack.<revision> tags this Job produces, so
+  # without wait the components roll out before the tags exist and land in
+  # ImagePullBackOff. A serial buildah pull/upgrade/commit/push across 15 images
+  # on vfs storage takes minutes rather than the seconds `crane copy` took, so
+  # the timeout is deliberately generous.
+  wait: true
+  timeout: 30m
   postBuild:
     substituteFrom:
     - kind: ConfigMap

--- a/flux/prow/charts/prow-config.yaml
+++ b/flux/prow/charts/prow-config.yaml
@@ -52,47 +52,47 @@ spec:
       server: "${BUILD_CLUSTER_ENDPOINT}"
       certificateAuthorityData: "${BUILD_CLUSTER_CA}"
     crier:
-      image: "${ACCOUNT_ID}.dkr.ecr.${REGION}.amazonaws.com/prow/crier:${PROW_VERSION}"
+      image: "${ACCOUNT_ID}.dkr.ecr.${REGION}.amazonaws.com/prow/crier:${PROW_VERSION}-ack.${PROW_PATCH_REVISION}"
       serviceAccount:
         name: "prow-deployment-service-account"
     deck:
-      image: "${ACCOUNT_ID}.dkr.ecr.${REGION}.amazonaws.com/prow/deck:${PROW_VERSION}"
+      image: "${ACCOUNT_ID}.dkr.ecr.${REGION}.amazonaws.com/prow/deck:${PROW_VERSION}-ack.${PROW_PATCH_REVISION}"
       serviceAccount:
         name: "prow-deployment-service-account"
     ghproxy:
-      image: "${ACCOUNT_ID}.dkr.ecr.${REGION}.amazonaws.com/prow/ghproxy:${PROW_VERSION}"
+      image: "${ACCOUNT_ID}.dkr.ecr.${REGION}.amazonaws.com/prow/ghproxy:${PROW_VERSION}-ack.${PROW_PATCH_REVISION}"
     hook:
-      image: "${ACCOUNT_ID}.dkr.ecr.${REGION}.amazonaws.com/prow/hook:${PROW_VERSION}"
+      image: "${ACCOUNT_ID}.dkr.ecr.${REGION}.amazonaws.com/prow/hook:${PROW_VERSION}-ack.${PROW_PATCH_REVISION}"
       scrapeMetrics: true
       serviceAccount:
         name: "prow-deployment-service-account"
     horologium:
-      image: "${ACCOUNT_ID}.dkr.ecr.${REGION}.amazonaws.com/prow/horologium:${PROW_VERSION}"
+      image: "${ACCOUNT_ID}.dkr.ecr.${REGION}.amazonaws.com/prow/horologium:${PROW_VERSION}-ack.${PROW_PATCH_REVISION}"
       serviceAccount:
         name: "prow-deployment-service-account"
     prowControllerManager:
-      image: "${ACCOUNT_ID}.dkr.ecr.${REGION}.amazonaws.com/prow/prow-controller-manager:${PROW_VERSION}"
+      image: "${ACCOUNT_ID}.dkr.ecr.${REGION}.amazonaws.com/prow/prow-controller-manager:${PROW_VERSION}-ack.${PROW_PATCH_REVISION}"
       scrapeMetrics: true
       serviceAccount:
         name: "prow-deployment-service-account"
     sinker:
-      image: "${ACCOUNT_ID}.dkr.ecr.${REGION}.amazonaws.com/prow/sinker:${PROW_VERSION}"
+      image: "${ACCOUNT_ID}.dkr.ecr.${REGION}.amazonaws.com/prow/sinker:${PROW_VERSION}-ack.${PROW_PATCH_REVISION}"
       serviceAccount:
         name: "prow-deployment-service-account"
     statusreconciler:
-      image: "${ACCOUNT_ID}.dkr.ecr.${REGION}.amazonaws.com/prow/status-reconciler:${PROW_VERSION}"
+      image: "${ACCOUNT_ID}.dkr.ecr.${REGION}.amazonaws.com/prow/status-reconciler:${PROW_VERSION}-ack.${PROW_PATCH_REVISION}"
       serviceAccount:
         name: "prow-deployment-service-account"
     tide:
-      image: "${ACCOUNT_ID}.dkr.ecr.${REGION}.amazonaws.com/prow/tide:${PROW_VERSION}"
+      image: "${ACCOUNT_ID}.dkr.ecr.${REGION}.amazonaws.com/prow/tide:${PROW_VERSION}-ack.${PROW_PATCH_REVISION}"
       scrapeMetrics: true
       serviceAccount:
         name: "prow-deployment-service-account"
     utility_images:
-      clonerefs: "${ACCOUNT_ID}.dkr.ecr.${REGION}.amazonaws.com/prow/clonerefs:${PROW_VERSION}"
-      entrypoint: "${ACCOUNT_ID}.dkr.ecr.${REGION}.amazonaws.com/prow/entrypoint:${PROW_VERSION}"
-      initupload: "${ACCOUNT_ID}.dkr.ecr.${REGION}.amazonaws.com/prow/initupload:${PROW_VERSION}"
-      sidecar: "${ACCOUNT_ID}.dkr.ecr.${REGION}.amazonaws.com/prow/sidecar:${PROW_VERSION}"
+      clonerefs: "${ACCOUNT_ID}.dkr.ecr.${REGION}.amazonaws.com/prow/clonerefs:${PROW_VERSION}-ack.${PROW_PATCH_REVISION}"
+      entrypoint: "${ACCOUNT_ID}.dkr.ecr.${REGION}.amazonaws.com/prow/entrypoint:${PROW_VERSION}-ack.${PROW_PATCH_REVISION}"
+      initupload: "${ACCOUNT_ID}.dkr.ecr.${REGION}.amazonaws.com/prow/initupload:${PROW_VERSION}-ack.${PROW_PATCH_REVISION}"
+      sidecar: "${ACCOUNT_ID}.dkr.ecr.${REGION}.amazonaws.com/prow/sidecar:${PROW_VERSION}-ack.${PROW_PATCH_REVISION}"
   chart:
     spec:
       chart: ./prow/config

--- a/flux/prow/mirror/mirror-job.yaml
+++ b/flux/prow/mirror/mirror-job.yaml
@@ -1,13 +1,40 @@
-# Mirrors official Prow images into a private ECR repository.
-# ECR does not support pull-through cache for Google Artifact Registry,
-# so we use crane to copy images on each Flux reconciliation.
+# Mirrors official Prow images into a private ECR repository, applying
+# outstanding OS security updates on the way through.
+#
+# Why we rebuild instead of straight-copying:
+#   Upstream Prow pins its ko base images (gcr.io/k8s-staging-test-infra/{alpine,
+#   git,git-custom-k8s-auth}) in .ko.yaml and only refreshes that pin every few
+#   months. Any Prow release built against an old base ships outdated expat,
+#   openssl and curl packages, so every Prow pod carries known CVEs no matter
+#   how recent the Prow tag is. Running `apk upgrade` here decouples our patch
+#   cadence from upstream's base-image bump cadence.
+#
+# ECR does not support pull-through cache for Google Artifact Registry, so the
+# images have to be copied either way.
 #
 # Images come from two upstream registries:
-#   - us-docker.pkg.dev/k8s-infra-prow/images (Prow core)
-#   - gcr.io/k8s-staging-test-infra (label_sync, commenter)
+#   - us-docker.pkg.dev/k8s-infra-prow/images (Prow core, ${PROW_VERSION})
+#   - gcr.io/k8s-staging-test-infra (label_sync, commenter, ${TOOLS_VERSION})
 #
-# This Job runs before prow-charts deploys, ensuring images are available
-# in ECR before Prow pods attempt to pull them.
+# Each patched image is published under two tags:
+#   <upstream-tag>-ack.${PROW_PATCH_REVISION}  authoritative; what prow-config
+#                                              pins, so a revision bump is what
+#                                              triggers a Deployment rollout
+#   <upstream-tag>                             compatibility alias, same patched
+#                                              content, for references that have
+#                                              not moved to the suffixed tag
+#
+# The suffix is load bearing. This Kustomization reconciles hourly with
+# force: true, so a mutable bare tag alone gives no way to pin or roll out a
+# specific patch build. Bump PROW_PATCH_REVISION in
+# flux/prow/version/prow-version-configmap.yaml to force a fresh rebuild without
+# changing the Prow version.
+#
+# The Job is idempotent. The init container skips any image whose patched tag is
+# already in ECR, so the hourly reconcile is a no-op once everything is built.
+#
+# This Job runs before prow-charts deploys, ensuring images are available in ECR
+# before Prow pods attempt to pull them.
 ---
 apiVersion: batch/v1
 kind: Job
@@ -22,95 +49,204 @@ spec:
       serviceAccountName: prow-mirror-service-account
       restartPolicy: Never
       initContainers:
-      - name: ecr-login
+      # Works out which images actually need building and stashes an ECR
+      # password for the build container (which has no aws CLI).
+      - name: plan
         image: amazon/aws-cli:latest
         command:
         - /bin/sh
+        - -eu
         - -c
         - |
-          aws ecr get-login-password --region $${AWS_REGION} > /ecr-auth/password
+          aws ecr get-login-password --region "$${AWS_REGION}" > /work/ecr-password
+
+          cat > /work/images.txt <<'EOF'
+          PROW|crier
+          PROW|deck
+          PROW|ghproxy
+          PROW|hook
+          PROW|horologium
+          PROW|prow-controller-manager
+          PROW|sinker
+          PROW|status-reconciler
+          PROW|tide
+          PROW|clonerefs
+          PROW|entrypoint
+          PROW|initupload
+          PROW|sidecar
+          TOOLS|label_sync
+          TOOLS|commenter
+          EOF
+
+          : > /work/build-list
+
+          while IFS='|' read -r class img; do
+            [ -z "$${class:-}" ] && continue
+
+            case "$$class" in
+              PROW)
+                src="us-docker.pkg.dev/k8s-infra-prow/images"
+                tag="$${PROW_VERSION}"
+                ;;
+              TOOLS)
+                src="gcr.io/k8s-staging-test-infra"
+                tag="$${TOOLS_VERSION}"
+                ;;
+              *)
+                echo "unknown image class: $$class" >&2
+                exit 1
+                ;;
+            esac
+
+            dst_tag="$${tag}-ack.$${PROW_PATCH_REVISION}"
+
+            if aws ecr describe-images \
+                 --region "$${AWS_REGION}" \
+                 --repository-name "prow/$${img}" \
+                 --image-ids "imageTag=$${dst_tag}" >/dev/null 2>&1; then
+              echo "  = prow/$${img}:$${dst_tag} already present"
+            else
+              echo "  + prow/$${img}:$${dst_tag} queued for build"
+              printf '%s|%s|%s|%s\n' "$$src" "$$img" "$$tag" "$$dst_tag" >> /work/build-list
+            fi
+          done < /work/images.txt
+
+          echo ""
+          echo "Queued $$(wc -l < /work/build-list) image(s) for patching."
         env:
         - name: AWS_REGION
           value: "${REGION}"
-        volumeMounts:
-        - name: ecr-auth
-          mountPath: /ecr-auth
-      containers:
-      - name: mirror
-        image: gcr.io/go-containerregistry/crane:debug
-        command:
-        - /busybox/sh
-        - -c
-        - |
-          set -eu
-
-          PROW_SRC="us-docker.pkg.dev/k8s-infra-prow/images"
-          TOOLS_SRC="gcr.io/k8s-staging-test-infra"
-          DST="$${ECR_REGISTRY}/prow"
-          TAG="$${PROW_VERSION}"
-          TOOLS_TAG="$${TOOLS_VERSION}"
-
-          # Authenticate to ECR using password from init container
-          crane auth login "$${ECR_REGISTRY}" --username AWS --password-stdin < /ecr-auth/password
-
-          # Prow core images (from us-docker.pkg.dev/k8s-infra-prow/images)
-          PROW_IMAGES="crier deck ghproxy hook horologium prow-controller-manager sinker status-reconciler tide"
-          # Pod utility images
-          PROW_IMAGES="$$PROW_IMAGES clonerefs entrypoint initupload sidecar"
-
-          # test-infra tool images (from gcr.io/k8s-staging-test-infra)
-          TOOL_IMAGES="label_sync commenter"
-
-          FAILED=0
-          TOTAL=0
-
-          # Mirror Prow core images
-          for img in $$PROW_IMAGES; do
-            TOTAL=$$((TOTAL + 1))
-            echo "→ $${img}:$${TAG}"
-            if crane copy "$${PROW_SRC}/$${img}:$${TAG}" "$${DST}/$${img}:$${TAG}" 2>&1; then
-              echo "  ✓ done"
-            else
-              echo "  ✗ FAILED"
-              FAILED=$$((FAILED + 1))
-            fi
-          done
-
-          # Mirror test-infra tool images
-          for img in $$TOOL_IMAGES; do
-            TOTAL=$$((TOTAL + 1))
-            echo "→ $${img}:$${TOOLS_TAG} (from k8s-staging-test-infra)"
-            if crane copy "$${TOOLS_SRC}/$${img}:$${TOOLS_TAG}" "$${DST}/$${img}:$${TOOLS_TAG}" 2>&1; then
-              echo "  ✓ done"
-            else
-              echo "  ✗ FAILED"
-              FAILED=$$((FAILED + 1))
-            fi
-          done
-
-          echo ""
-          echo "Mirror complete. Failures: $${FAILED}/$${TOTAL}"
-          if [ "$$FAILED" -gt 0 ]; then
-            exit 1
-          fi
-        env:
-        - name: ECR_REGISTRY
-          value: "${ACCOUNT_ID}.dkr.ecr.${REGION}.amazonaws.com"
         - name: PROW_VERSION
           value: "${PROW_VERSION}"
         - name: TOOLS_VERSION
           value: "${TOOLS_VERSION}"
+        - name: PROW_PATCH_REVISION
+          value: "${PROW_PATCH_REVISION}"
         volumeMounts:
-        - name: ecr-auth
-          mountPath: /ecr-auth
+        - name: work
+          mountPath: /work
+      containers:
+      - name: patch
+        image: quay.io/containers/buildah:v1.39.0
+        # buildah needs to unpack and re-commit image layers. Matches the
+        # privilege level already used by the build-prow-images postsubmit.
+        securityContext:
+          privileged: true
+        command:
+        - /bin/bash
+        - -c
+        - |
+          set -uo pipefail
+
+          if [ ! -s /work/build-list ]; then
+            echo "All patched images already present in ECR. Nothing to do."
+            exit 0
+          fi
+
+          buildah login -u AWS --password-stdin "$${ECR_REGISTRY}" < /work/ecr-password
+
+          # Pull the upstream image, apply pending apk updates, push under the
+          # patched tag. Returns 2 for "cannot patch", which is not retryable.
+          patch_one() {
+            __src="$$1"; __img="$$2"; __tag="$$3"; __dst_tag="$$4"
+            __dst="$${ECR_REGISTRY}/prow/$${__img}:$${__dst_tag}"
+
+            __ctr=$$(buildah from --pull=always "$${__src}/$${__img}:$${__tag}") || return 1
+
+            if ! buildah run --user root "$$__ctr" -- /bin/sh -c 'command -v apk >/dev/null 2>&1'; then
+              echo "     base image has no apk; refusing to publish unpatched" >&2
+              buildah rm "$$__ctr" >/dev/null 2>&1 || true
+              return 2
+            fi
+
+            if ! buildah run --user root "$$__ctr" -- /bin/sh -c 'apk -U upgrade --no-cache'; then
+              buildah rm "$$__ctr" >/dev/null 2>&1 || true
+              return 1
+            fi
+
+            buildah commit --rm "$$__ctr" "$$__dst" >/dev/null || return 1
+
+            if ! buildah push "$$__dst"; then
+              buildah rmi "$$__dst" >/dev/null 2>&1 || true
+              return 1
+            fi
+
+            # Also publish the patched image under the bare upstream tag. The
+            # suffixed tag is authoritative and is what prow-config pins, but
+            # generated job config lags behind a tag bump by design (see
+            # bootstrap/README.md), and hand-maintained manifests can reference
+            # the bare tag too. Pointing it at patched content means a missed
+            # reference degrades to "patched but unpinned" instead of
+            # "silently unpatched".
+            __bare="$${ECR_REGISTRY}/prow/$${__img}:$${__tag}"
+            buildah tag "$$__dst" "$$__bare" >/dev/null 2>&1 || true
+            if ! buildah push "$$__bare"; then
+              echo "     warning: could not update bare tag $${__tag}" >&2
+            fi
+
+            buildah rmi "$$__dst" "$$__bare" >/dev/null 2>&1 || true
+            return 0
+          }
+
+          FAILED=0
+          TOTAL=0
+
+          while IFS='|' read -r src img tag dst_tag; do
+            [ -z "$${src:-}" ] && continue
+            TOTAL=$$((TOTAL + 1))
+            echo "-> $${img}:$${dst_tag} (from $${src}/$${img}:$${tag})"
+
+            attempt=1
+            rc=1
+            while [ "$$attempt" -le 3 ]; do
+              patch_one "$$src" "$$img" "$$tag" "$$dst_tag"
+              rc=$$?
+              [ "$$rc" -eq 0 ] && break
+              # Unpatchable base image, retrying will not help.
+              [ "$$rc" -eq 2 ] && break
+              echo "   retry $$attempt/3"
+              attempt=$$((attempt + 1))
+              sleep 10
+            done
+
+            if [ "$$rc" -eq 0 ]; then
+              echo "   done"
+            else
+              echo "   FAILED (rc=$$rc)"
+              FAILED=$$((FAILED + 1))
+            fi
+          done < /work/build-list
+
+          echo ""
+          echo "Patch complete. Failures: $${FAILED}/$${TOTAL}"
+          [ "$$FAILED" -gt 0 ] && exit 1
+          exit 0
+        env:
+        - name: ECR_REGISTRY
+          value: "${ACCOUNT_ID}.dkr.ecr.${REGION}.amazonaws.com"
+        - name: STORAGE_DRIVER
+          value: vfs
+        - name: BUILDAH_ISOLATION
+          value: chroot
+        volumeMounts:
+        - name: work
+          mountPath: /work
           readOnly: true
+        - name: containers-storage
+          mountPath: /var/lib/containers
         resources:
           requests:
-            cpu: "500m"
-            memory: "256Mi"
-          limits:
             cpu: "1"
-            memory: "512Mi"
+            memory: "2Gi"
+            ephemeral-storage: "20Gi"
+          limits:
+            cpu: "2"
+            memory: "4Gi"
+            ephemeral-storage: "30Gi"
       volumes:
-      - name: ecr-auth
+      - name: work
         emptyDir: {}
+      # vfs storage duplicates layers per image, so give it real room.
+      - name: containers-storage
+        emptyDir:
+          sizeLimit: 30Gi

--- a/flux/prow/version/prow-version-configmap.yaml
+++ b/flux/prow/version/prow-version-configmap.yaml
@@ -1,5 +1,18 @@
 # Prow image versions for postBuild substitution.
 # Updated by ./scripts/upgrade-prow.sh or manually.
+#
+# PROW_PATCH_REVISION is appended to the mirrored image tags as
+# "-ack.<revision>". The prow-mirror Job rebuilds the upstream images with
+# current OS packages and publishes them under that suffixed tag, and under the
+# bare upstream tag as a compatibility alias. Bump the revision to force a rebuild against
+# freshly published OS security updates without changing the Prow version, then
+# force-reconcile the prow-mirror Kustomization.
+#
+# It is a monotonic counter and must never be reset. PROW_VERSION and
+# TOOLS_VERSION move independently but share this suffix, so reusing a revision
+# would point the untouched tag at an image that already exists in ECR; the
+# mirror would skip the rebuild and that component would roll back to its
+# least-patched build.
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -8,3 +21,4 @@ metadata:
 data:
   PROW_VERSION: "v20260702-fff8399c7"
   TOOLS_VERSION: "v20260515-778139c32d"
+  PROW_PATCH_REVISION: "1"

--- a/prow/agent-workflows/images/Dockerfile.add-resource
+++ b/prow/agent-workflows/images/Dockerfile.add-resource
@@ -18,6 +18,10 @@ ENV GOPATH=/home/prow/go \
 # Set working directory
 WORKDIR /app
 
+# Apply outstanding OS security updates before installing anything else
+RUN apt-get update \
+    && apt-get upgrade -y \
+    && rm -rf /var/lib/apt/lists/*
 # Install git and dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \
     ca-certificates \

--- a/prow/agent-workflows/images_config.yaml
+++ b/prow/agent-workflows/images_config.yaml
@@ -1,3 +1,3 @@
 image_repo: ${PROW_IMAGES_REPO_URI}
 images:
-    add-resource: add-resource-0.0.5
+    add-resource: add-resource-0.0.6

--- a/prow/config/Chart.yaml
+++ b/prow/config/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: prow-config
 description: Configuration for the ACK Prow cluster
 type: application
-version: 0.4.21
+version: 0.4.22
 appVersion: "1.16.0"

--- a/prow/jobs/images/Dockerfile.auto-generate-controllers
+++ b/prow/jobs/images/Dockerfile.auto-generate-controllers
@@ -10,6 +10,10 @@ ENV GOPATH=/home/prow/go \
     GO111MODULE=on \
     PATH=/home/prow/go/bin:/usr/local/go/bin:${PATH}
 
+RUN echo "Applying OS security updates ..." \
+    && apt-get update \
+    && apt-get upgrade -y \
+    && rm -rf /var/lib/apt/lists/*
 RUN echo "Installing packages ..." \
     && apt-get update \
     && apt-get install -y --no-install-recommends\

--- a/prow/jobs/images/Dockerfile.auto-update-controllers
+++ b/prow/jobs/images/Dockerfile.auto-update-controllers
@@ -10,6 +10,10 @@ ENV GOPATH=/home/prow/go \
     GO111MODULE=on \
     PATH=/home/prow/go/bin:/usr/local/go/bin:${PATH}
 
+RUN echo "Applying OS security updates ..." \
+    && apt-get update \
+    && apt-get upgrade -y \
+    && rm -rf /var/lib/apt/lists/*
 RUN echo "Installing packages ..." \
     && apt-get update \
     && apt-get install -y --no-install-recommends\

--- a/prow/jobs/images/Dockerfile.build-prow-images
+++ b/prow/jobs/images/Dockerfile.build-prow-images
@@ -26,6 +26,10 @@ ENV GOPATH=/home/prow/go \
     GO111MODULE=on \
     PATH=/home/prow/go/bin:/usr/local/go/bin:${PATH}
 
+RUN echo "Applying OS security updates ..." \
+    && dnf -y upgrade --refresh \
+    && dnf clean all
+
 RUN dnf -y install \
 		which \
 		git \

--- a/prow/jobs/images/Dockerfile.controller-release-tag
+++ b/prow/jobs/images/Dockerfile.controller-release-tag
@@ -1,5 +1,9 @@
 FROM public.ecr.aws/docker/library/debian:trixie-slim AS base
 
+RUN echo "Applying OS security updates ..." \
+    && apt-get update \
+    && apt-get upgrade -y \
+    && rm -rf /var/lib/apt/lists/*
 RUN echo "Installing packages ..." \
     && apt-get update \
     && apt-get install -y --no-install-recommends\

--- a/prow/jobs/images/Dockerfile.deploy
+++ b/prow/jobs/images/Dockerfile.deploy
@@ -17,6 +17,10 @@ RUN mkdir -p /etc/containers /var/lib/containers/storage /run/containers/storage
     && printf '[storage]\ndriver = "vfs"\nrunroot = "/run/containers/storage"\ngraphroot = "/var/lib/containers/storage"\n' > /etc/containers/storage.conf \
     && rm -f /etc/subuid /etc/subgid
 
+RUN echo "Applying OS security updates ..." \
+    && dnf -y upgrade --refresh \
+    && dnf clean all
+
 RUN dnf -y install \
 		which \
 		git \

--- a/prow/jobs/images/Dockerfile.deploy-docs
+++ b/prow/jobs/images/Dockerfile.deploy-docs
@@ -5,6 +5,8 @@ FROM public.ecr.aws/docker/library/golang:${GO_VERSION}-alpine
 WORKDIR /scripts
 COPY deploy-docs.sh /scripts/deploy-docs.sh
 
+RUN apk -U upgrade --no-cache
+
 RUN apk add --no-cache \
     bash \
     git \

--- a/prow/jobs/images/Dockerfile.docs
+++ b/prow/jobs/images/Dockerfile.docs
@@ -3,6 +3,11 @@ FROM public.ecr.aws/docker/library/alpine:3.17.2
 WORKDIR /docs
 COPY build-docs.sh /docs/build-docs.sh
 
+# NOTE: alpine 3.17 is end-of-life and no longer receives security updates, so
+# this upgrade is a no-op for most advisories. Bumping the base tag is tracked
+# separately -- it needs the docs build revalidated against a newer Python.
+RUN apk -U upgrade --no-cache
+
 RUN apk add -y --no-cache \
     bash \
     gcc \

--- a/prow/jobs/images/Dockerfile.integration-test
+++ b/prow/jobs/images/Dockerfile.integration-test
@@ -11,6 +11,10 @@ ENV GOPATH=/home/prow/go \
     GO111MODULE=on \
     PATH=/home/prow/go/bin:/usr/local/go/bin:${PATH}
 
+RUN echo "Applying OS security updates ..." \
+    && apt-get update \
+    && apt-get upgrade -y \
+    && rm -rf /var/lib/apt/lists/*
 RUN echo "Installing packages ..." \
     && apt-get update \
     && apt-get install -y --no-install-recommends\

--- a/prow/jobs/images/Dockerfile.kubectl
+++ b/prow/jobs/images/Dockerfile.kubectl
@@ -4,6 +4,7 @@ FROM public.ecr.aws/docker/library/debian:trixie-slim
 ARG KUBECTL_VERSION=v1.35.5
 
 RUN apt-get update \
+    && apt-get upgrade -y \
     && apt-get install -y --no-install-recommends \
         bash \
         ca-certificates \

--- a/prow/jobs/images/Dockerfile.olm-bundle-pr
+++ b/prow/jobs/images/Dockerfile.olm-bundle-pr
@@ -12,6 +12,10 @@ ENV GOPATH=/home/prow/go \
 
 ENV OPERATOR_SDK_BIN_PATH=/usr/local/bin
 
+RUN echo "Applying OS security updates ..." \
+    && apt-get update \
+    && apt-get upgrade -y \
+    && rm -rf /var/lib/apt/lists/*
 RUN echo "Installing packages ..." \
     && apt-get update \
     && apt-get install -y --no-install-recommends\

--- a/prow/jobs/images/Dockerfile.olm-test
+++ b/prow/jobs/images/Dockerfile.olm-test
@@ -12,6 +12,10 @@ ENV GOPATH=/home/prow/go \
 
 ENV OPERATOR_SDK_BIN_PATH=/usr/local/bin
 
+RUN echo "Applying OS security updates ..." \
+    && apt-get update \
+    && apt-get upgrade -y \
+    && rm -rf /var/lib/apt/lists/*
 RUN echo "Installing packages ..." \
     && apt-get update \
     && apt-get install -y --no-install-recommends\

--- a/prow/jobs/images/Dockerfile.scan-controllers-cve
+++ b/prow/jobs/images/Dockerfile.scan-controllers-cve
@@ -13,6 +13,8 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o ack-build-tools ./prow/job
 # Start a new stage from scratch
 FROM public.ecr.aws/docker/library/alpine:latest
 
+RUN apk -U upgrade --no-cache
+
 RUN apk add --no-cache wget tar
 
 ARG TRIVY_VERSION=0.69.3

--- a/prow/jobs/images/Dockerfile.soak-test
+++ b/prow/jobs/images/Dockerfile.soak-test
@@ -11,6 +11,10 @@ ENV GOPATH=/home/prow/go \
     GO111MODULE=on \
     PATH=/home/prow/go/bin:/usr/local/go/bin:${PATH}
 
+RUN echo "Applying OS security updates ..." \
+    && dnf -y upgrade --refresh \
+    && dnf clean all
+
 RUN dnf -y install \
 		which \
 		git \

--- a/prow/jobs/images/Dockerfile.unit-test
+++ b/prow/jobs/images/Dockerfile.unit-test
@@ -11,6 +11,10 @@ ENV GOPATH=/home/prow/go \
     GO111MODULE=on \
     PATH=/home/prow/go/bin:/usr/local/go/bin:${PATH}
 
+RUN echo "Applying OS security updates ..." \
+    && apt-get update \
+    && apt-get upgrade -y \
+    && rm -rf /var/lib/apt/lists/*
 RUN echo "Installing packages ..." \
     && apt-get update \
     && apt-get install -y --no-install-recommends\

--- a/prow/jobs/images/Dockerfile.upgrade-go-version
+++ b/prow/jobs/images/Dockerfile.upgrade-go-version
@@ -13,4 +13,6 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o ack-build-tools ./prow/job
 # Start a new stage from scratch
 FROM public.ecr.aws/docker/library/alpine:latest
 
+RUN apk -U upgrade --no-cache
+
 COPY --from=builder /go/ack-build-tools /usr/local/bin/

--- a/prow/jobs/images/Dockerfile.verify-attribution
+++ b/prow/jobs/images/Dockerfile.verify-attribution
@@ -15,7 +15,10 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o attribution-gen ./main.go
 # Start a new stage from scratch
 FROM public.ecr.aws/docker/library/debian:trixie-slim
 
-RUN apt-get update && apt-get install -y ca-certificates
+RUN apt-get update \
+    && apt-get upgrade -y \
+    && apt-get install -y ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
 
 COPY --from=builder /app/attribution-gen /usr/local/bin/
 

--- a/prow/jobs/images_config.yaml
+++ b/prow/jobs/images_config.yaml
@@ -1,18 +1,18 @@
 image_repo: ${PROW_IMAGES_REPO_URI}
 images:
-    auto-generate-controllers: prow-auto-generate-controllers-0.0.43
-    auto-update-controllers: prow-auto-update-controllers-0.0.34
-    build-prow-images: prow-build-prow-images-0.0.71
-    controller-release-tag: prow-controller-release-tag-0.0.34
-    deploy: prow-deploy-0.0.45
-    deploy-docs: prow-deploy-docs-0.0.14
-    docs: prow-docs-0.0.39
-    integration-test: prow-integration-0.0.57
-    kubectl: prow-kubectl-0.0.2
-    olm-bundle-pr: prow-olm-bundle-pr-0.0.35
-    olm-test: prow-olm-test-0.0.34
-    scan-controllers-cve: prow-scan-controllers-cve-0.0.28
-    soak-test: prow-soak-0.0.33
-    unit-test: prow-unit-0.0.38
-    upgrade-go-version: prow-upgrade-go-version-0.0.36
-    verify-attribution: prow-verify-attribution-0.0.33
+    auto-generate-controllers: prow-auto-generate-controllers-0.0.44
+    auto-update-controllers: prow-auto-update-controllers-0.0.35
+    build-prow-images: prow-build-prow-images-0.0.72
+    controller-release-tag: prow-controller-release-tag-0.0.35
+    deploy: prow-deploy-0.0.46
+    deploy-docs: prow-deploy-docs-0.0.15
+    docs: prow-docs-0.0.40
+    integration-test: prow-integration-0.0.58
+    kubectl: prow-kubectl-0.0.3
+    olm-bundle-pr: prow-olm-bundle-pr-0.0.36
+    olm-test: prow-olm-test-0.0.35
+    scan-controllers-cve: prow-scan-controllers-cve-0.0.29
+    soak-test: prow-soak-0.0.34
+    unit-test: prow-unit-0.0.39
+    upgrade-go-version: prow-upgrade-go-version-0.0.37
+    verify-attribution: prow-verify-attribution-0.0.34

--- a/prow/jobs/job-config-job.yaml
+++ b/prow/jobs/job-config-job.yaml
@@ -134,7 +134,7 @@ spec:
           mountPath: /output
       containers:
       - name: apply-configmap
-        image: public.ecr.aws/m5q3e4b2/ack-test-infra-prod-prow-images:prow-kubectl-0.0.2
+        image: ${PROW_IMAGES_REPO_URI}:prow-kubectl-0.0.2
         command:
         - /bin/bash
         - -ec

--- a/prow/jobs/templates/job-config-job.yaml.tpl
+++ b/prow/jobs/templates/job-config-job.yaml.tpl
@@ -87,18 +87,19 @@ spec:
           apk add --no-cache gettext > /dev/null 2>&1
 
           echo "Substituting variables in jobs.yaml..."
-          # Substitute only the 4 variables needed for Prow job configuration.
+          # Substitute only the variables needed for Prow job configuration.
           # The $$ prefix is escaped by Flux postBuild (becomes $ after substitution).
-          envsubst '$$TEST_INFRA_ORG $$TEST_INFRA_REPO $$TEST_INFRA_BRANCH $$PROW_IMAGES_REPO_URI $$CONTROLLER_ECR_REGISTRY $$PROW_MIRROR_REGISTRY $$PROW_VERSION $$TOOLS_VERSION' \
+          envsubst '$$TEST_INFRA_ORG $$TEST_INFRA_REPO $$TEST_INFRA_BRANCH $$PROW_IMAGES_REPO_URI $$CONTROLLER_ECR_REGISTRY $$PROW_MIRROR_REGISTRY $$PROW_VERSION $$TOOLS_VERSION $$PROW_PATCH_REVISION' \
             < /workspace/prow/jobs/jobs.yaml \
             > /output/jobs-substituted.yaml
 
-          # Verify no unresolved TEST_INFRA variables remain
+          # Verify no unresolved variables remain
           if grep -qF 'TEST_INFRA_ORG}' /output/jobs-substituted.yaml || \
              grep -qF 'TEST_INFRA_REPO}' /output/jobs-substituted.yaml || \
-             grep -qF 'TEST_INFRA_BRANCH}' /output/jobs-substituted.yaml; then
+             grep -qF 'TEST_INFRA_BRANCH}' /output/jobs-substituted.yaml || \
+             grep -qF 'PROW_PATCH_REVISION}' /output/jobs-substituted.yaml; then
             echo "ERROR: Variable substitution incomplete!"
-            grep -c 'TEST_INFRA' /output/jobs-substituted.yaml || true
+            grep -c 'TEST_INFRA\|PROW_PATCH_REVISION' /output/jobs-substituted.yaml || true
             exit 1
           fi
 
@@ -124,6 +125,8 @@ spec:
           value: "${PROW_VERSION}"
         - name: TOOLS_VERSION
           value: "${TOOLS_VERSION}"
+        - name: PROW_PATCH_REVISION
+          value: "${PROW_PATCH_REVISION}"
         volumeMounts:
         - name: workspace
           mountPath: /workspace

--- a/prow/jobs/templates/periodics/label_sync.tpl
+++ b/prow/jobs/templates/periodics/label_sync.tpl
@@ -13,7 +13,7 @@
     serviceAccountName: periodic-service-account
     containers:
     - name: label-sync
-      image: ${PROW_MIRROR_REGISTRY}/label_sync:${TOOLS_VERSION}
+      image: ${PROW_MIRROR_REGISTRY}/label_sync:${TOOLS_VERSION}-ack.${PROW_PATCH_REVISION}
       resources:
         limits:
           cpu: 1

--- a/prow/jobs/templates/periodics/lifecycle_bot_periodic_close.tpl
+++ b/prow/jobs/templates/periodics/lifecycle_bot_periodic_close.tpl
@@ -11,7 +11,7 @@
   spec:
     serviceAccountName: periodic-service-account
     containers:
-      - image: ${PROW_MIRROR_REGISTRY}/commenter:${TOOLS_VERSION}
+      - image: ${PROW_MIRROR_REGISTRY}/commenter:${TOOLS_VERSION}-ack.${PROW_PATCH_REVISION}
         resources:
           limits:
             cpu: 1

--- a/prow/jobs/templates/periodics/lifecycle_bot_periodic_rotten.tpl
+++ b/prow/jobs/templates/periodics/lifecycle_bot_periodic_rotten.tpl
@@ -11,7 +11,7 @@
   spec:
     serviceAccountName: periodic-service-account
     containers:
-      - image: ${PROW_MIRROR_REGISTRY}/commenter:${TOOLS_VERSION}
+      - image: ${PROW_MIRROR_REGISTRY}/commenter:${TOOLS_VERSION}-ack.${PROW_PATCH_REVISION}
         resources:
           limits:
             cpu: 1

--- a/prow/jobs/templates/periodics/lifecycle_bot_periodic_stale.tpl
+++ b/prow/jobs/templates/periodics/lifecycle_bot_periodic_stale.tpl
@@ -11,7 +11,7 @@
   spec:
     serviceAccountName: periodic-service-account
     containers:
-      - image: ${PROW_MIRROR_REGISTRY}/commenter:${TOOLS_VERSION}
+      - image: ${PROW_MIRROR_REGISTRY}/commenter:${TOOLS_VERSION}-ack.${PROW_PATCH_REVISION}
         resources:
           limits:
             cpu: 1

--- a/prow/plugins/images/Dockerfile.agent-plugin
+++ b/prow/plugins/images/Dockerfile.agent-plugin
@@ -22,6 +22,11 @@ RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o webhook-server ./
 # Runtime stage
 FROM public.ecr.aws/docker/library/alpine:3.19
 
+# Apply outstanding OS security updates. Advisories for base packages
+# (expat/openssl/curl) are published faster than the pinned Alpine tag is
+# refreshed, so without this the image ships with known CVEs.
+RUN apk -U upgrade --no-cache
+
 # Install ca-certificates for HTTPS requests
 RUN apk --no-cache add ca-certificates
 

--- a/prow/plugins/images_config.yaml
+++ b/prow/plugins/images_config.yaml
@@ -1,3 +1,3 @@
 image_repo: ${PROW_IMAGES_REPO_URI}
 images:
-    agent-plugin: agent-plugin-0.0.3
+    agent-plugin: agent-plugin-0.0.4

--- a/scripts/upgrade-prow.sh
+++ b/scripts/upgrade-prow.sh
@@ -4,14 +4,21 @@
 #
 # Updates the PROW_VERSION in the prow-version ConfigMap and upgrades the
 # ProwJob CRD from upstream. All image references use Flux variable
-# substitution (${PROW_IMAGE_REGISTRY}/${component}:${PROW_VERSION}), so
-# updating the ConfigMap is all that's needed to roll out new images.
+# substitution (${PROW_IMAGE_REGISTRY}/${component}:${PROW_VERSION}-ack.${PROW_PATCH_REVISION}),
+# so updating the ConfigMap is all that's needed to roll out new images.
+#
+# PROW_PATCH_REVISION is a monotonic counter. It increments whenever an upstream
+# tag moves or --bump-patch is passed, and is never reset, so the mirror always
+# targets a tag that does not yet exist. Use --bump-patch to rebuild the current
+# Prow version against newly published OS security updates without moving to a
+# new upstream release.
 #
 # Usage:
 #   ./scripts/upgrade-prow.sh              # auto-detect latest tag
 #   ./scripts/upgrade-prow.sh <tag>        # use a specific tag
 #   ./scripts/upgrade-prow.sh --dry-run    # show what would change
 #   ./scripts/upgrade-prow.sh --crd-only   # only upgrade the CRD
+#   ./scripts/upgrade-prow.sh --bump-patch # re-patch current version (OS updates)
 #
 # Requires: curl, yq
 # Optional: crane (faster tag detection), kubectl (CRD validation)
@@ -30,21 +37,25 @@ CHART_FILE="$REPO_ROOT/prow/config/Chart.yaml"
 # --- Parse arguments ---
 DRY_RUN=false
 CRD_ONLY=false
+BUMP_PATCH=false
 TARGET_TAG=""
 
 for arg in "$@"; do
   case "$arg" in
-    --dry-run)  DRY_RUN=true ;;
-    --crd-only) CRD_ONLY=true ;;
+    --dry-run)    DRY_RUN=true ;;
+    --crd-only)   CRD_ONLY=true ;;
+    --bump-patch) BUMP_PATCH=true ;;
     --help|-h)
-      echo "Usage: $0 [--dry-run] [--crd-only] [<tag>]"
+      echo "Usage: $0 [--dry-run] [--crd-only] [--bump-patch] [<tag>]"
       echo ""
       echo "Upgrades Prow version and CRD."
       echo ""
       echo "Options:"
-      echo "  --dry-run    Show what would change without modifying files"
-      echo "  --crd-only   Only upgrade the ProwJob CRD"
-      echo "  <tag>        Specific image tag (e.g., v20260519-c47e31ece)"
+      echo "  --dry-run     Show what would change without modifying files"
+      echo "  --crd-only    Only upgrade the ProwJob CRD"
+      echo "  --bump-patch  Increment PROW_PATCH_REVISION to rebuild the current"
+      echo "                Prow version against new OS security updates"
+      echo "  <tag>         Specific image tag (e.g., v20260519-c47e31ece)"
       exit 0
       ;;
     v*) TARGET_TAG="$arg" ;;
@@ -64,6 +75,16 @@ if [[ "$CRD_ONLY" == "false" ]]; then
   if ! command -v yq >/dev/null 2>&1; then
     echo "error: yq is required (https://github.com/mikefarah/yq)" >&2
     exit 1
+  fi
+
+  # Tracks whether an upstream tag moved. A new upstream tag has never been
+  # patched, so the patch revision restarts at 1 rather than incrementing.
+  VERSION_CHANGED=false
+
+  # --bump-patch re-patches the versions already pinned instead of moving them.
+  if [[ "$BUMP_PATCH" == "true" && -z "$TARGET_TAG" ]]; then
+    TARGET_TAG=$(yq '.data.PROW_VERSION' "$VERSION_FILE")
+    echo "Re-patching pinned Prow version: $TARGET_TAG"
   fi
 
   # Detect latest tag
@@ -103,6 +124,8 @@ if [[ "$CRD_ONLY" == "false" ]]; then
     echo "  Current: $CURRENT_TAG"
     echo "  Target:  $TARGET_TAG"
 
+    VERSION_CHANGED=true
+
     if [[ "$DRY_RUN" == "false" ]]; then
       yq -i ".data.PROW_VERSION = \"${TARGET_TAG}\"" "$VERSION_FILE"
       echo "  Updated: $VERSION_FILE"
@@ -125,7 +148,11 @@ if [[ "$CRD_ONLY" == "false" ]]; then
   echo "Detecting latest tools image tag (label_sync, commenter)..."
 
   TOOLS_TAG=""
-  if command -v crane >/dev/null 2>&1; then
+  if [[ "$BUMP_PATCH" == "true" ]]; then
+    TOOLS_TAG=$(yq '.data.TOOLS_VERSION' "$VERSION_FILE")
+  fi
+
+  if [[ -z "$TOOLS_TAG" ]] && command -v crane >/dev/null 2>&1; then
     TOOLS_TAG=$(crane ls "gcr.io/k8s-staging-test-infra/label_sync" 2>/dev/null \
       | grep -E '^v[0-9]{8}-[a-f0-9]+$' \
       | sort -V \
@@ -147,6 +174,7 @@ if [[ "$CRD_ONLY" == "false" ]]; then
     else
       echo "  Current: $CURRENT_TOOLS"
       echo "  Latest:  $TOOLS_TAG"
+      VERSION_CHANGED=true
       if [[ "$DRY_RUN" == "false" ]]; then
         yq -i ".data.TOOLS_VERSION = \"${TOOLS_TAG}\"" "$VERSION_FILE"
         echo "  Updated TOOLS_VERSION"
@@ -156,6 +184,44 @@ if [[ "$CRD_ONLY" == "false" ]]; then
     fi
   else
     echo "  Could not detect tools version, skipping."
+  fi
+
+  # --- Patch revision (suffix on the mirrored, OS-patched image tags) ---
+  echo ""
+  echo "Resolving patch revision..."
+
+  CURRENT_REV=$(yq '.data.PROW_PATCH_REVISION' "$VERSION_FILE")
+  if [[ -z "$CURRENT_REV" || "$CURRENT_REV" == "null" ]]; then
+    CURRENT_REV=0
+  fi
+
+  # Monotonic counter, never reset. PROW_VERSION and TOOLS_VERSION move
+  # independently but share this one suffix, so resetting on a version change
+  # would repoint the *untouched* tag at a revision that already exists in ECR.
+  # The mirror's existence check would then skip the rebuild and that component
+  # would silently roll back to its least-patched build. Always incrementing
+  # guarantees a tag that does not exist yet, so every image gets rebuilt and
+  # repatched. Cost is rebuilding images whose upstream tag did not move, which
+  # is a fresh patch rather than a regression.
+  if [[ "$VERSION_CHANGED" == "true" || "$BUMP_PATCH" == "true" ]]; then
+    TARGET_REV=$((CURRENT_REV + 1))
+    if [[ "$VERSION_CHANGED" == "true" ]]; then
+      REV_REASON="upstream version changed"
+    else
+      REV_REASON="--bump-patch requested"
+    fi
+  else
+    TARGET_REV="$CURRENT_REV"
+    REV_REASON="no rebuild needed"
+  fi
+
+  if [[ "$TARGET_REV" == "$CURRENT_REV" ]]; then
+    echo "  PROW_PATCH_REVISION stays at $CURRENT_REV ($REV_REASON)"
+  elif [[ "$DRY_RUN" == "false" ]]; then
+    yq -i ".data.PROW_PATCH_REVISION = \"${TARGET_REV}\"" "$VERSION_FILE"
+    echo "  PROW_PATCH_REVISION: $CURRENT_REV → $TARGET_REV ($REV_REASON)"
+  else
+    echo "  [dry-run] Would set PROW_PATCH_REVISION: $CURRENT_REV → $TARGET_REV ($REV_REASON)"
   fi
 
   echo ""


### PR DESCRIPTION
## Summary

Image scanning flags the Prow control plane, our own CI job images, and the secrets-store CSI driver for outdated OS packages — `expat`, `openssl` and `curl`. None of these are application defects, and none are fixed by moving to a newer upstream version, because the outdated packages are inherited from pinned base images.

**Why a version bump doesn't fix this.** `kubernetes-sigs/prow` pins its ko base images in [`.ko.yaml`](https://github.com/kubernetes-sigs/prow/blob/main/.ko.yaml) and refreshes that pin every 6–12 months. It currently points at `gcr.io/k8s-staging-test-infra/git-custom-k8s-auth:v20260512-1f34ef0df3`, last bumped 2026-06-09, while `v20260729-*` bases already exist upstream. The tag we run, `v20260702-fff8399c7`, was built *after* that bump, so it already carries the newest base upstream offers. The `eks-distro-build-tooling` Prow images don't help either — [their build](https://github.com/aws/eks-distro-build-tooling/blob/main/projects/kubernetes/test-infra/Makefile) sets `BASE_IMAGE` to the same upstream image and adds no OS updates.

So the fix has to apply OS updates ourselves.

## Changes

### 1. Bump the secrets-store CSI driver addon

`aws-secrets-store-csi-driver-provider` `v3.1.1-eksbuild.1` → `v3.1.2-eksbuild.1`. The addon bundles the `secrets-store-csi-driver` image that the DaemonSet runs, so the bundle version is what governs how current those packages are.

### 2. Apply OS updates in ACK-owned images

The final stage of all 18 Dockerfiles now runs `apt-get upgrade` / `apk -U upgrade` / `dnf upgrade` as appropriate, and the tags in the three `images_config.yaml` files are bumped so `build-prow-images` rebuilds and republishes them.

Per the repo's two-phase flow this commit bumps **only** the image config. The regenerated `jobs.yaml` / `job-config-job.yaml` / `agent-workflows.yaml` / `prow/plugins/deployments/` land in the follow-up bot PR, once the images are actually in ECR. The one exception kept here is the `${PROW_IMAGES_REPO_URI}` un-hardcoding in `job-config-job.yaml`, which reverses a literal registry baked in by #1008; its tag stays at the image that exists today.

The invariant: **every image tag referenced by a file this PR applies directly is already in ECR.**

### 3. Rebuild instead of straight-copying mirrored Prow images

`prow-mirror` previously ran `crane copy`. It now uses buildah to pull each image, run `apk upgrade`, and publish it under two tags:

| Tag | Role |
|---|---|
| `<upstream-tag>-ack.<PROW_PATCH_REVISION>` | Authoritative. What `prow-config` pins, so a revision bump is what drives the rollout. |
| `<upstream-tag>` | Compatibility alias, same patched content. A reference that hasn't moved to the suffixed tag degrades to *patched but unpinned* rather than *silently unpatched*. |

The Kustomization gains `wait: true` + `timeout: 30m` so `prow-charts`, which depends on it, cannot roll out the suffixed tags before the Job has produced them — `dependsOn` alone gates on apply, not completion.

Two safety properties:
- **Idempotent.** An init container skips any image whose patched tag is already in ECR, so the hourly reconcile is a fast no-op once everything is built.
- **Fails loudly.** If a base image has no `apk` (e.g. upstream moves a component to distroless) the job refuses to publish rather than silently shipping it unpatched.

`PROW_PATCH_REVISION` decouples our patch cadence from upstream's base-image cadence. It's a **monotonic counter, never reset**: `PROW_VERSION` and `TOOLS_VERSION` move independently but share the one suffix, so reusing a revision would point the untouched tag at an image that already exists in ECR — the mirror would skip the rebuild and roll that component back to its least-patched build. `upgrade-prow.sh --bump-patch` rebuilds the pinned version against newly published OS updates.

## Testing

Local only; nothing applied to a cluster.

- `kustomize build` succeeds for all 7 touched kustomizations.
- Both embedded mirror-job scripts extracted from the rendered Job, put through Flux's substitution rules, and syntax-checked (`sh -n`, `bash -n`). `bash -n` on `upgrade-prow.sh`.
- Mirror job logic exercised against stubbed `aws`/`buildah`:
  - cold cache → all 15 images queued with correct source registries and tags;
  - warm cache → 0 queued, exits 0 without building;
  - transient push failure → retried and succeeded;
  - base without `apk` → refused, **no push attempted**, no pointless retries, exits 1;
  - dual-tag → two pushes and one `tag` alias per image, suffixed and bare.
- `helm template prow/config` with the real `HelmRelease` values renders all 9 component and 4 utility images on the `-ack.1` tag; 0 left on an unpinned bare tag.
- Generator output confirmed byte-identical to `main` for all five generated files; `job-config-job.yaml` differs by the single registry line.
- Enumerated every `prow-*` tag referenced in directly-applied files — all are pre-existing tags, none of the bumped ones.
- `make prow-gen` re-run to confirm the *sources* generate cleanly against #1031's build-cluster changes; output intentionally not committed.
- No IAM changes needed: `${STACK_NAME}-prow-mirror-role` already holds `ecr:*` on `repository/prow/*`.

## Reviewer notes

- **The mirror Job runs privileged.** buildah needs it to unpack and re-commit layers. This matches the existing `build-prow-images` postsubmit, which already runs `privileged: true` in `test-pods`. Worth a conscious ack.
- **Addon bundle contents unverified.** The EKS addon image registry doesn't grant `ecr:DescribeImages` to arbitrary accounts, so I couldn't confirm which `secrets-store-csi-driver` tag `v3.1.2-eksbuild.1` ships. Worth confirming with a scan after rollout.
- **`Dockerfile.docs` is on `alpine:3.17.2`, which is EOL**, so `apk upgrade` is a no-op there for most advisories. Flagged in a comment, left for a follow-up that revalidates the docs build on a newer Python.
- **Two images are unpinned** (`alpine:latest` in `scan-controllers-cve` and `upgrade-go-version`). Left as-is to keep this diff scoped.

## Follow-ups

- `flux/prow/build-cluster-connection/job.yaml` pins `prow-kubectl-0.0.2` and is not in the generator's output set, so it needs a manual bump once `0.0.3` is in ECR. Documented in `bootstrap/README.md` under "Exceptions the generator does not cover".
- The Flux controller images come through the ECR pull-through cache, which is passthrough-only and can't carry a patch layer. Needs either a Flux upgrade (currently 2.18.4) or dropping the pull-through cache in favour of mirror-and-patch like Prow.
- A PR to `kubernetes-sigs/prow` bumping `.ko.yaml` to the `v20260729-*` bases would reduce recurrence for everyone.
