### PR TITLE
Fix mirror Job env typing and unsupported addon version from #1037

### DIFF
--- a/flux/ack/cluster/addons/addons.yaml
+++ b/flux/ack/cluster/addons/addons.yaml
@@ -8,13 +8,18 @@ metadata:
 spec:
   clusterName: ${STACK_NAME}-cluster
   name: aws-secrets-store-csi-driver-provider
-  # Keep this at the newest published version. The addon bundles the upstream
-  # secrets-store-csi-driver image, so an old bundle leaves the driver DaemonSet
-  # running outdated OS packages. Check for newer versions with:
+  # Keep this at the newest version supported by THIS cluster's Kubernetes
+  # version. The addon bundles the upstream secrets-store-csi-driver image, so an
+  # old bundle leaves the driver DaemonSet running outdated OS packages.
+  #
+  # Always pass --kubernetes-version when checking; the unfiltered output lists
+  # versions for newer Kubernetes releases too, and picking one of those puts the
+  # Addon CR into ACK.Terminal with "Addon version specified is not supported":
   #   aws eks describe-addon-versions \
   #     --addon-name aws-secrets-store-csi-driver-provider \
-  #     --kubernetes-version 1.35 --region us-west-2
-  addonVersion: v3.1.2-eksbuild.1
+  #     --kubernetes-version 1.35 --region us-west-2 \
+  #     --query 'addons[0].addonVersions[].addonVersion'
+  addonVersion: v3.1.1-eksbuild.2
   configurationValues: |-
     {
       "secrets-store-csi-driver": {

--- a/flux/prow/mirror/mirror-job.yaml
+++ b/flux/prow/mirror/mirror-job.yaml
@@ -98,7 +98,7 @@ spec:
                 ;;
             esac
 
-            dst_tag="$${tag}-ack.$${PROW_PATCH_REVISION}"
+            dst_tag="$${tag}$${PATCH_SUFFIX}"
 
             if aws ecr describe-images \
                  --region "$${AWS_REGION}" \
@@ -120,8 +120,14 @@ spec:
           value: "${PROW_VERSION}"
         - name: TOOLS_VERSION
           value: "${TOOLS_VERSION}"
-        - name: PROW_PATCH_REVISION
-          value: "${PROW_PATCH_REVISION}"
+        # Pass the whole suffix, not the bare revision. `kustomize build` strips
+        # the redundant quotes from value: "${PROW_PATCH_REVISION}", and Flux
+        # then substitutes a bare number, which YAML parses as an int -- the API
+        # server rejects the Job because env[].value must be a string. Keeping a
+        # non-numeric prefix in the value makes it a string under any quoting.
+        # Must stay in sync with the tag suffix in flux/prow/charts/prow-config.yaml.
+        - name: PATCH_SUFFIX
+          value: "-ack.${PROW_PATCH_REVISION}"
         volumeMounts:
         - name: work
           mountPath: /work

--- a/prow/jobs/templates/job-config-job.yaml.tpl
+++ b/prow/jobs/templates/job-config-job.yaml.tpl
@@ -89,7 +89,7 @@ spec:
           echo "Substituting variables in jobs.yaml..."
           # Substitute only the variables needed for Prow job configuration.
           # The $$ prefix is escaped by Flux postBuild (becomes $ after substitution).
-          envsubst '$$TEST_INFRA_ORG $$TEST_INFRA_REPO $$TEST_INFRA_BRANCH $$PROW_IMAGES_REPO_URI $$CONTROLLER_ECR_REGISTRY $$PROW_MIRROR_REGISTRY $$PROW_VERSION $$TOOLS_VERSION $$PROW_PATCH_REVISION' \
+          envsubst '$$TEST_INFRA_ORG $$TEST_INFRA_REPO $$TEST_INFRA_BRANCH $$PROW_IMAGES_REPO_URI $$CONTROLLER_ECR_REGISTRY $$PROW_MIRROR_REGISTRY $$PROW_VERSION $$TOOLS_VERSION $$PATCH_SUFFIX' \
             < /workspace/prow/jobs/jobs.yaml \
             > /output/jobs-substituted.yaml
 
@@ -97,9 +97,9 @@ spec:
           if grep -qF 'TEST_INFRA_ORG}' /output/jobs-substituted.yaml || \
              grep -qF 'TEST_INFRA_REPO}' /output/jobs-substituted.yaml || \
              grep -qF 'TEST_INFRA_BRANCH}' /output/jobs-substituted.yaml || \
-             grep -qF 'PROW_PATCH_REVISION}' /output/jobs-substituted.yaml; then
+             grep -qF 'PATCH_SUFFIX}' /output/jobs-substituted.yaml; then
             echo "ERROR: Variable substitution incomplete!"
-            grep -c 'TEST_INFRA\|PROW_PATCH_REVISION' /output/jobs-substituted.yaml || true
+            grep -c 'TEST_INFRA\|PATCH_SUFFIX' /output/jobs-substituted.yaml || true
             exit 1
           fi
 
@@ -125,8 +125,11 @@ spec:
           value: "${PROW_VERSION}"
         - name: TOOLS_VERSION
           value: "${TOOLS_VERSION}"
-        - name: PROW_PATCH_REVISION
-          value: "${PROW_PATCH_REVISION}"
+        # Whole suffix, not the bare revision: kustomize drops the redundant
+        # quotes and Flux then substitutes a bare number, which YAML parses as an
+        # int and the API server rejects for env[].value.
+        - name: PATCH_SUFFIX
+          value: "-ack.${PROW_PATCH_REVISION}"
         volumeMounts:
         - name: workspace
           mountPath: /workspace

--- a/prow/jobs/templates/periodics/label_sync.tpl
+++ b/prow/jobs/templates/periodics/label_sync.tpl
@@ -13,7 +13,7 @@
     serviceAccountName: periodic-service-account
     containers:
     - name: label-sync
-      image: ${PROW_MIRROR_REGISTRY}/label_sync:${TOOLS_VERSION}-ack.${PROW_PATCH_REVISION}
+      image: ${PROW_MIRROR_REGISTRY}/label_sync:${TOOLS_VERSION}${PATCH_SUFFIX}
       resources:
         limits:
           cpu: 1

--- a/prow/jobs/templates/periodics/lifecycle_bot_periodic_close.tpl
+++ b/prow/jobs/templates/periodics/lifecycle_bot_periodic_close.tpl
@@ -11,7 +11,7 @@
   spec:
     serviceAccountName: periodic-service-account
     containers:
-      - image: ${PROW_MIRROR_REGISTRY}/commenter:${TOOLS_VERSION}-ack.${PROW_PATCH_REVISION}
+      - image: ${PROW_MIRROR_REGISTRY}/commenter:${TOOLS_VERSION}${PATCH_SUFFIX}
         resources:
           limits:
             cpu: 1

--- a/prow/jobs/templates/periodics/lifecycle_bot_periodic_rotten.tpl
+++ b/prow/jobs/templates/periodics/lifecycle_bot_periodic_rotten.tpl
@@ -11,7 +11,7 @@
   spec:
     serviceAccountName: periodic-service-account
     containers:
-      - image: ${PROW_MIRROR_REGISTRY}/commenter:${TOOLS_VERSION}-ack.${PROW_PATCH_REVISION}
+      - image: ${PROW_MIRROR_REGISTRY}/commenter:${TOOLS_VERSION}${PATCH_SUFFIX}
         resources:
           limits:
             cpu: 1

--- a/prow/jobs/templates/periodics/lifecycle_bot_periodic_stale.tpl
+++ b/prow/jobs/templates/periodics/lifecycle_bot_periodic_stale.tpl
@@ -11,7 +11,7 @@
   spec:
     serviceAccountName: periodic-service-account
     containers:
-      - image: ${PROW_MIRROR_REGISTRY}/commenter:${TOOLS_VERSION}-ack.${PROW_PATCH_REVISION}
+      - image: ${PROW_MIRROR_REGISTRY}/commenter:${TOOLS_VERSION}${PATCH_SUFFIX}
         resources:
           limits:
             cpu: 1


### PR DESCRIPTION
Hotfix for two defects in #1037 that stopped its Flux-side changes from applying. Found while verifying the rollout on the prod cluster.

**No outage.** The Prow control plane kept running on its previous images throughout — all pods Running/Ready with ~6d uptime, untouched. The `wait: true` added to `prow-mirror` during review of #1037 is what prevented `prow-charts` from rolling out image tags that had not been built yet, which would have put deck/hook/tide/crier into `ImagePullBackOff`.

## Observed state before this fix

| Kustomization | Status |
|---|---|
| `prow-mirror` | **failed** — Job rejected by the API server |
| `prow-charts` | blocked on `prow-mirror` |
| `prometheus`, `prometheus-dashboards` | blocked on `prow-charts` |
| `ack-addons` | **unhealthy** — Addon CR in `ACK.Terminal` |
| `secrets` | blocked on `ack-addons` |

Net effect: #1037's step 2 (rebuilding our own job images) landed correctly — all 16 patched images are in ECR, including `prow-build-prow-images-0.0.72`. Steps 1 and 3 delivered nothing.

## Defect 1 — mirror Job rejected on env value typing

```
env[name="PROW_PATCH_REVISION"].value: expected string, got &value.valueUnstructured{Value:1}
```

The manifest quoted the value as `value: "${PROW_PATCH_REVISION}"`, but `kustomize build` strips quotes it considers redundant, emitting `value: ${PROW_PATCH_REVISION}`. Flux then substitutes `1`, and YAML parses that as an **integer**, which the API server rejects because `env[].value` must be a string.

Every other substituted variable survived because its value happens to be non-numeric (`us-west-2`, `v20260702-fff8399c7`, an ECR hostname). Only the purely numeric one tripped it.

Fixed by passing the whole suffix instead of the bare revision, so the value can never be numeric under any quoting:

```yaml
- name: PATCH_SUFFIX
  value: "-ack.${PROW_PATCH_REVISION}"
```

The same latent bug was in `job-config-job.yaml.tpl` and would have broken the `prow-jobs` Kustomization the moment the bot regenerated the job config, so it is fixed there and in the four periodic templates too.

## Defect 2 — addon version not offered for this cluster

The addon pinned `v3.1.2-eksbuild.1`, which is not available for this cluster's Kubernetes version. The Addon CR went:

```
ACK.Terminal=True  InvalidParameterException: Addon version specified is not supported
```

The live addon was never changed (`describe-addon` still reports `v3.1.1-eksbuild.1`, `ACTIVE`), so there was no impact beyond `ack-addons` staying unhealthy and blocking `secrets`.

Pinned to `v3.1.1-eksbuild.2`, the newest version offered for Kubernetes 1.35 and also the default.

My mistake in #1037 was reading `describe-addon-versions` **without** `--kubernetes-version`; that output also lists versions for newer Kubernetes releases, and my summary collapsed compatibility across all versions rather than per version. The comment now says to always filter by cluster version and shows the query.

## Testing

- **Server-side dry run against the live cluster, create path:** `job.batch/prow-mirror-images-dryrun serverside-applied (server dry run)`, and confirmed nothing persisted. Applying under the real name only reports `spec.template ... field is immutable`, which is expected for an existing completed Job and is exactly why the Kustomization uses `force: true`.
- **Addon manifest dry run:** all four resources `serverside-applied`, including `secrets-store-csi`.
- **Version check:** `v3.1.1-eksbuild.2` confirmed present in `describe-addon-versions --kubernetes-version 1.35`.
- **Env value type assertion** over `kustomize build` + Flux substitution for `flux/prow/mirror`, `flux/prow/charts` and `prow/jobs` — all `env[].value` are strings. This is the check that would have caught defect 1, and it is the gap in how #1037 was verified: substitution was simulated against the raw file, where the quotes were still intact, instead of against the kustomize output.
- `make prow-gen` regenerates cleanly with `PATCH_SUFFIX` threaded through; generated output intentionally not committed, per the two-phase flow.
- Both embedded mirror scripts still pass `sh -n` / `bash -n`; `dst_tag` resolves to `v20260702-fff8399c7-ack.1`.

## After merge

`prow-mirror` will build and push the 15 patched images, then `prow-charts` rolls the control plane onto the `-ack.1` tags. Expect the mirror Job to take several minutes on its first run; the `timeout: 30m` covers it. I will confirm the rollout and re-check the image digests once it settles.

Still outstanding from #1037, unchanged: `flux/prow/build-cluster-connection/job.yaml` needs a manual bump to `prow-kubectl-0.0.3` now that the image exists, and the bot PR needs to land the regenerated job config.
