### PR TITLE
Disable Flux prune ahead of the Argo CD migration (stage 1/8)

### DIFF
--- a/flux/ack-build-cluster.yaml
+++ b/flux/ack-build-cluster.yaml
@@ -20,7 +20,10 @@ spec:
     kind: GitRepository
     name: test-infra
   path: ./flux/ack/build-cluster
-  prune: true
+  # prune deliberately disabled for the Argo CD migration: converting this path
+  # to a chart makes every raw object stale, and prune deletes stale objects.
+  # Must be live before any content change (see docs, D19-P1).
+  prune: false
   deletionPolicy: WaitForTermination
   targetNamespace: ack-system
   postBuild:

--- a/flux/ack.yaml
+++ b/flux/ack.yaml
@@ -25,7 +25,10 @@ spec:
     kind: GitRepository
     name: test-infra
   path: ./flux/ack/capability/role
-  prune: true
+  # prune deliberately disabled for the Argo CD migration: converting this path
+  # to a chart makes every raw object stale, and prune deletes stale objects.
+  # Must be live before any content change (see docs, D19-P1).
+  prune: false
   deletionPolicy: WaitForTermination
   targetNamespace: ack-system
   postBuild:
@@ -45,7 +48,10 @@ spec:
     kind: GitRepository
     name: test-infra
   path: ./flux/ack/cluster/addons/roles
-  prune: true
+  # prune deliberately disabled for the Argo CD migration: converting this path
+  # to a chart makes every raw object stale, and prune deletes stale objects.
+  # Must be live before any content change (see docs, D19-P1).
+  prune: false
   deletionPolicy: WaitForTermination
   targetNamespace: ack-system
   postBuild:
@@ -69,7 +75,10 @@ spec:
     kind: GitRepository
     name: test-infra
   path: ./flux/ack/capability
-  prune: true
+  # prune deliberately disabled for the Argo CD migration: converting this path
+  # to a chart makes every raw object stale, and prune deletes stale objects.
+  # Must be live before any content change (see docs, D19-P1).
+  prune: false
   deletionPolicy: WaitForTermination
   targetNamespace: ack-system
   postBuild:
@@ -93,7 +102,10 @@ spec:
     kind: GitRepository
     name: test-infra
   path: ./flux/ack/cluster
-  prune: true
+  # prune deliberately disabled for the Argo CD migration: converting this path
+  # to a chart makes every raw object stale, and prune deletes stale objects.
+  # Must be live before any content change (see docs, D19-P1).
+  prune: false
   deletionPolicy: WaitForTermination
   targetNamespace: ack-system
   postBuild:
@@ -117,7 +129,10 @@ spec:
     kind: GitRepository
     name: test-infra
   path: ./flux/ack/cluster/addons
-  prune: true
+  # prune deliberately disabled for the Argo CD migration: converting this path
+  # to a chart makes every raw object stale, and prune deletes stale objects.
+  # Must be live before any content change (see docs, D19-P1).
+  prune: false
   deletionPolicy: WaitForTermination
   targetNamespace: ack-system
   postBuild:
@@ -142,7 +157,10 @@ spec:
     kind: GitRepository
     name: test-infra
   path: ./flux/ack/cluster/pod-identities/roles
-  prune: true
+  # prune deliberately disabled for the Argo CD migration: converting this path
+  # to a chart makes every raw object stale, and prune deletes stale objects.
+  # Must be live before any content change (see docs, D19-P1).
+  prune: false
   deletionPolicy: WaitForTermination
   targetNamespace: ack-system
   postBuild:
@@ -166,7 +184,10 @@ spec:
     kind: GitRepository
     name: test-infra
   path: ./flux/ack/cluster/pod-identities
-  prune: true
+  # prune deliberately disabled for the Argo CD migration: converting this path
+  # to a chart makes every raw object stale, and prune deletes stale objects.
+  # Must be live before any content change (see docs, D19-P1).
+  prune: false
   deletionPolicy: WaitForTermination
   postBuild:
     substituteFrom:
@@ -190,7 +211,10 @@ spec:
     kind: GitRepository
     name: test-infra
   path: ./flux/ack/prow
-  prune: true
+  # prune deliberately disabled for the Argo CD migration: converting this path
+  # to a chart makes every raw object stale, and prune deletes stale objects.
+  # Must be live before any content change (see docs, D19-P1).
+  prune: false
   deletionPolicy: WaitForTermination
   targetNamespace: ack-system
   postBuild:
@@ -214,7 +238,10 @@ spec:
     kind: GitRepository
     name: test-infra
   path: ./flux/ack/flux
-  prune: true
+  # prune deliberately disabled for the Argo CD migration: converting this path
+  # to a chart makes every raw object stale, and prune deletes stale objects.
+  # Must be live before any content change (see docs, D19-P1).
+  prune: false
   deletionPolicy: WaitForTermination
   targetNamespace: ack-system
   postBuild:

--- a/flux/ack/build-cluster/access-entries.yaml
+++ b/flux/ack/build-cluster/access-entries.yaml
@@ -17,6 +17,8 @@ metadata:
   name: build-cluster-admin-access
   namespace: ack-system
   annotations:
+    kustomize.toolkit.fluxcd.io/prune: disabled
+    helm.sh/resource-policy: keep
     services.k8s.aws/deletion-policy: retain
 spec:
   clusterRef:
