### PR TITLE
Enable routing to build cluster by Prow controlplane components

### DIFF
--- a/flux/prow/charts/prow-config.yaml
+++ b/flux/prow/charts/prow-config.yaml
@@ -44,9 +44,10 @@ spec:
     # server + certificateAuthorityData come from the ACK Cluster CR status via
     # the build-cluster-connection ConfigMap.
     buildCluster:
-      # Provisioned and staged by this deployment but not yet wired into the four
-      # components; flip to true in a follow-up once the build cluster is verified.
-      enabled: false
+      # Build cluster provisioned and verified; wired into the four components.
+      # Pre-submit routing is enabled separately via presubmit_cluster in
+      # prow/jobs/jobs_config.yaml.
+      enabled: true
       name: build
       clusterName: "${STACK_NAME}-build-cluster"
       server: "${BUILD_CLUSTER_ENDPOINT}"

--- a/prow/config/Chart.yaml
+++ b/prow/config/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: prow-config
 description: Configuration for the ACK Prow cluster
 type: application
-version: 0.4.22
+version: 0.4.23
 appVersion: "1.16.0"


### PR DESCRIPTION
Issue #, if available:

Description of changes:
 Flips buildCluster.enabled to true in flux/prow/charts/prow-config.yaml, wiring the dedicated EKS build cluster (provisioned in #1031) into the four control-plane components — prow-controller-manager, sinker, crier, and deck. This is the first of the two follow-ups called out in #1031's rollout plan.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
