### PR TITLE
Stop build-cluster wiring from gating the Prow control plane

### DIFF
--- a/flux/prow.yaml
+++ b/flux/prow.yaml
@@ -92,8 +92,10 @@ spec:
   path: ./flux/prow/build-cluster-connection
   prune: false
   force: true
-  # wait for the Job to COMPLETE (not just apply), so prow-charts' dependsOn
-  # blocks until the ConfigMap it substitutes from actually exists.
+  # Wait for the Job to COMPLETE (not just apply) so this Kustomization's own
+  # readiness reflects the build-cluster-connection ConfigMap actually existing.
+  # Nothing gates on it any more (see prow-charts below), so a failure here is
+  # contained to the build cluster wiring.
   wait: true
   timeout: 5m
   postBuild:
@@ -128,9 +130,20 @@ spec:
     - kind: ConfigMap
       name: build-cluster-connection
       optional: true
+  # Deliberately NOT dependent on prow-build-cluster-connection. Correctness is
+  # already enforced inside the chart rather than by ordering:
+  #   - build-cluster-kubeconfig-ConfigMap.yaml is wrapped in
+  #     `if .Values.buildCluster.enabled`, so while the flag is false the endpoint
+  #     and CA are unused and their absence cannot matter.
+  #   - when the flag is true, `required` on buildCluster.server,
+  #     certificateAuthorityData and clusterName makes the render fail loudly, so
+  #     a missing ConfigMap can never produce a silently broken kubeconfig.
+  # Gating on it instead meant any failure of that Job — for example a
+  # prow-kubectl tag absent from one environment's registry — blocked the entire
+  # Prow control plane rollout. Failing locally in prow-charts and retrying is a
+  # far smaller blast radius than wedging every component.
   dependsOn:
   - name: prow-mirror
-  - name: prow-build-cluster-connection
 ---
 # Build cluster kubeconfig ConfigMap — applied LOCALLY to flux-system on the
 # control-plane cluster. Substitutes the cluster ARN into the aws-provider


### PR DESCRIPTION
Removes `prow-build-cluster-connection` from `prow-charts`' `dependsOn`, so a failure in the build-cluster wiring can no longer block the entire Prow control plane rollout.

cc @knottnt — this touches the dependency wiring from #1031, so I'd like your read. I have not changed the build cluster design itself, only what gates on it.

## What went wrong

Staging's Prow upgrade was blocked for hours by this chain:

```
build-cluster-connection Job: ImagePullBackOff (prow-kubectl-0.0.3 absent from staging's registry)
  -> prow-build-cluster-connection: health check failed after 5m
    -> prow-charts:            dependency not ready
      -> prometheus:           dependency not ready
        -> prometheus-dashboards: dependency not ready
```

The entire control plane stayed on unpatched images because one gated, disabled-by-default feature's helper Job could not pull its image. `buildCluster.enabled` was `false` the whole time, so nothing in that chain actually needed the build-cluster connection data.

The trigger was my own change in #1043, which bumped that Job to `prow-kubectl-0.0.3`. Each environment has its own registry with independent tag numbering, so a tag valid in prod was absent in staging.

## Why removing the dependency is safe

Correctness is already enforced inside the chart, not by ordering — the `dependsOn` was belt-and-braces on top of guards that already exist:

- `build-cluster-kubeconfig-ConfigMap.yaml` is wrapped in `{{- if .Values.buildCluster.enabled }}`, so while the flag is false the endpoint and CA are unused.
- When the flag is true, `required` on `buildCluster.server`, `certificateAuthorityData` and `clusterName` makes the render fail rather than emit a partial kubeconfig.
- `prow-charts` already declares that ConfigMap `optional: true` in `substituteFrom`, which anticipates it being absent.

I verified all three paths by rendering the chart with the real `HelmRelease` values and `BUILD_CLUSTER_ENDPOINT`/`BUILD_CLUSTER_CA` deliberately empty, simulating the ConfigMap being absent:

| `buildCluster.enabled` | endpoint/CA | Result |
|---|---|---|
| `false` | empty | Renders fine; **no** `build-cluster-kubeconfig` ConfigMap emitted |
| `true` | empty | **Fails loudly**: `buildCluster.server is required when buildCluster.enabled` |
| `true` | supplied | Renders fine; ConfigMap emitted and mounted |

The middle row is the important one. A missing ConfigMap cannot produce a silently broken kubeconfig — it produces a failed `prow-charts` render, which Flux retries, contained to that one Kustomization.

## Trade-off

When `buildCluster.enabled` flips to `true` (as #1045 does), if `prow-charts` reconciles before the connection Job has written its ConfigMap, `prow-charts` will fail its render until the next retry. That is a transient, self-healing, clearly-attributed failure in one Kustomization.

That seems strictly preferable to the current behaviour, where an unrelated failure in that Job wedges every Prow component. `prow-build-cluster-connection` keeps `wait: true` so its own readiness still reflects the Job completing; it is simply no longer a gate on anything else. `prow-charts` was its only consumer in the graph.

## Testing

- `kustomize build flux/` succeeds; `flux/prow.yaml` parses.
- Dependency graph after the change — `prow-charts` now gates only on `prow-mirror`, everything else untouched:

```
prow-version                   dependsOn=[]
prow-crds                      dependsOn=['ack-pod-identities']
prow-mirror                    dependsOn=['prow-version', 'ack-pod-identities', 'ack-prow']
prow-build-cluster-connection  dependsOn=['ack-build-infra']
prow-charts                    dependsOn=['prow-mirror']
prow-build-cluster-kubeconfig  dependsOn=[]
prow-build-cluster-resources   dependsOn=['prow-build-cluster-kubeconfig', 'ack-build-infra']
```

- Confirmed `prow-charts` was the only Kustomization depending on `prow-build-cluster-connection`, so nothing else changes ordering.

## Related, not fixed here

The underlying cause of the staging outage was that its registry had not been rebuilt since 2026-07-23, so newer job-image tags did not exist there. Staging's `build-prow-images` postsubmit has never produced a ProwJob — all 41 of its ProwJobs are `periodic`. I am still tracking that separately; this PR only limits the blast radius when it happens.
