### PR TITLE
Bump secrets-store CSI provider addon to v3.1.2-eksbuild.1

### DIFF
--- a/flux/ack/cluster/addons/addons.yaml
+++ b/flux/ack/cluster/addons/addons.yaml
@@ -19,7 +19,7 @@ spec:
   #     --addon-name aws-secrets-store-csi-driver-provider \
   #     --kubernetes-version 1.35 --region us-west-2 \
   #     --query 'addons[0].addonVersions[].addonVersion'
-  addonVersion: v3.1.1-eksbuild.2
+  addonVersion: v3.1.2-eksbuild.1
   configurationValues: |-
     {
       "secrets-store-csi-driver": {


### PR DESCRIPTION
Bumps `aws-secrets-store-csi-driver-provider` from `v3.1.1-eksbuild.2` to `v3.1.2-eksbuild.1`.

## Why this is safe now when it wasn't earlier

`v3.1.2-eksbuild.1` is the version #1037 originally pinned. It failed then, because it was not offered for this cluster's Kubernetes version, and the Addon CR went:

```
ACK.Terminal=True  InvalidParameterException: Addon version specified is not supported
```

#1041 pinned back to `v3.1.1-eksbuild.2`, the newest version offered for 1.35 at the time.

AWS has since added 1.35 compatibility. `describe-addon-versions` now returns it for both 1.35 and 1.36:

```
$ aws eks describe-addon-versions --addon-name aws-secrets-store-csi-driver-provider \
    --kubernetes-version 1.35 --region us-west-2 \
    --query 'addons[0].addonVersions[].addonVersion'
v3.1.2-eksbuild.1     <- was absent from this list earlier
v3.1.1-eksbuild.2
v3.1.1-eksbuild.1
...
```

## Verification, and its limit

Verified: `v3.1.2-eksbuild.1` is present in the supported list for Kubernetes 1.35, queried with `--kubernetes-version` as the comment in this file instructs. That filtered query is precisely the check whose absence caused the original mistake.

**Not** verified: I could not query the live cluster while preparing this — my credentials had rotated to a different account. So this rests on the addon-versions API rather than on a dry-run against the cluster, and the cluster is assumed to still be on 1.35 (as it was when last checked, `v1.35.6-eks-8f14419`).

After merge, please confirm the Addon CR actually reconciles rather than assuming it did:

```bash
kubectl -n ack-system get addons.eks.services.k8s.aws secrets-store-csi \
  -o jsonpath='{.spec.addonVersion} {.status.status}{"\n"}{range .status.conditions[*]}{.type}={.status} {.message}{"\n"}{end}'
```

Expect `ACTIVE`, `ACK.ResourceSynced=True`, and **no** `ACK.Terminal`. If `ACK.Terminal` appears, `ack-addons` goes unhealthy and blocks the `secrets` Kustomization, which is what happened last time — revert to `v3.1.1-eksbuild.2` in that case.
