### PR TITLE
Fix mirror Job patching only the first image (active outage)

### DIFF
--- a/flux/prow/mirror/mirror-job.yaml
+++ b/flux/prow/mirror/mirror-job.yaml
@@ -159,13 +159,13 @@ spec:
 
             __ctr=$$(buildah from --pull=always "$${__src}/$${__img}:$${__tag}") || return 1
 
-            if ! buildah run --user root "$$__ctr" -- /bin/sh -c 'command -v apk >/dev/null 2>&1'; then
+            if ! buildah run --user root "$$__ctr" -- /bin/sh -c 'command -v apk >/dev/null 2>&1' < /dev/null; then
               echo "     base image has no apk; refusing to publish unpatched" >&2
               buildah rm "$$__ctr" >/dev/null 2>&1 || true
               return 2
             fi
 
-            if ! buildah run --user root "$$__ctr" -- /bin/sh -c 'apk -U upgrade --no-cache'; then
+            if ! buildah run --user root "$$__ctr" -- /bin/sh -c 'apk -U upgrade --no-cache' < /dev/null; then
               buildah rm "$$__ctr" >/dev/null 2>&1 || true
               return 1
             fi
@@ -196,8 +196,12 @@ spec:
 
           FAILED=0
           TOTAL=0
+          EXPECTED=$$(wc -l < /work/build-list | tr -d ' ')
 
-          while IFS='|' read -r src img tag dst_tag; do
+          # Read the work list on FD 3, not stdin. buildah run attaches the
+          # container's stdin, which drains an inherited stdin and silently ends
+          # the loop after the first image.
+          while IFS='|' read -r src img tag dst_tag <&3; do
             [ -z "$${src:-}" ] && continue
             TOTAL=$$((TOTAL + 1))
             echo "-> $${img}:$${dst_tag} (from $${src}/$${img}:$${tag})"
@@ -221,10 +225,19 @@ spec:
               echo "   FAILED (rc=$$rc)"
               FAILED=$$((FAILED + 1))
             fi
-          done < /work/build-list
+          done 3< /work/build-list
 
           echo ""
-          echo "Patch complete. Failures: $${FAILED}/$${TOTAL}"
+          echo "Patch complete. Processed $${TOTAL}/$${EXPECTED}, failures: $${FAILED}"
+
+          # Fail loudly if the loop did not cover the whole work list. Without
+          # this the Job reports success after a partial run, and prow-charts
+          # then rolls components onto tags that were never built.
+          if [ "$$TOTAL" -ne "$$EXPECTED" ]; then
+            echo "ERROR: processed $${TOTAL} of $${EXPECTED} queued images" >&2
+            exit 1
+          fi
+
           [ "$$FAILED" -gt 0 ] && exit 1
           exit 0
         env:


### PR DESCRIPTION
> **Merging this resolves an active partial outage.** `ghproxy`, `horologium` and `tide` currently have no available replicas; `deck` and `hook` are at half capacity.

## What broke

The mirror Job read its work list on **stdin**:

```sh
while IFS='|' read -r src img tag dst_tag; do
  ...
done < /work/build-list
```

`buildah run` attaches the container's stdin, which drained that inherited descriptor, so the loop ended after the first image. The Job then **reported success** because the failure counter was zero:

```
Queued 15 image(s) for patching.
...
Patch complete. Failures: 0/1
```

Only `prow/crier` was rebuilt. `prow-charts` had already pinned all 13 components to `-ack.1`, so the twelve tags that were never built could not be pulled.

| Component | State |
|---|---|
| `ghproxy`, `horologium`, `tide` | 0 available — `ImagePullBackOff` |
| `deck`, `hook` | 1 of 2 available, old pod still serving |
| `prow-controller-manager`, `sinker`, `statusreconciler` | 1 of 1, old pod still serving; new pod failing |
| `crier` | healthy on the patched image |

`wait: true` did not help here: the Job genuinely completed and reported success, so Flux correctly treated it as healthy and let `prow-charts` proceed.

## Fix

Read the work list on FD 3 so no child process can consume it, and redirect `buildah run`'s stdin from `/dev/null` as belt and braces:

```sh
while IFS='|' read -r src img tag dst_tag <&3; do
  ...
done 3< /work/build-list
```

**And assert completeness before exiting 0.** The silent partial success is what let this reach the control plane — a Job that does 1 of 15 and reports success is indistinguishable from a healthy run, and `prow-charts` depends on this Job having actually produced every tag:

```sh
if [ "$TOTAL" -ne "$EXPECTED" ]; then
  echo "ERROR: processed ${TOTAL} of ${EXPECTED} queued images" >&2
  exit 1
fi
```

## Testing

Reproduced with a stub whose `buildah run` drains stdin, exactly like the runtime attaching container stdin:

| | exit | images pushed | reported |
|---|---|---|---|
| before (`a99499c`, deployed) | 0 | 2 | `Failures: 0/1` |
| after | 0 | 30 | `Processed 15/15, failures: 0` |

The before case matches production output exactly. 30 pushes for 15 images is correct — suffixed tag plus bare alias.

Also confirmed the earlier checks still hold: `kustomize build` clean, env values all strings after substitution, `sh -n` / `bash -n` on both embedded scripts.

## Recovery after merge

`prow-mirror` reconciles on source change with `force: true`, so Flux recreates the Job, all 15 images get patched, and the pending ReplicaSets pull successfully. No manual intervention needed; recovery should follow within a few minutes of the mirror Job completing.

The already-patched `crier` will be skipped by the plan container, since its `-ack.1` tag exists.
