### PR TITLE
fix: ignore ACKGenerateBuildDate in verify-code-gen test

### DIFF
--- a/cd/scripts/verify-code-gen.sh
+++ b/cd/scripts/verify-code-gen.sh
@@ -143,6 +143,9 @@ filter_patterns_for_file() {
         NOTES.txt)
             echo 'controller:[0-9]+\.[0-9]+\.[0-9]+'
             ;;
+        pkg/version/version.go)
+         echo 'ACKGenerateBuildDate'
+          ;;
         *)
             # No patterns to filter for other files
             echo ''


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