@@ -36,6 +38,8 @@ metadata:
   name: build-admin-access
   namespace: ack-system
   annotations:
+    kustomize.toolkit.fluxcd.io/prune: disabled
+    helm.sh/resource-policy: keep
     services.k8s.aws/deletion-policy: retain
 spec:
   clusterRef:
@@ -55,6 +59,8 @@ metadata:
   name: build-readonly-access
   namespace: ack-system
   annotations:
+    kustomize.toolkit.fluxcd.io/prune: disabled
+    helm.sh/resource-policy: keep
     services.k8s.aws/deletion-policy: retain
 spec:
   clusterRef:
@@ -76,6 +82,8 @@ metadata:
   name: prow-deployment-build-access
   namespace: ack-system
   annotations:
+    kustomize.toolkit.fluxcd.io/prune: disabled
+    helm.sh/resource-policy: keep
     services.k8s.aws/deletion-policy: retain
 spec:
   clusterRef:
@@ -95,6 +103,8 @@ metadata:
   name: flux-build-cluster-access
   namespace: ack-system
   annotations:
+    kustomize.toolkit.fluxcd.io/prune: disabled
+    helm.sh/resource-policy: keep
     services.k8s.aws/deletion-policy: retain
 spec:
   clusterRef:
@@ -128,6 +138,8 @@ metadata:
   name: build-node-access
   namespace: ack-system
   annotations:
+    kustomize.toolkit.fluxcd.io/prune: disabled
+    helm.sh/resource-policy: keep
     services.k8s.aws/deletion-policy: retain
     services.k8s.aws/adoption-policy: adopt-or-create
 spec:

--- a/flux/ack/build-cluster/flux-pod-identity.yaml
+++ b/flux/ack/build-cluster/flux-pod-identity.yaml
@@ -18,6 +18,9 @@ kind: PodIdentityAssociation
 metadata:
   name: flux-build-cluster-pod-identity
   namespace: ack-system
+  annotations:
+    kustomize.toolkit.fluxcd.io/prune: disabled
+    helm.sh/resource-policy: keep
 spec:
   clusterName: ${STACK_NAME}-cluster
   namespace: flux-system

--- a/flux/ack/build-cluster/infra/cluster.yaml
+++ b/flux/ack/build-cluster/infra/cluster.yaml
@@ -12,6 +12,8 @@ metadata:
   name: build-cluster
   namespace: ack-system
   annotations:
+    kustomize.toolkit.fluxcd.io/prune: disabled
+    helm.sh/resource-policy: keep
     services.k8s.aws/deletion-policy: retain
 spec:
   name: ${STACK_NAME}-build-cluster

--- a/flux/ack/build-cluster/infra/nat.yaml
+++ b/flux/ack/build-cluster/infra/nat.yaml
@@ -10,6 +10,9 @@ kind: ElasticIPAddress
 metadata:
   name: build-nat-eip
   namespace: ack-system
+  annotations:
+    kustomize.toolkit.fluxcd.io/prune: disabled
+    helm.sh/resource-policy: keep
 spec:
   tags:
   - key: Name
@@ -20,6 +23,9 @@ kind: NATGateway
 metadata:
   name: build-natgw
   namespace: ack-system
+  annotations:
+    kustomize.toolkit.fluxcd.io/prune: disabled
+    helm.sh/resource-policy: keep
 spec:
   connectivityType: public
   subnetRef:

--- a/flux/ack/build-cluster/infra/roles.yaml
+++ b/flux/ack/build-cluster/infra/roles.yaml
@@ -12,6 +12,9 @@ kind: Role
 metadata:
   name: build-cluster-role
   namespace: ack-system
+  annotations:
+    kustomize.toolkit.fluxcd.io/prune: disabled
+    helm.sh/resource-policy: keep
 spec:
   name: ${STACK_NAME}-build-cluster-role
   assumeRolePolicyDocument: |
@@ -39,6 +42,9 @@ kind: Role
 metadata:
   name: build-node-role
   namespace: ack-system
+  annotations:
+    kustomize.toolkit.fluxcd.io/prune: disabled
+    helm.sh/resource-policy: keep
 spec:
   name: ${STACK_NAME}-build-node-role
   assumeRolePolicyDocument: |
@@ -76,6 +82,9 @@ kind: Role
 metadata:
   name: build-cluster-admin-access-role
   namespace: ack-system
+  annotations:
+    kustomize.toolkit.fluxcd.io/prune: disabled
+    helm.sh/resource-policy: keep
 spec:
   name: ${STACK_NAME}-build-cluster-admin-access-role
   assumeRolePolicyDocument: |

--- a/flux/ack/build-cluster/infra/routetables.yaml
+++ b/flux/ack/build-cluster/infra/routetables.yaml
@@ -10,6 +10,9 @@ kind: RouteTable
 metadata:
   name: build-rt-public
   namespace: ack-system
+  annotations:
+    kustomize.toolkit.fluxcd.io/prune: disabled
+    helm.sh/resource-policy: keep
 spec:
   vpcRef:
     from:
@@ -28,6 +31,9 @@ kind: RouteTable
 metadata:
   name: build-rt-private
   namespace: ack-system
+  annotations:
+    kustomize.toolkit.fluxcd.io/prune: disabled
+    helm.sh/resource-policy: keep
 spec:
   vpcRef:
     from:

