### PR TITLE
Require a builder image bump when prow/jobs/tools changes

### DIFF
--- a/bootstrap/README.md
+++ b/bootstrap/README.md
@@ -225,6 +225,9 @@ is applied directly by the `prow-jobs` Kustomization (`interval: 5m`,
   job builds its own successor. This only holds while step 1 above is respected;
   hand-committing a regenerated `jobs.yaml` would point the job at the image it
   has not built yet.
+- **Changing `prow/jobs/tools/` requires bumping `build-prow-images`.**
+  `ack-build-tools` is compiled into that image, so without a bump the new binary
+  is never built.
 - **`flux/prow/build-cluster-connection/job.yaml`** pins a `prow-kubectl` tag
   but is not in the generator's output set, so `make prow-gen` will never update
   it. Bump it by hand once the new tag is in ECR, or its OS packages silently


### PR DESCRIPTION
Adds one requirement to the existing "Exceptions the generator does not cover" list in `bootstrap/README.md`:

> **Changing `prow/jobs/tools/` requires bumping `build-prow-images`.** `ack-build-tools` is compiled into that image, so without a bump the new binary is never built.

That list already noted `build-prow-images` is *safe* to bump alone, but not that it is sometimes *required*. Missing it is what wedged the `build-prow-images` postsubmit from #1031 until #1043.

Documentation only. 3 lines, one file.
