### PR TITLE
fix: Match version.go by basename in verify-code-gen filter

### DIFF
--- a/cd/scripts/verify-code-gen.sh
+++ b/cd/scripts/verify-code-gen.sh
@@ -73,13 +73,15 @@ info_msg "Checking for differences..."
 # validated (semver prefix must match, 'dirty' suffix is rejected) before
 # the git-describe suffix is filtered out as noise.
 #
-# Patterns are applied only to the files that contain them:
+# Patterns are applied only to the files that contain them. Note that the
+# case labels are matched against each file's basename, not its full path:
 #   ack-generate-metadata.yaml: api_directory_checksum, build_date,
 #                                build_hash, go_version, version
 #   kustomization.yaml:         newTag
 #   Chart.yaml:                 version, appVersion
 #   values.yaml:                tag
 #   NOTES.txt:                  embedded image tag (controller:X.Y.Z)
+#   version.go:                 ACKGenerateBuildDate (pkg/version/version.go)
 
 # Validates the version field in ack-generate-metadata.yaml.
 # Fails if either version contains 'dirty' or the semver prefixes differ.
@@ -143,9 +145,9 @@ filter_patterns_for_file() {
         NOTES.txt)
             echo 'controller:[0-9]+\.[0-9]+\.[0-9]+'
             ;;
-        pkg/version/version.go)
-         echo 'ACKGenerateBuildDate'
-          ;;
+        version.go)
+            echo '\s*ACKGenerateBuildDate\s*='
+            ;;
         *)
             # No patterns to filter for other files
             echo ''


### PR DESCRIPTION
The `ACKGenerateBuildDate` filter added in #1054 never takes effect, so `verify-code-gen` still fails on the timestamp it was meant to ignore.

### Why it doesn't work

`filter_patterns_for_file` matches its `case` labels against the file's **basename**:

```bash
local basename
basename=$(basename "$file")
case "$basename" in
```

`basename pkg/version/version.go` is `version.go`, so the label added in #1054 — `pkg/version/version.go)` — cannot match. The file falls through to `*)`, which applies no filtering, and the timestamp is compared verbatim. Every other label in the block (`ack-generate-metadata.yaml`, `Chart.yaml`, `values.yaml`, `NOTES.txt`) is a bare basename, which is the convention this follows.

```
$ f="pkg/version/version.go"; basename "$f"
version.go
```

### Impact

code-generator [#728](https://github.com/aws-controllers-k8s/code-generator/pull/728) bakes the `ack-generate` build timestamp into the committed `pkg/version/version.go`:

```go
const (
	ACKGenerateVersion   = "v0.62.1"
	ACKGenerateBuildDate = "2026-08-13T16:27:58Z"
)
```

CI rebuilds `ack-generate` on every run, so this value can never match what is committed. That makes `verify-code-gen` fail on **every controller PR that regenerates code**, which is what #1054 set out to fix. Live example: [s3control-controller#47](https://github.com/aws-controllers-k8s/s3control-controller/pull/47), whose entire reported diff is that one line.

### The change

Match on `version.go`, and anchor the pattern on the assignment rather than the bare identifier so the filter cannot suppress a genuine change that merely mentions the constant:

```diff
-        pkg/version/version.go)
-         echo 'ACKGenerateBuildDate'
-          ;;
+        version.go)
+            echo '\s*ACKGenerateBuildDate\s*='
+            ;;
```

Also notes the basename-matching behaviour in the header comment that enumerates the patterns, since that is the detail the original change tripped over, and adds the new entry to that list.

### Testing

Ran the script's real diff-detection loop against a real controller repo (`s3control-controller` at the head of #47), simulating what CI does after `make build-controller` — the only thing a fresh regeneration changes is the build timestamp:

```
simulated regeneration diff:
       apis/v1alpha1/ack-generate-metadata.yaml | 2 +-
       pkg/version/version.go                   | 2 +-

--- with the filter as merged in #1054 ---
FAIL (differences reported):
      -	ACKGenerateBuildDate = "2026-08-13T16:27:58Z"
      +	ACKGenerateBuildDate = "2026-08-13T18:00:00Z"

--- with this branch's fix ---
PASS (no meaningful differences)

RESULT: reproduces the failure and the fix resolves it
```

Also exercised `filter_patterns_for_file` directly, extracted from the script, to confirm the fix is scoped and nothing regresses:

```
the line that is blocking every regen PR:
  PASS  pkg/version/version.go  filtered=yes
a real code change in the same file must still be reported:
  PASS  pkg/version/version.go  filtered=no
the deterministic sibling constant must still be reported:
  PASS  pkg/version/version.go  filtered=no
pre-existing cases must not regress:
  PASS  apis/v1alpha1/ack-generate-metadata.yaml  filtered=yes
  PASS  helm/Chart.yaml  filtered=yes
  PASS  helm/values.yaml  filtered=yes
  PASS  config/controller/kustomization.yaml  filtered=yes
  PASS  helm/templates/NOTES.txt  filtered=yes
  PASS  pkg/resource/access_point/references.go  filtered=no
```

`bash -n` is clean.

### Alternative worth considering

This filters a non-determinism rather than removing it. Dropping `ACKGenerateBuildDate` from `templates/pkg/version/version.go.tpl` in code-generator would address the source: `ack-generate-metadata.yaml` already records `build_date`, and `ACKGenerateVersion` — the part that identifies the generator build — is deterministic and would stay. Happy to send that instead if maintainers prefer it; this change is the smaller, immediate unblock.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