--- a/flux/ack/build-cluster/infra/subnets.yaml
+++ b/flux/ack/build-cluster/infra/subnets.yaml
@@ -13,6 +13,9 @@ kind: Subnet
 metadata:
   name: build-subnet-private-a
   namespace: ack-system
+  annotations:
+    kustomize.toolkit.fluxcd.io/prune: disabled
+    helm.sh/resource-policy: keep
 spec:
   cidrBlock: "10.1.0.0/20"
   availabilityZone: us-west-2a
@@ -33,6 +36,9 @@ kind: Subnet
 metadata:
   name: build-subnet-private-b
   namespace: ack-system
+  annotations:
+    kustomize.toolkit.fluxcd.io/prune: disabled
+    helm.sh/resource-policy: keep
 spec:
   cidrBlock: "10.1.16.0/20"
   availabilityZone: us-west-2b
@@ -53,6 +59,9 @@ kind: Subnet
 metadata:
   name: build-subnet-public-a
   namespace: ack-system
+  annotations:
+    kustomize.toolkit.fluxcd.io/prune: disabled
+    helm.sh/resource-policy: keep
 spec:
   cidrBlock: "10.1.64.0/20"
   availabilityZone: us-west-2a
@@ -74,6 +83,9 @@ kind: Subnet
 metadata:
   name: build-subnet-public-b
   namespace: ack-system
+  annotations:
+    kustomize.toolkit.fluxcd.io/prune: disabled
+    helm.sh/resource-policy: keep
 spec:
   cidrBlock: "10.1.80.0/20"
   availabilityZone: us-west-2b

--- a/flux/ack/build-cluster/infra/vpc.yaml
+++ b/flux/ack/build-cluster/infra/vpc.yaml
@@ -9,6 +9,9 @@ kind: VPC
 metadata:
   name: build-vpc
   namespace: ack-system
+  annotations:
+    kustomize.toolkit.fluxcd.io/prune: disabled
+    helm.sh/resource-policy: keep
 spec:
   cidrBlocks:
   - "10.1.0.0/16"
@@ -24,6 +27,9 @@ kind: InternetGateway
 metadata:
   name: build-igw
   namespace: ack-system
+  annotations:
+    kustomize.toolkit.fluxcd.io/prune: disabled
+    helm.sh/resource-policy: keep
 spec:
   vpcRef:
     from:

--- a/flux/ack/build-cluster/infra/vpc.yaml
+++ b/flux/ack/build-cluster/infra/vpc.yaml
@@ -14,6 +14,7 @@ spec:
   - "10.1.0.0/16"
   enableDNSSupport: true
   enableDNSHostnames: true
+  enableNetworkAddressUsageMetrics: false
   tags:
   - key: Name
     value: ${STACK_NAME}-build-vpc

--- a/flux/ack/build-cluster/pod-identities/prow-pod-identities.yaml
+++ b/flux/ack/build-cluster/pod-identities/prow-pod-identities.yaml
@@ -15,6 +15,9 @@ kind: PodIdentityAssociation
 metadata:
   name: prow-build-presubmit-pod-identity
   namespace: ack-system
+  annotations:
+    kustomize.toolkit.fluxcd.io/prune: disabled
+    helm.sh/resource-policy: keep
 spec:
   clusterRef:
     from:

--- a/flux/ack/build-cluster/roles/flux-build-cluster-role.yaml
+++ b/flux/ack/build-cluster/roles/flux-build-cluster-role.yaml
@@ -12,6 +12,9 @@ kind: Role
 metadata:
   name: flux-build-cluster-role
   namespace: ack-system
+  annotations:
+    kustomize.toolkit.fluxcd.io/prune: disabled
+    helm.sh/resource-policy: keep
 spec:
   name: ${STACK_NAME}-flux-build-cluster-role
   assumeRolePolicyDocument: |

--- a/flux/ack/capability/capability.yaml
+++ b/flux/ack/capability/capability.yaml
@@ -5,6 +5,8 @@ metadata:
   name: ack-eks-capability
   namespace: ack-system
   annotations:
+    kustomize.toolkit.fluxcd.io/prune: disabled
+    helm.sh/resource-policy: keep
     services.k8s.aws/adoption-policy: adopt-or-create
     services.k8s.aws/adoption-fields: '{"name": "ack-eks", "clusterName": "${STACK_NAME}-cluster"}'
     services.k8s.aws/deletion-policy: retain

--- a/flux/ack/capability/role/ack-capability-role.yaml
+++ b/flux/ack/capability/role/ack-capability-role.yaml
@@ -8,6 +8,8 @@ metadata:
   name: ack-capability-role
   namespace: ack-system
   annotations:
+    kustomize.toolkit.fluxcd.io/prune: disabled
+    helm.sh/resource-policy: keep
     services.k8s.aws/adoption-policy: adopt-or-create
     services.k8s.aws/adoption-fields: '{"name": "${STACK_NAME}-ack-capability-role"}'
     services.k8s.aws/deletion-policy: retain

--- a/flux/ack/cluster/access-entries.yaml
+++ b/flux/ack/cluster/access-entries.yaml
@@ -8,6 +8,8 @@ metadata:
   name: cluster-admin-access
   namespace: ack-system
   annotations:
