### PR TITLE
Fix false negatives due to deltas in ACKGenerateVersion

### DIFF
--- a/cd/scripts/verify-code-gen.sh
+++ b/cd/scripts/verify-code-gen.sh
@@ -146,7 +146,7 @@ filter_patterns_for_file() {
             echo 'controller:[0-9]+\.[0-9]+\.[0-9]+'
             ;;
         version.go)
-            echo '\s*ACKGenerateBuildDate\s*='
+            echo '\s*(ACKGenerateBuildDate|ACKGenerateVersion)\s*='
             ;;
         *)
             # No patterns to filter for other files


### PR DESCRIPTION
Issue #, if available:

Description of changes:
PR fixes issue where verify-code-gen check will fail due to difference in generated `ACKGenerateVersion` in version.go if any PR has been merged into code-generator since the target PR was published. Note, changes to generated controller code will still fail the `verify-code-gen`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
