### PR TITLE
Apply test_config.yaml ConfigMap to build cluster

### DIFF
--- a/flux/prow/build-cluster-resources/kustomization.yaml
+++ b/flux/prow/build-cluster-resources/kustomization.yaml
@@ -1,8 +1,27 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
+# disableNameSuffixHash so the generated ConfigMap keeps the bare name
+# `test-config` — the `preset-test-config` preset mounts it by that exact name,
+# and a content hash suffix would break the volume mount. Mirrors
+# prow/jobs/kustomization.yaml.
+generatorOptions:
+  disableNameSuffixHash: true
+
 resources:
 - namespace.yaml
 - rbac.yaml
 - nodeclass.yaml
 - nodepool.yaml
+
+# test-config ConfigMap for pre-submit pods running on the build cluster.
+# References the SAME source file the control plane uses (prow/jobs/test_config.yaml)
+# so the two clusters can't drift. Flux's kustomize-controller builds with load
+# restrictions disabled (LoadRestrictionsNone), so this out-of-path file reference
+# is permitted; a plain `kustomize build` needs --load-restrictor LoadRestrictionsNone.
+configMapGenerator:
+- name: test-config
+  namespace: test-pods
+  behavior: create
+  files:
+  - ../../../prow/jobs/test_config.yaml


### PR DESCRIPTION
Issue #, if available:

Description of changes:
Build cluster canary test of ecr service presubmits showed that test_config.yaml was not being applied to the build cluster prevent e2e, release, and recommended-policy jobs to fail due to a missing volume mount sourced from test_config.yaml. This PR updates `build-cluster-resource` to apply test_config.yaml to the build-cluster via Flux. Note, test_config.yaml is still maintained on the control plane cluster.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