+    kustomize.toolkit.fluxcd.io/prune: disabled
+    helm.sh/resource-policy: keep
     services.k8s.aws/deletion-policy: retain
 spec:
   clusterName: ${STACK_NAME}-cluster
@@ -25,6 +27,8 @@ metadata:
   name: admin-access
   namespace: ack-system
   annotations:
+    kustomize.toolkit.fluxcd.io/prune: disabled
+    helm.sh/resource-policy: keep
     services.k8s.aws/deletion-policy: retain
     services.k8s.aws/adoption-policy: adopt
     services.k8s.aws/adoption-fields: '{"clusterName": "${STACK_NAME}-cluster", "principalARN": "arn:aws:iam::${ACCOUNT_ID}:role/Admin"}'
@@ -44,6 +48,8 @@ metadata:
   name: readonly-access
   namespace: ack-system
   annotations:
+    kustomize.toolkit.fluxcd.io/prune: disabled
+    helm.sh/resource-policy: keep
     services.k8s.aws/deletion-policy: retain
 spec:
   clusterName: ${STACK_NAME}-cluster

--- a/flux/ack/cluster/addons/addons.yaml
+++ b/flux/ack/cluster/addons/addons.yaml
@@ -5,6 +5,9 @@ kind: Addon
 metadata:
   name: secrets-store-csi
   namespace: ack-system
+  annotations:
+    kustomize.toolkit.fluxcd.io/prune: disabled
+    helm.sh/resource-policy: keep
 spec:
   clusterName: ${STACK_NAME}-cluster
   name: aws-secrets-store-csi-driver-provider
@@ -34,6 +37,9 @@ kind: Addon
 metadata:
   name: external-dns-addon
   namespace: ack-system
+  annotations:
+    kustomize.toolkit.fluxcd.io/prune: disabled
+    helm.sh/resource-policy: keep
 spec:
   clusterName: ${STACK_NAME}-cluster
   name: external-dns
@@ -46,6 +52,9 @@ kind: Addon
 metadata:
   name: coredns
   namespace: ack-system
+  annotations:
+    kustomize.toolkit.fluxcd.io/prune: disabled
+    helm.sh/resource-policy: keep
 spec:
   clusterName: ${STACK_NAME}-cluster
   name: coredns

--- a/flux/ack/cluster/addons/roles/external-dns-role.yaml
+++ b/flux/ack/cluster/addons/roles/external-dns-role.yaml
@@ -5,6 +5,9 @@ kind: Role
 metadata:
   name: external-dns-role
   namespace: ack-system
+  annotations:
+    kustomize.toolkit.fluxcd.io/prune: disabled
+    helm.sh/resource-policy: keep
 spec:
   name: ${STACK_NAME}-external-dns-role
   assumeRolePolicyDocument: |

--- a/flux/ack/cluster/cluster.yaml
+++ b/flux/ack/cluster/cluster.yaml
@@ -6,6 +6,8 @@ metadata:
   name: ${STACK_NAME}-cluster
   namespace: ack-system
   annotations:
+    kustomize.toolkit.fluxcd.io/prune: disabled
+    helm.sh/resource-policy: keep
     services.k8s.aws/adoption-policy: adopt-or-create
     services.k8s.aws/adoption-fields: '{"name": "${STACK_NAME}-cluster"}'
     services.k8s.aws/deletion-policy: retain

--- a/flux/ack/cluster/ingress-class.yaml
+++ b/flux/ack/cluster/ingress-class.yaml
@@ -6,5 +6,8 @@ apiVersion: networking.k8s.io/v1
 kind: IngressClass
 metadata:
   name: alb
+  annotations:
+    kustomize.toolkit.fluxcd.io/prune: disabled
+    helm.sh/resource-policy: keep
 spec:
   controller: eks.amazonaws.com/alb

--- a/flux/ack/cluster/nodepool-control-plane.yaml
+++ b/flux/ack/cluster/nodepool-control-plane.yaml
@@ -8,6 +8,9 @@ apiVersion: karpenter.sh/v1
 kind: NodePool
 metadata:
   name: prow-control-plane
+  annotations:
+    kustomize.toolkit.fluxcd.io/prune: disabled
+    helm.sh/resource-policy: keep
 spec:
   template:
     metadata:

--- a/flux/ack/cluster/nodepool.yaml
+++ b/flux/ack/cluster/nodepool.yaml
@@ -7,6 +7,9 @@ apiVersion: karpenter.sh/v1
 kind: NodePool
 metadata:
   name: prow-compute
+  annotations:
+    kustomize.toolkit.fluxcd.io/prune: disabled
+    helm.sh/resource-policy: keep
 spec:
   template:
     spec:

--- a/flux/ack/cluster/pod-identities/prow-namespaces.yaml
+++ b/flux/ack/cluster/pod-identities/prow-namespaces.yaml
@@ -4,38 +4,60 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: prow
+  annotations:
+    kustomize.toolkit.fluxcd.io/prune: disabled
+    helm.sh/resource-policy: keep
 ---
 apiVersion: v1
 kind: Namespace
 metadata:
   name: test-pods
+  annotations:
+    kustomize.toolkit.fluxcd.io/prune: disabled
+    helm.sh/resource-policy: keep
 ---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: prow-deployment-service-account
   namespace: prow
