### PR TITLE
Resolve agent-plugin modules via the Go module proxy

### DIFF
--- a/prow/plugins/images/Dockerfile.agent-plugin
+++ b/prow/plugins/images/Dockerfile.agent-plugin
@@ -10,7 +10,14 @@ WORKDIR /app
 
 # Copy go mod files
 COPY go.mod go.sum ./
-ENV GOPROXY=direct
+# Resolve modules through the module proxy, falling back to direct VCS on any
+# error. GOPROXY=direct alone cannot resolve this module graph: go.opencensus.io
+# pulls in google.golang.org/grpc v1.33.2, which needs a pseudo-version of
+# github.com/cncf/udpa/go, and that repository has since moved to cncf/xds, so
+# the git fetch fails. The proxy serves an immutable copy. The `|` separator
+# falls back to direct on any error, so this can only add a resolution path.
+ARG GOPROXY=https://proxy.golang.org|direct
+ENV GOPROXY=${GOPROXY}
 RUN go mod download
 
 # Copy source code

--- a/prow/plugins/images_config.yaml
+++ b/prow/plugins/images_config.yaml
@@ -1,3 +1,3 @@
 image_repo: ${PROW_IMAGES_REPO_URI}
 images:
-    agent-plugin: agent-plugin-0.0.6
+    agent-plugin: agent-plugin-0.0.7


### PR DESCRIPTION
The `agent-plugin` image build has now failed twice with a byte-identical error, so this is reproducible rather than the flake I first took it for.

## The failure

```
[1/2] STEP 5/8: ENV GOPROXY=direct
[1/2] STEP 6/8: RUN go mod download
go: go.opencensus.io@v0.24.0 requires
    google.golang.org/grpc@v1.33.2 requires
    github.com/cncf/udpa/go@v0.0.0-20191209042840-269d4d468f6f: invalid version:
    git fetch --unshallow -f --end-of-options origin ...: exit status 128:
    fatal: shallow file has changed since we read it
Error: building at STEP "RUN go mod download": exit status 1
Error building prow plugins
```

`Dockerfile.agent-plugin` is the only builder that hard-sets `ENV GOPROXY=direct`; every other Dockerfile in the repo uses `ARG GOPROXY=https://proxy.golang.org|direct`. With `direct`, Go has to clone every module from VCS, including `github.com/cncf/udpa/go` at a 2019 pseudo-version reached transitively through `go.opencensus.io` (indirect) → `google.golang.org/grpc@v1.33.2`. That repository has since moved to `cncf/xds`, so the clone fails.

Note it appears in `go.sum` only as a `/go.mod` hash — it is needed purely to resolve the module graph, never built. Exactly the case a module proxy handles and direct VCS does not.

## Fix

Match the convention used everywhere else in the repo:

```dockerfile
ARG GOPROXY=https://proxy.golang.org|direct
ENV GOPROXY=${GOPROXY}
```

**This cannot regress the current behaviour.** The `|` separator falls back to `direct` on *any* error, so if the proxy is unreachable from the build environment the build behaves exactly as it does today. The change can only add a resolution path.

## What I verified, and what I did not

Verified:
- Two consecutive builds failed at the same step with identical output — reproducible, not transient.
- `Dockerfile.agent-plugin` is the only builder pinning `GOPROXY=direct`; the working images use the proxy form.
- The failing module is an indirect, graph-only dependency (`/go.mod`-only entry in `go.sum`), consistent with the diagnosis.

**Not** verified: I could not confirm from my host that `proxy.golang.org` serves this specific module — there is no egress to it from my dev desktop (`curl` returns 000, and a local `go get` A/B did not complete). The real validation is the build itself. Given the fallback semantics the downside is bounded: worst case the build fails the same way it does now, and we look at pinning or pruning the dependency instead.

## Follow-up if this does not take

The alternative is to address the dependency rather than the transport — `go mod tidy` on `prow/plugins/agent-plugin` to see whether `go.opencensus.io` is still genuinely needed, or an explicit `replace`/`exclude` for the archived module. I did not do that here because changing the module graph is a larger change than fixing the fetch transport, and the transport is the actual thing that broke.

## Context

This is the last item in the #1037 series. Everything else is done: the Prow control plane is fully on patched images with all Deployments at full replicas, and the `add-resource` workflow was wired in #1044. `agent-plugin` is the only container still on an unpatched image.

## Also in this PR

`agent-plugin` is bumped to `0.0.7` to re-trigger the postsubmit, whose only trigger is a change under `prow/*/images_config.yaml`. `0.0.6` was never built, so nothing is lost by moving past it. The generated plugin deployment deliberately stays on the existing `agent-plugin-0.0.3` until the build succeeds; the bot PR wires it after that, and that path does work for plugins because a successful build makes `BUILT_PLUGIN_TAGS` non-empty.

The `ARG GOPROXY=https://proxy.golang.org|direct` form, including the unquoted `|`, is already used by the Dockerfiles that build successfully in this repo, so the syntax is proven here.