+  annotations:
+    kustomize.toolkit.fluxcd.io/prune: disabled
+    helm.sh/resource-policy: keep
 ---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: pre-submit-service-account
   namespace: test-pods
+  annotations:
+    kustomize.toolkit.fluxcd.io/prune: disabled
+    helm.sh/resource-policy: keep
 ---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: post-submit-service-account
   namespace: test-pods
+  annotations:
+    kustomize.toolkit.fluxcd.io/prune: disabled
+    helm.sh/resource-policy: keep
 ---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: periodic-service-account
   namespace: test-pods
+  annotations:
+    kustomize.toolkit.fluxcd.io/prune: disabled
+    helm.sh/resource-policy: keep
 ---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: prow-mirror-service-account
   namespace: test-pods
+
+  annotations:
+    kustomize.toolkit.fluxcd.io/prune: disabled
+    helm.sh/resource-policy: keep

--- a/flux/ack/cluster/pod-identities/prow-pod-identities.yaml
+++ b/flux/ack/cluster/pod-identities/prow-pod-identities.yaml
@@ -7,6 +7,9 @@ kind: PodIdentityAssociation
 metadata:
   name: prow-deployment-pod-identity
   namespace: ack-system
+  annotations:
+    kustomize.toolkit.fluxcd.io/prune: disabled
+    helm.sh/resource-policy: keep
 spec:
   clusterName: ${STACK_NAME}-cluster
   namespace: prow
@@ -18,6 +21,9 @@ kind: PodIdentityAssociation
 metadata:
   name: prow-postsubmit-pod-identity
   namespace: ack-system
+  annotations:
+    kustomize.toolkit.fluxcd.io/prune: disabled
+    helm.sh/resource-policy: keep
 spec:
   clusterName: ${STACK_NAME}-cluster
   namespace: test-pods
@@ -29,6 +35,9 @@ kind: PodIdentityAssociation
 metadata:
   name: prow-presubmit-pod-identity
   namespace: ack-system
+  annotations:
+    kustomize.toolkit.fluxcd.io/prune: disabled
+    helm.sh/resource-policy: keep
 spec:
   clusterName: ${STACK_NAME}-cluster
   namespace: test-pods
@@ -40,6 +49,9 @@ kind: PodIdentityAssociation
 metadata:
   name: prow-periodic-pod-identity
   namespace: ack-system
+  annotations:
+    kustomize.toolkit.fluxcd.io/prune: disabled
+    helm.sh/resource-policy: keep
 spec:
   clusterName: ${STACK_NAME}-cluster
   namespace: test-pods
@@ -51,6 +63,9 @@ kind: PodIdentityAssociation
 metadata:
   name: prow-mirror-pod-identity
   namespace: ack-system
+  annotations:
+    kustomize.toolkit.fluxcd.io/prune: disabled
+    helm.sh/resource-policy: keep
 spec:
   clusterName: ${STACK_NAME}-cluster
   namespace: test-pods
@@ -62,6 +77,9 @@ kind: PodIdentityAssociation
 metadata:
   name: prow-workflow-runner-pod-identity
   namespace: ack-system
+  annotations:
+    kustomize.toolkit.fluxcd.io/prune: disabled
+    helm.sh/resource-policy: keep
 spec:
   clusterName: ${STACK_NAME}-cluster
   namespace: test-pods

--- a/flux/ack/cluster/pod-identities/roles/prow-iam-roles.yaml
+++ b/flux/ack/cluster/pod-identities/roles/prow-iam-roles.yaml
@@ -6,6 +6,9 @@ kind: Role
 metadata:
   name: prow-deployment-role
   namespace: ack-system
+  annotations:
+    kustomize.toolkit.fluxcd.io/prune: disabled
+    helm.sh/resource-policy: keep
 spec:
   name: ${STACK_NAME}-prow-deployment-role
   assumeRolePolicyDocument: |
@@ -54,6 +57,9 @@ kind: Role
 metadata:
   name: prow-postsubmit-role
   namespace: ack-system
+  annotations:
+    kustomize.toolkit.fluxcd.io/prune: disabled
+    helm.sh/resource-policy: keep
 spec:
   name: ${STACK_NAME}-prow-postsubmit-role
   assumeRolePolicyDocument: |
@@ -160,6 +166,9 @@ kind: Role
 metadata:
   name: prow-presubmit-role
   namespace: ack-system
+  annotations:
+    kustomize.toolkit.fluxcd.io/prune: disabled
+    helm.sh/resource-policy: keep
 spec:
   name: ${STACK_NAME}-prow-presubmit-role
   assumeRolePolicyDocument: |
@@ -252,6 +261,9 @@ kind: Role
 metadata:
   name: prow-periodic-role
   namespace: ack-system
+  annotations:
+    kustomize.toolkit.fluxcd.io/prune: disabled
+    helm.sh/resource-policy: keep
 spec:
   name: ${STACK_NAME}-prow-periodic-role
   assumeRolePolicyDocument: |
@@ -302,6 +314,9 @@ kind: Role
 metadata:
   name: prow-workflow-runner-role
   namespace: ack-system
+  annotations:
+    kustomize.toolkit.fluxcd.io/prune: disabled
+    helm.sh/resource-policy: keep
 spec:
   name: ${STACK_NAME}-prow-workflow-runner-role
   assumeRolePolicyDocument: |
@@ -353,6 +368,9 @@ kind: Role
 metadata:
   name: prow-mirror-role
   namespace: ack-system
+  annotations:
+    kustomize.toolkit.fluxcd.io/prune: disabled
+    helm.sh/resource-policy: keep
 spec:
   name: ${STACK_NAME}-prow-mirror-role
   assumeRolePolicyDocument: |

--- a/flux/ack/cluster/storage-class.yaml
+++ b/flux/ack/cluster/storage-class.yaml
@@ -3,6 +3,8 @@ kind: StorageClass
 metadata:
   name: auto-ebs-sc
   annotations:
+    kustomize.toolkit.fluxcd.io/prune: disabled
+    helm.sh/resource-policy: keep
     storageclass.kubernetes.io/is-default-class: "true"
 provisioner: ebs.csi.eks.amazonaws.com
 volumeBindingMode: WaitForFirstConsumer

--- a/flux/ack/flux/ecr-pull-through-cache.yaml
+++ b/flux/ack/flux/ecr-pull-through-cache.yaml
@@ -7,6 +7,9 @@ kind: PullThroughCacheRule
 metadata:
   name: ghcr-fluxcd
   namespace: ack-system
+  annotations:
+    kustomize.toolkit.fluxcd.io/prune: disabled
+    helm.sh/resource-policy: keep
 spec:
   ecrRepositoryPrefix: fluxcd
   upstreamRegistryURL: ghcr.io

--- a/flux/ack/prow/ecr-repositories.yaml
+++ b/flux/ack/prow/ecr-repositories.yaml
@@ -7,6 +7,8 @@ kind: Repository
 metadata:
   name: prow-crier
   annotations:
+    kustomize.toolkit.fluxcd.io/prune: disabled
+    helm.sh/resource-policy: keep
     ecr.services.k8s.aws/force-delete: "true"
 spec:
   name: prow/crier
@@ -19,6 +21,8 @@ kind: Repository
 metadata:
   name: prow-deck
   annotations:
+    kustomize.toolkit.fluxcd.io/prune: disabled
+    helm.sh/resource-policy: keep
     ecr.services.k8s.aws/force-delete: "true"
 spec:
   name: prow/deck
@@ -31,6 +35,8 @@ kind: Repository
 metadata:
   name: prow-ghproxy
   annotations:
+    kustomize.toolkit.fluxcd.io/prune: disabled
+    helm.sh/resource-policy: keep
     ecr.services.k8s.aws/force-delete: "true"
 spec:
   name: prow/ghproxy
@@ -43,6 +49,8 @@ kind: Repository
 metadata:
   name: prow-hook
   annotations:
+    kustomize.toolkit.fluxcd.io/prune: disabled
+    helm.sh/resource-policy: keep
     ecr.services.k8s.aws/force-delete: "true"
 spec:
   name: prow/hook
@@ -55,6 +63,8 @@ kind: Repository
 metadata:
   name: prow-horologium
   annotations:
+    kustomize.toolkit.fluxcd.io/prune: disabled
+    helm.sh/resource-policy: keep
     ecr.services.k8s.aws/force-delete: "true"
 spec:
   name: prow/horologium
@@ -67,6 +77,8 @@ kind: Repository
 metadata:
   name: prow-controller-manager
   annotations:
+    kustomize.toolkit.fluxcd.io/prune: disabled
+    helm.sh/resource-policy: keep
     ecr.services.k8s.aws/force-delete: "true"
 spec:
   name: prow/prow-controller-manager
@@ -79,6 +91,8 @@ kind: Repository
 metadata:
   name: prow-sinker
   annotations:
+    kustomize.toolkit.fluxcd.io/prune: disabled
+    helm.sh/resource-policy: keep
     ecr.services.k8s.aws/force-delete: "true"
 spec:
   name: prow/sinker
@@ -91,6 +105,8 @@ kind: Repository
 metadata:
   name: prow-status-reconciler
   annotations:
+    kustomize.toolkit.fluxcd.io/prune: disabled
+    helm.sh/resource-policy: keep
     ecr.services.k8s.aws/force-delete: "true"
 spec:
   name: prow/status-reconciler
@@ -103,6 +119,8 @@ kind: Repository
 metadata:
   name: prow-tide
   annotations:
+    kustomize.toolkit.fluxcd.io/prune: disabled
+    helm.sh/resource-policy: keep
     ecr.services.k8s.aws/force-delete: "true"
 spec:
   name: prow/tide
@@ -115,6 +133,8 @@ kind: Repository
 metadata:
   name: prow-clonerefs
   annotations:
+    kustomize.toolkit.fluxcd.io/prune: disabled
+    helm.sh/resource-policy: keep
     ecr.services.k8s.aws/force-delete: "true"
 spec:
   name: prow/clonerefs
@@ -127,6 +147,8 @@ kind: Repository
 metadata:
   name: prow-entrypoint
   annotations:
+    kustomize.toolkit.fluxcd.io/prune: disabled
+    helm.sh/resource-policy: keep
     ecr.services.k8s.aws/force-delete: "true"
 spec:
   name: prow/entrypoint
@@ -139,6 +161,8 @@ kind: Repository
 metadata:
   name: prow-initupload
   annotations:
+    kustomize.toolkit.fluxcd.io/prune: disabled
+    helm.sh/resource-policy: keep
     ecr.services.k8s.aws/force-delete: "true"
 spec:
   name: prow/initupload
@@ -151,6 +175,8 @@ kind: Repository
 metadata:
   name: prow-sidecar
   annotations:
+    kustomize.toolkit.fluxcd.io/prune: disabled
+    helm.sh/resource-policy: keep
     ecr.services.k8s.aws/force-delete: "true"
 spec:
   name: prow/sidecar
@@ -163,6 +189,8 @@ kind: Repository
 metadata:
   name: prow-label-sync
   annotations:
+    kustomize.toolkit.fluxcd.io/prune: disabled
+    helm.sh/resource-policy: keep
     ecr.services.k8s.aws/force-delete: "true"
 spec:
   name: prow/label_sync
@@ -175,6 +203,8 @@ kind: Repository
 metadata:
   name: prow-commenter
   annotations:
+    kustomize.toolkit.fluxcd.io/prune: disabled
+    helm.sh/resource-policy: keep
     ecr.services.k8s.aws/force-delete: "true"
 spec:
   name: prow/commenter

--- a/flux/ack/prow/prow-dns.yaml
+++ b/flux/ack/prow/prow-dns.yaml
@@ -8,6 +8,8 @@ metadata:
   name: prow-hosted-zone
   namespace: ack-system
   annotations:
+    kustomize.toolkit.fluxcd.io/prune: disabled
+    helm.sh/resource-policy: keep
     services.k8s.aws/deletion-policy: retain
 spec:
   name: ${PROW_DOMAIN}

--- a/flux/ack/prow/prow-logs-bucket.yaml
+++ b/flux/ack/prow/prow-logs-bucket.yaml
@@ -6,6 +6,8 @@ metadata:
   name: prow-logs
   namespace: ack-system
   annotations:
+    kustomize.toolkit.fluxcd.io/prune: disabled
+    helm.sh/resource-policy: keep
     services.k8s.aws/deletion-policy: retain
 spec:
   name: ${STACK_NAME}-prow-logs-${ACCOUNT_ID}

--- a/flux/ack/prow/supernova-role.yaml
+++ b/flux/ack/prow/supernova-role.yaml
@@ -6,6 +6,8 @@ metadata:
   name: supernova-role
   namespace: ack-system
   annotations:
+    kustomize.toolkit.fluxcd.io/prune: disabled
+    helm.sh/resource-policy: keep
     services.k8s.aws/adoption-policy: adopt-or-create
     services.k8s.aws/adoption-fields: '{"name": "Nova-DO-NOT-DELETE"}'
     services.k8s.aws/deletion-policy: retain

--- a/flux/flux/source.yaml
+++ b/flux/flux/source.yaml
@@ -21,7 +21,16 @@ metadata:
 spec:
   interval: 60m
   path: ./flux
-  prune: true
+  # prune: false. This is the root: its inventory is every child Kustomization and
+  # HelmRelease, so with prune enabled, removing a file from flux/kustomization.yaml deletes
+  # the corresponding Kustomization - which is how the argocd-rbac path was retired, and it
+  # worked only because that Kustomization had prune off itself.
+  #
+  # Phase 5 removes those files wholesale, and a cascade of deletions driven by a git diff is
+  # the wrong mechanism for it: each deletion should be deliberate and checked. The cost is
+  # that removing a path now leaves its Kustomization object behind for manual deletion,
+  # which is the intended trade.
+  prune: false
   sourceRef:
     kind: GitRepository
     name: test-infra

--- a/flux/prow.yaml
+++ b/flux/prow.yaml
@@ -45,7 +45,11 @@ spec:
     kind: GitRepository
     name: test-infra
   path: ./flux/prow/crds
-  prune: true
+  # prune deliberately disabled for the Argo CD migration: this path is converted or
+  # deleted later in the sequence, and prune deletes objects that a conversion makes
+  # stale. Deleting a Kustomization with prune enabled also garbage-collects its
+  # inventory, so this must be false before any later stage removes it.
+  prune: false
   dependsOn:
   - name: ack-pod-identities
 ---

--- a/flux/prow.yaml
+++ b/flux/prow.yaml
@@ -146,7 +146,10 @@ spec:
     kind: GitRepository
     name: test-infra
   path: ./flux/prow/build-cluster-kubeconfig
-  prune: true
+  # prune disabled ahead of the chart conversion: converting this path makes the
+  # raw object stale, and prune deletes stale objects. Must be live before the
+  # content change (D19-P1).
+  prune: false
   postBuild:
     substituteFrom:
     - kind: ConfigMap
@@ -168,7 +171,10 @@ spec:
     kind: GitRepository
     name: test-infra
   path: ./flux/prow/build-cluster-resources
-  prune: true
+  # prune disabled ahead of the chart conversion: converting this path makes the
+  # raw object stale, and prune deletes stale objects. Must be live before the
+  # content change (D19-P1).
+  prune: false
   kubeConfig:
     configMapRef:
       name: build-cluster-flux-kubeconfig

--- a/flux/prow.yaml
+++ b/flux/prow.yaml
@@ -27,7 +27,12 @@ spec:
     kind: GitRepository
     name: test-infra
   path: ./flux/prow/version
-  prune: true
+  # prune: false, the last three paths to lose it. Phase 5 DELETES this Kustomization, and a
+  # Kustomization with prune enabled garbage-collects its inventory when it is deleted - here
+  # that is the prow-version ConfigMap. The chart defaults that replaced it are git-authored,
+  # so losing the ConfigMap is survivable, but it should be an explicit `kubectl delete` and
+  # not a side effect of removing a file.
+  prune: false
 ---
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
@@ -114,7 +119,13 @@ spec:
     kind: GitRepository
     name: test-infra
   path: ./flux/prow/charts
-  prune: true
+  # prune: false, and on this path it is the difference between a clean Flux removal and an
+  # outage. Its inventory holds the prow-config and prow-data-plane HelmReleases, and
+  # prow-config's release owns Prow's nine Deployments. Deleting this Kustomization while
+  # prune is enabled would garbage-collect those HelmReleases, and whether helm-controller
+  # then UNINSTALLS the releases - taking the Deployments with them - depends on how it treats
+  # a suspended release on deletion. With prune off the question never arises.
+  prune: false
   targetNamespace: flux-system
   postBuild:
     substituteFrom:

--- a/flux/prow/charts/prow-agent-workflows.yaml
+++ b/flux/prow/charts/prow-agent-workflows.yaml
@@ -9,7 +9,11 @@ spec:
     kind: GitRepository
     name: test-infra
   path: ./prow/agent-workflows
-  prune: true
+  # prune deliberately disabled for the Argo CD migration: this path is converted or
+  # deleted later in the sequence, and prune deletes objects that a conversion makes
+  # stale. Deleting a Kustomization with prune enabled also garbage-collects its
+  # inventory, so this must be false before any later stage removes it.
+  prune: false
   postBuild:
     substituteFrom:
     - kind: ConfigMap

--- a/flux/prow/charts/prow-plugins.yaml
+++ b/flux/prow/charts/prow-plugins.yaml
@@ -9,7 +9,11 @@ spec:
     kind: GitRepository
     name: test-infra
   path: ./prow/plugins/deployments
-  prune: true
+  # prune deliberately disabled for the Argo CD migration: this path is converted or
+  # deleted later in the sequence, and prune deletes objects that a conversion makes
+  # stale. Deleting a Kustomization with prune enabled also garbage-collects its
+  # inventory, so this must be false before any later stage removes it.
+  prune: false
   postBuild:
     substituteFrom:
     - kind: ConfigMap

--- a/flux/secrets.yaml
+++ b/flux/secrets.yaml
@@ -12,7 +12,11 @@ spec:
     kind: GitRepository
     name: test-infra
   path: ./flux/secrets
-  prune: true
+  # prune deliberately disabled for the Argo CD migration: this path is converted or
+  # deleted later in the sequence, and prune deletes objects that a conversion makes
+  # stale. Deleting a Kustomization with prune enabled also garbage-collects its
+  # inventory, so this must be false before any later stage removes it.
+  prune: false
   postBuild:
     substituteFrom:
     - kind: ConfigMap


### PR DESCRIPTION
**Stage 1 of 8** in the Flux → Argo CD migration. See `docs/argocd-migration-runbook.md`.

This stage only makes objects harder to delete. It changes no behaviour: Flux keeps
reconciling exactly as before, and every path keeps rendering the same content.

## What this does

- `prune: false` on all 19 Kustomizations that had it enabled
- `kustomize.toolkit.fluxcd.io/prune: disabled` and `helm.sh/resource-policy: keep` on the
  objects those paths own, so deletion is structurally prevented rather than only configured
  away
- `enableNetworkAddressUsageMetrics: false` on the build VPC, unrelated but trivial and already
  in this range

## Why it comes first

Every later stage suspends or deletes something, and **a Kustomization with prune enabled
garbage-collects its inventory when it is deleted.** In staging `prow-charts` held the
`prow-config` HelmRelease, whose Helm release owns Prow's nine Deployments — so pruning it would
have taken the control plane down. Disabling prune everywhere first is what makes the whole
migration reversible up to the cutover.

`prune: false` is also why the migration leaves debris that has to be swept by hand at each
stage. That is a deliberate trade: reversibility over tidiness.

## Two things a reviewer should know

**`prometheus` and `prometheus-dashboards` deliberately keep `prune: true`.** They are never
converted to charts — a later stage deletes them outright — so there is no window in which prune
could delete a stale object, and prune reclaiming their inventory on deletion is the wanted
outcome rather than the hazard.

**The fourth commit is not a cherry-pick.** `prow-agent-workflows`, `prow-crds`, `prow-plugins`
and `secrets` had prune disabled in staging by commits belonging to later stages, so delivering
this stage on its own would have left those four at `prune: true` — precisely the condition this
stage exists to prevent. It was written for this PR.

## Testing

- Every changed YAML file parses (35 files)
- Diff contains nothing but the prune flips, the two annotations, and the one metrics flag
- Verified against the target cluster's live state that after this merge no Kustomization is left
  at `prune: true` except the prometheus pair

## Gate before the next stage

```
kubectl get kustomizations.kustomize.toolkit.fluxcd.io -A \
  -o custom-columns='NAME:.metadata.name,PRUNE:.spec.prune' \
  | grep -i true | grep -vE 'prometheus'
# must return nothing
```

Note the reconciler reads `main` on a 1-minute interval, so this is live shortly after merge.
