### PR TITLE
Stand up the Argo CD capability without cluster-admin (stage 3/8)

### DIFF
--- a/bootstrap/argocd-access.tf
+++ b/bootstrap/argocd-access.tf
@@ -1,0 +1,358 @@
+################################################################################
+# Argo CD authorization and cluster registration
+#
+# Everything here is pure Terraform. No local-exec, no kubectl.
+#
+# What EKS already did for us when the capability was created (verified live):
+#   AmazonEKSArgoCDClusterPolicy  scope=cluster
+#   AmazonEKSArgoCDPolicy         scope=namespace, namespaces=[argocd]
+#
+# Those cover Argo CD's OWN operation - reading its CRs, reading cluster
+# registration Secrets, API discovery, namespace creation, CRD create. They do NOT
+# grant permission to deploy workloads or to read arbitrary resources for health
+# assessment. That is what this file adds.
+#
+# Authorization is granted via EKS access policies rather than in-cluster RBAC,
+# because Argo CD cannot apply the object that authorizes Argo CD. The repo already
+# documents this pattern for Flux in flux/ack/build-cluster/access-entries.yaml.
+################################################################################
+
+################################################################################
+# SCOPE: hub cluster only.
+#
+# Nothing here touches the build cluster, deliberately. The build cluster is not
+# registered as an Argo CD spoke until Phase 4, and when it is, its AccessEntry
+# belongs in flux/ack/build-cluster/access-entries.yaml as an ACK CR alongside the
+# eight already there - not in Terraform. See docs/argocd-migration.md, D13.
+################################################################################
+
+locals {
+  argocd_capability_role_arn = aws_iam_role.argocd_capability.arn
+
+  # Namespaces Argo CD may write to on the hub.
+  #
+  # Granting authorization is not the same as Argo CD acting: while Flux still owns
+  # these objects there are no Applications targeting them, so this is inert until
+  # Phase 4 cutover. flux-system is transitional and should be dropped in Phase 5.
+  # `prometheus` was here until kube-prometheus-stack was removed from the repo. Nothing
+  # writes to that namespace any more, so the grant went with it rather than lingering as
+  # authorization for something that no longer exists.
+  argocd_hub_namespaces = [
+    "ack-system",
+    "prow",
+    "test-pods",
+    "flux-system",
+  ]
+}
+
+################################################################################
+# Hub cluster (control plane) authorization
+################################################################################
+
+# Cluster-wide read for resource discovery and health assessment. Argo CD needs to
+# read all resource types cluster-wide even when it writes to only a few namespaces.
+resource "aws_eks_access_policy_association" "argocd_hub_read" {
+  cluster_name  = aws_eks_cluster.this.name
+  principal_arn = local.argocd_capability_role_arn
+  policy_arn    = "arn:${local.partition}:eks::aws:cluster-access-policy/AmazonEKSAdminViewPolicy"
+
+  access_scope {
+    type = "cluster"
+  }
+}
+
+# Write access, namespace-scoped.
+#
+# ONE association carrying the full namespace list - NOT for_each over namespaces.
+# aws_eks_access_policy_association is keyed by (cluster, principal, policy), so its
+# Terraform ID contains no namespace component:
+#   <cluster>#<principal-arn>#<policy-arn>
+# A for_each over namespaces therefore produces N resources all contending for the
+# same AWS resource. They thrash on every apply and only the last writer survives,
+# silently leaving the other namespaces ungranted. namespaces is a list property of
+# a single association, not a key.
+resource "aws_eks_access_policy_association" "argocd_hub_write" {
+  cluster_name  = aws_eks_cluster.this.name
+  principal_arn = local.argocd_capability_role_arn
+  policy_arn    = "arn:${local.partition}:eks::aws:cluster-access-policy/AmazonEKSAdminPolicy"
+
+  access_scope {
+    type       = "namespace"
+    namespaces = local.argocd_hub_namespaces
+  }
+}
+
+################################################################################
+# Cluster registration
+#
+# Registration is a labelled Secret in the capability's namespace. The server field
+# must be the EKS cluster ARN - API server URLs and kubernetes.default.svc are not
+# supported. No connection credentials are needed; the capability derives them from
+# the capability role and the access entries above.
+#
+# The hub registration must be Terraform-owned: Argo CD cannot deploy anything until
+# at least one cluster is registered, so this is the chicken-and-egg seam.
+################################################################################
+
+resource "kubernetes_secret_v1" "argocd_cluster_hub" {
+  metadata {
+    name      = "in-cluster"
+    namespace = "argocd"
+
+    labels = {
+      "argocd.argoproj.io/secret-type" = "cluster"
+    }
+  }
+
+  data = {
+    name    = "in-cluster"
+    server  = aws_eks_cluster.this.arn
+    project = kubernetes_manifest.argocd_project.manifest.metadata.name
+  }
+
+  depends_on = [awscc_eks_capability.argocd]
+}
+
+################################################################################
+# AppProject
+#
+# spec.sourceNamespaces is REQUIRED by the managed capability and must contain the
+# capability's configured namespace. Omitting it does not error clearly - Applications
+# in that namespace simply cannot reference the project, surfacing as deployment
+# failures. The built-in "default" project is not relied upon for this reason.
+#
+# kubernetes_manifest validates against the live API at PLAN time, so the Argo CD
+# CRDs must already exist. That holds here because the capability created them. On a
+# fresh bootstrap the capability and this resource would be in the same apply, so the
+# capability must be applied first:
+#   terraform apply -target=awscc_eks_capability.argocd
+# then a full apply. Only affects an empty account; on an existing stack the CRDs are
+# already present.
+################################################################################
+
+resource "kubernetes_manifest" "argocd_project" {
+  manifest = {
+    apiVersion = "argoproj.io/v1alpha1"
+    kind       = "AppProject"
+
+    metadata = {
+      name      = "test-infra"
+      namespace = "argocd"
+    }
+
+    spec = {
+      description = "ACK test-infra platform applications"
+
+      sourceNamespaces = ["argocd"]
+
+      sourceRepos = [
+        "https://github.com/${var.test_infra_org}/${var.test_infra_repo}",
+      ]
+
+      # Hub only. The build cluster is added as a destination in Phase 4, when it is
+      # registered as a spoke - not before. A destination for an unregistered cluster
+      # would be misleading.
+      # HUB ONLY. Spoke destinations are added at runtime, not here.
+      #
+      # A destination naming the build cluster is keyed to a cluster ACK owns, and
+      # Terraform must not hold anything keyed to it (D13) - the same reason the
+      # registration Secret is written by the prow-build-cluster-connection Job rather
+      # than by Terraform. Terraform authorises only the cluster it owns and bootstraps.
+      #
+      # The Job appends the spoke destination, which is why destinations is in
+      # ignore_changes below. Without that, the next terraform apply would silently
+      # revert the addition and Applications targeting the build cluster would start
+      # being rejected.
+      destinations = [
+        {
+          server    = aws_eks_cluster.this.arn
+          namespace = "*"
+        },
+      ]
+
+      clusterResourceWhitelist = [
+        {
+          group = "*"
+          kind  = "*"
+        },
+      ]
+    }
+  }
+
+  depends_on = [awscc_eks_capability.argocd]
+
+  lifecycle {
+    # Spoke destinations are appended at runtime by the prow-build-cluster-connection
+    # Job, because a destination naming the build cluster is keyed to a cluster ACK owns
+    # and Terraform must not hold that (D13).
+    #
+    # Without this, every terraform apply would rewrite destinations back to the hub-only
+    # list. Nothing would error - the Job re-adds it on its next run - but in between,
+    # Applications targeting the build cluster are REJECTED rather than failing at sync,
+    # so the symptom appears at a distance from the apply that caused it.
+    #
+    # Scoped to destinations alone. sourceRepos, sourceNamespaces and
+    # clusterResourceWhitelist stay Terraform-managed and drift-corrected.
+    ignore_changes = [manifest.spec.destinations]
+  }
+}
+
+################################################################################
+# CRD write exception
+#
+# AmazonEKSArgoCDClusterPolicy grants customresourcedefinitions `create`, but
+# get/update/patch/delete only on Argo CD's OWN CRDs. Any Application that manages a
+# third-party CRD therefore installs it successfully on first sync and then fails
+# forever on the next one. Confirmed live in staging:
+#
+#   customresourcedefinitions.apiextensions.k8s.io "..." is forbidden: User
+#   ".../ack-test-infra-staging-argocd-capability-role/..." cannot patch resource
+#   "customresourcedefinitions" in API group "apiextensions.k8s.io" at the cluster scope
+#
+# It does not fail fast either - the Application retries indefinitely and sits in
+# Running, so the symptom is a stuck sync rather than a clear permission error.
+#
+# This matters for prow-crds, which installs the ProwJob CRD and must be able to
+# refresh it when scripts/upgrade-prow.sh pulls a new version from upstream.
+#
+# Granted as narrow in-cluster RBAC on exactly one resource type rather than by
+# attaching AmazonEKSClusterAdminPolicy, which would hand over the whole cluster.
+#
+# Terraform must own this: it is the object that authorizes Argo CD, so Argo CD
+# cannot apply it (3.4).
+################################################################################
+
+# Custom in-cluster RBAC CANNOT be used here, which is worth recording because the
+# AWS docs suggest otherwise. The capability's auto-created access entry has:
+#
+#   kubernetesGroups: []
+#   username: arn:aws:sts::<acct>:assumed-role/<role>/{{SessionName}}
+#
+# There is no group to bind to, and the username is session-templated - at runtime it
+# resolves to a fresh value like aws-go-sdk-1787004054908077004. A ClusterRoleBinding
+# to "eks-access-entry:<principal-arn>", which the Register-target-clusters docs
+# recommend, binds to a group that does not exist and silently grants nothing.
+# Verified by attempting exactly that: the CRD patch stayed forbidden.
+#
+# A separate IAM role does not help either - every capability role gets an identical,
+# equally unbindable access entry. The only lever is which access POLICIES are
+# associated.
+#
+# AmazonEKSKROPolicy grants apiextensions.k8s.io/customresourcedefinitions: * . It is
+# AWS-managed and far narrower than AmazonEKSClusterAdminPolicy. Its incidental
+# grants (kro.run/*, leases, events) are inert here - no kro CRDs are installed.
+resource "aws_eks_access_policy_association" "argocd_hub_crd" {
+  cluster_name  = aws_eks_cluster.this.name
+  principal_arn = local.argocd_capability_role_arn
+  policy_arn    = "arn:${local.partition}:eks::aws:cluster-access-policy/AmazonEKSKROPolicy"
+
+  access_scope {
+    type = "cluster"
+  }
+}
+
+################################################################################
+# ACK custom resources.
+#
+# Found by cutting one path over and watching it fail safely:
+#
+#   pullthroughcacherules.ecr.services.k8s.aws "ghcr-fluxcd" is forbidden: User
+#   ".../ack-test-infra-staging-argocd-capability-role/aws-go-sdk-..." cannot patch
+#   resource "pullthroughcacherules" in API group "ecr.services.k8s.aws" in the
+#   namespace "ack-system"
+#
+# AmazonEKSAdminPolicy is already associated for the workload namespaces, but the
+# AWS-managed policies enumerate standard API groups and do not extend to arbitrary
+# CRDs. Argo CD manages 63 ACK custom resources across the *.services.k8s.aws
+# groups, so without this it can render them but never apply them.
+#
+# As established in D14, in-cluster RBAC is not an option: the capability's access
+# entry carries no kubernetesGroups and a session-templated username, so there is no
+# stable subject to bind. Associated access policies are the only lever.
+#
+# AmazonEKSACKPolicy is exactly the right shape - it is what the ACK capability role
+# itself is granted, and it is scoped to the *.services.k8s.aws groups rather than
+# handing out cluster-admin.
+#
+# Cluster scope, matching the ACK capability role's own association: ACK CRs live in
+# ack-system today, but the scope of a policy granting only ACK API groups is already
+# narrow, and namespace scope would silently break if a controller is ever pointed at
+# another namespace.
+################################################################################
+resource "aws_eks_access_policy_association" "argocd_hub_ack" {
+  cluster_name  = aws_eks_cluster.this.name
+  principal_arn = local.argocd_capability_role_arn
+  policy_arn    = "arn:${local.partition}:eks::aws:cluster-access-policy/AmazonEKSACKPolicy"
+
+  access_scope {
+    type = "cluster"
+  }
+}
+
+################################################################################
+# Cluster-scoped objects in the ack-cluster chart.
+#
+# Found by cutting one path over and reading the per-resource result. The three
+# namespaced ACK CRs synced; all four cluster-scoped objects were refused:
+#
+#   StorageClass  auto-ebs-sc         SyncFailed  cannot patch StorageClass
+#   IngressClass  alb                 SyncFailed  cannot patch IngressClass
+#   NodePool      prow-compute        SyncFailed  cannot patch NodePool
+#   NodePool      prow-control-plane  SyncFailed  cannot patch NodePool
+#
+# NO ACCESS POLICY SOLVES THIS. Recorded so the next attempt does not repeat it:
+#
+#   AmazonEKSBlockStorageClusterPolicy and AmazonEKSComputeClusterPolicy cannot be
+#   associated at all - "InvalidParameterException: The specified policyArn can only
+#   be associated with service-linked roles". They are reserved for EKS Auto Mode's
+#   own service-linked roles. Declaring either as a resource here makes every apply
+#   fail, which is why neither appears below.
+#
+#   AmazonEKSLoadBalancingClusterPolicy associates but grants no IngressClass write.
+#   AmazonEKSAdminPolicy grants nothing extra at either scope: it mirrors the built-in
+#   admin ClusterRole, which is namespace-oriented and excludes cluster-scoped
+#   resources and CRD instances. It also covers no CRD group, so it misses
+#   karpenter.sh regardless. Associating it at CLUSTER scope REPLACES the
+#   namespace-scoped association above of the same policy, silently widening that
+#   grant - verify with list-associated-access-policies after any change.
+#
+#   The only associable policy covering all four is AmazonEKSClusterAdminPolicy, i.e.
+#   cluster-admin for Argo CD.
+#
+# Solved instead by adding a Kubernetes group to the capability role's access entry
+# and binding a narrow ClusterRole to it - see the access entry at the end of this
+# file and argocd-rbac.tf.
+################################################################################
+
+################################################################################
+# A Kubernetes group on the capability role's access entry.
+#
+# This is the lever that avoids granting Argo CD cluster-admin. An earlier decision
+# record concluded in-cluster RBAC was impossible here, because the capability's
+# auto-created access entry ships with kubernetesGroups: [] and a session-templated
+# username that cannot serve as an RBAC subject. The first half is true; the
+# conclusion was not. A group can be ADDED to the entry, and a group is bindable.
+#
+# With this set, argocd-rbac.tf binds a ClusterRole granting
+# exactly storage.k8s.io/storageclasses, networking.k8s.io/ingressclasses,
+# karpenter.sh/nodepools and eks.amazonaws.com/nodeclasses - the cluster-scoped
+# objects in the ack-cluster chart. Verified: all four sync, and adding the group
+# leaves the six associated access policies intact.
+#
+# Kept as a separate resource rather than folded into an access entry declaration,
+# because the entry itself is created by the capability, not by Terraform. Terraform
+# only adds the group to it.
+################################################################################
+resource "aws_eks_access_entry" "argocd_capability_group" {
+  cluster_name  = aws_eks_cluster.this.name
+  principal_arn = local.argocd_capability_role_arn
+
+  # Must match the subject in argocd-rbac.tf, which consumes this via local.argocd_rbac_group.
+  kubernetes_groups = ["argocd-cluster-scoped"]
+
+  lifecycle {
+    # The capability owns the entry and sets type and username; Terraform contributes
+    # only the group. Without this, Terraform and the capability fight over the rest.
+    ignore_changes = [type, user_name]
+  }
+}

--- a/bootstrap/argocd-logs.tf
+++ b/bootstrap/argocd-logs.tf
@@ -1,0 +1,118 @@
+################################################################################
+# Argo CD capability controller log delivery (plan section 3.7)
+#
+# The capability's controllers run on AWS-managed infrastructure outside the
+# cluster, so Prometheus cannot scrape them and `kubectl logs` cannot reach them.
+# Log delivery is the compensating control for that observability gap (D7).
+#
+# Delivery is CloudWatch Vended Logs, configured through the CloudWatch Logs API
+# rather than the EKS capability API: a delivery SOURCE per log type (the capability
+# ARN plus a log type), a delivery DESTINATION (the log group), and a DELIVERY
+# joining them.
+#
+# *** The sources MUST be created serially, WITH a settling delay between them. ***
+#
+# PutDeliverySource modifies the capability, and the capability accepts only one
+# modification at a time:
+#
+#   ConflictException: Capability argocd cannot be updated as it is currently
+#   being modified by another request
+#
+# A for_each over log types creates them in parallel and most of them fail. Ordering
+# alone is not sufficient either: the capability stays in a modifying state for a
+# short period AFTER PutDeliverySource returns, so a bare depends_on chain still
+# collides. Hence explicit resources chained through time_sleep.
+#
+# This keeps a plain `terraform apply` correct without needing -parallelism=1, which
+# a fresh bootstrap would not know to pass.
+#
+# To add a log type, add a resource and extend the chain. The five available are:
+#   EKS_CAPABILITY_ARGOCD_APPLICATION_LOGS      sync and health decisions
+#   EKS_CAPABILITY_ARGOCD_APPLICATIONSET_LOGS   generator expansion
+#   EKS_CAPABILITY_ARGOCD_REPOSERVER_LOGS       manifest generation
+#   EKS_CAPABILITY_ARGOCD_SERVER_LOGS           API and UI access
+#   EKS_CAPABILITY_ARGOCD_COMMITSERVER_LOGS     git write-back (unused here)
+#
+# The three enabled below are the ones that matter during the migration. SERVER is
+# API/UI access logging and COMMITSERVER covers git write-back, which is not used.
+################################################################################
+
+variable "argocd_log_retention_days" {
+  description = "Retention for the Argo CD controller log group. Kept short; these are for troubleshooting, not audit."
+  type        = number
+  default     = 14
+}
+
+resource "aws_cloudwatch_log_group" "argocd_controllers" {
+  name              = "/aws/eks/${local.cluster_name}/capability/argocd"
+  retention_in_days = var.argocd_log_retention_days
+}
+
+resource "aws_cloudwatch_log_delivery_destination" "argocd" {
+  name          = "${local.stack_name}-argocd-controllers"
+  output_format = "json"
+
+  delivery_destination_configuration {
+    destination_resource_arn = aws_cloudwatch_log_group.argocd_controllers.arn
+  }
+}
+
+# --- Delivery sources: serialized chain, see the header note ---
+
+resource "aws_cloudwatch_log_delivery_source" "application" {
+  name         = "${local.stack_name}-argocd-application"
+  log_type     = "EKS_CAPABILITY_ARGOCD_APPLICATION_LOGS"
+  resource_arn = awscc_eks_capability.argocd.arn
+}
+
+resource "time_sleep" "argocd_log_source_1" {
+  depends_on      = [aws_cloudwatch_log_delivery_source.application]
+  create_duration = "45s"
+}
+
+resource "aws_cloudwatch_log_delivery_source" "applicationset" {
+  name         = "${local.stack_name}-argocd-applicationset"
+  log_type     = "EKS_CAPABILITY_ARGOCD_APPLICATIONSET_LOGS"
+  resource_arn = awscc_eks_capability.argocd.arn
+
+  depends_on = [time_sleep.argocd_log_source_1]
+}
+
+resource "time_sleep" "argocd_log_source_2" {
+  depends_on      = [aws_cloudwatch_log_delivery_source.applicationset]
+  create_duration = "45s"
+}
+
+resource "aws_cloudwatch_log_delivery_source" "reposerver" {
+  name         = "${local.stack_name}-argocd-reposerver"
+  log_type     = "EKS_CAPABILITY_ARGOCD_REPOSERVER_LOGS"
+  resource_arn = awscc_eks_capability.argocd.arn
+
+  depends_on = [time_sleep.argocd_log_source_2]
+}
+
+# --- Deliveries: also chained, since each references the capability-backed source ---
+
+resource "aws_cloudwatch_log_delivery" "application" {
+  delivery_source_name     = aws_cloudwatch_log_delivery_source.application.name
+  delivery_destination_arn = aws_cloudwatch_log_delivery_destination.argocd.arn
+}
+
+resource "aws_cloudwatch_log_delivery" "applicationset" {
+  delivery_source_name     = aws_cloudwatch_log_delivery_source.applicationset.name
+  delivery_destination_arn = aws_cloudwatch_log_delivery_destination.argocd.arn
+
+  depends_on = [aws_cloudwatch_log_delivery.application]
+}
+
+resource "aws_cloudwatch_log_delivery" "reposerver" {
+  delivery_source_name     = aws_cloudwatch_log_delivery_source.reposerver.name
+  delivery_destination_arn = aws_cloudwatch_log_delivery_destination.argocd.arn
+
+  depends_on = [aws_cloudwatch_log_delivery.applicationset]
+}
+
+output "argocd_log_group" {
+  description = "CloudWatch log group receiving Argo CD capability controller logs."
+  value       = aws_cloudwatch_log_group.argocd_controllers.name
+}

--- a/bootstrap/argocd-rbac.tf
+++ b/bootstrap/argocd-rbac.tf
@@ -1,0 +1,434 @@
+################################################################################
+# In-cluster RBAC for the Argo CD capability.
+#
+# WHY TERRAFORM OWNS THIS. Argo CD cannot apply the object that authorises Argo CD,
+# so this path could never be an Application. It was reconciled by Flux until Phase 5,
+# which made it the last thing Flux owned and blocked Flux removal outright. Terraform
+# is the right owner rather than the residual one: the SUBJECT these objects bind is
+# the kubernetesGroup that Terraform adds to the capability role's access entry
+# (aws_eks_access_entry.argocd_capability_group in argocd-access.tf). Both halves of
+# one mechanism now live in one place, and neither can be applied without the other
+# being visible.
+#
+# Migrated from flux/argocd/{cluster-scoped-rbac,namespaced-rbac}.yaml, adopted by
+# `terraform import` so no object was recreated - a gap in the ClusterRoleBinding is a
+# gap in Argo CD's authorisation, and deleting to recreate would have opened one.
+#
+# WHY IN-CLUSTER RBAC AT ALL, since EKS access policies do the rest of the work here:
+# Kubernetes escalation prevention refuses to let a principal create a Role granting
+# permissions it does not itself hold, and that check resolves IN-CLUSTER RBAC ONLY.
+# A principal authorised entirely by EKS access policies holds nothing as far as the
+# RBAC authorizer is concerned, so it cannot create a Role granting anything at all:
+#
+#   roles.rbac.authorization.k8s.io "build-cluster-connection-write" is forbidden:
+#   user ".../ack-test-infra-staging-argocd-capability-role/aws-go-sdk-..."
+#   (groups=["argocd-cluster-scoped" "system:authenticated"]) is attempting to grant
+#   RBAC permissions not currently held: {APIGroups:[""], Resources:["configmaps"], ...}
+#
+# Most of what follows therefore adds no access Argo CD lacked. It restates access the
+# associated policies already grant, in the form the RBAC authorizer can see. The two
+# exceptions are called out where they appear, because they are real expansions.
+#
+# `kubectl auth can-i --as-group=argocd-cluster-scoped` is the right probe for this and
+# the wrong probe for anything else: it reports what the RBAC authorizer sees, which is
+# exactly the escalation-prevention view, and it reports `no` for everything granted by
+# an access policy, because those are enforced by the EKS authorizer and are invisible
+# to a SubjectAccessReview. Do not read a `no` from it as a gap without checking which
+# authorizer is meant to be answering.
+#
+# Full history, including the options rejected: docs/argocd-migration.md.
+################################################################################
+
+locals {
+  # The group on the capability role's access entry. Every binding here uses it as the
+  # subject; aws_eks_access_entry.argocd_capability_group puts it on the entry. The
+  # entry's username is session-templated (".../{{SessionName}}") and cannot serve as
+  # an RBAC subject, so a group is the only stable option.
+  argocd_rbac_group = one(aws_eks_access_entry.argocd_capability_group.kubernetes_groups)
+
+  # One name, used by the four Roles below and by the RoleBindings that reference them.
+  argocd_grantor_name = "argocd-rbac-grantor"
+
+  # Namespaces holding a CR type that `admin` does not aggregate. Not the same set as
+  # argocd_hub_namespaces: flux-system needs no grantor Role, and `argocd` gets one
+  # despite being covered by no access policy at all.
+  argocd_grantor_namespaces = [
+    "ack-system",
+    "prow",
+    "test-pods",
+    "argocd",
+  ]
+}
+
+################################################################################
+# Cluster-scoped grants.
+#
+# No associable EKS access policy covers these objects, which is why in-cluster RBAC
+# is here at all rather than another access_policy_association:
+#
+#   AmazonEKSBlockStorageClusterPolicy and AmazonEKSComputeClusterPolicy are rejected
+#   outright - "The specified policyArn can only be associated with service-linked
+#   roles". AmazonEKSLoadBalancingClusterPolicy associates but grants no IngressClass
+#   write. AmazonEKSAdminPolicy mirrors the built-in admin ClusterRole, which is
+#   namespace-oriented and excludes cluster-scoped resources and CRD instances; it
+#   makes no difference at either scope, and associating it at CLUSTER scope silently
+#   REPLACES the namespace-scoped association of the same policy in argocd-access.tf,
+#   widening that grant.
+#
+#   The only associable policy that would cover all of these is
+#   AmazonEKSClusterAdminPolicy, i.e. cluster-admin for Argo CD.
+################################################################################
+
+resource "kubernetes_cluster_role_v1" "argocd_cluster_scoped" {
+  metadata {
+    name = "argocd-cluster-scoped"
+  }
+
+  ##############################################################################
+  # 1-4. The cluster-scoped objects in the ack-cluster chart. If that chart stops
+  # carrying them, these four rules go too.
+  ##############################################################################
+
+  # StorageClass - auto-ebs-sc
+  rule {
+    api_groups = ["storage.k8s.io"]
+    resources  = ["storageclasses"]
+    verbs      = ["get", "list", "watch", "create", "update", "patch", "delete"]
+  }
+
+  # IngressClass - alb
+  rule {
+    api_groups = ["networking.k8s.io"]
+    resources  = ["ingressclasses"]
+    verbs      = ["get", "list", "watch", "create", "update", "patch", "delete"]
+  }
+
+  # Karpenter NodePool - prow-compute and prow-control-plane on the hub, and the build
+  # cluster's pool, since that cluster is registered as a spoke.
+  rule {
+    api_groups = ["karpenter.sh"]
+    resources  = ["nodepools"]
+    verbs      = ["get", "list", "watch", "create", "update", "patch", "delete"]
+  }
+
+  # EKS Auto Mode NodeClass - the build cluster's custom prow-compute class. Required
+  # because that cluster enables Auto Mode with no built-in NodePools, so no managed
+  # `default` NodeClass exists.
+  rule {
+    api_groups = ["eks.amazonaws.com"]
+    resources  = ["nodeclasses"]
+    verbs      = ["get", "list", "watch", "create", "update", "patch", "delete"]
+  }
+
+  ##############################################################################
+  # 5-8. For prow-plugins. THIS IS A DELIBERATE PRIVILEGE EXPANSION, decided rather
+  # than drifted into, and one of the two grants here that is NOT merely a
+  # restatement of access Argo CD already holds.
+  #
+  # prow/plugins/deployments/agent-plugin/rbac.yaml carries a ClusterRole and
+  # ClusterRoleBinding. Applying them needs two separate permissions: the ability to
+  # create ClusterRoles at all, and holding everything the created ClusterRole grants,
+  # or escalation prevention refuses it. Measured before deciding, with
+  # `kubectl auth can-i --as-group=argocd-cluster-scoped`:
+  #
+  #   create clusterroles         no    create prowjobs (all ns)   no
+  #   create clusterrolebindings  no    patch  prowjobs (all ns)   no
+  #                                     list   pods     (all ns)   no
+  #                                     get    pods/log (all ns)   no
+  #
+  # Every other grantor rule in this file is honestly describable as access Argo CD
+  # already had, only expressed where escalation prevention can see it -
+  # AmazonEKSAdminPolicy grants it namespace-scoped admin over the four namespaces in
+  # argocd_hub_namespaces. Cluster-wide prowjobs write and pod read is WIDER than that,
+  # so that description does not apply here.
+  #
+  # The alternative was narrowing the plugin's own ClusterRole to namespaced Roles,
+  # which the evidence supports - its Deployment pins PROW_JOB_NAMESPACE to prow and
+  # all live ProwJobs are in prow, so the ClusterRole is wider than the workload needs.
+  # Not taken here: it changes generated RBAC and the plugin's effective permissions,
+  # which belongs to whoever owns agent-plugin. If it lands, shrink these rules to
+  # match - they only need to remain a superset of what that ClusterRole grants.
+  #
+  # What bounds the expansion: kustomize-controller holds strictly more than this and
+  # loses it in Phase 5, so the number of broadly-privileged principals does not rise.
+  # No `delete` on any of it, and no `escalate` - which would let Argo CD create a Role
+  # conferring anything at all.
+  ##############################################################################
+
+  # Create the objects themselves. Without this the failure is a plain "cannot create
+  # resource clusterroles at the cluster scope", not an escalation error, which is easy
+  # to mistake for one.
+  rule {
+    api_groups = ["rbac.authorization.k8s.io"]
+    resources  = ["clusterroles", "clusterrolebindings"]
+    verbs      = ["get", "create", "update", "patch"]
+  }
+
+  # Hold what the agent-plugin ClusterRole grants, so escalation prevention passes.
+  # These mirror it exactly; if that file gains a verb or resource, these need it too
+  # or the sync fails.
+  rule {
+    api_groups = ["prow.k8s.io"]
+    resources  = ["prowjobs"]
+    verbs      = ["create", "get", "list", "watch", "update", "patch"]
+  }
+
+  rule {
+    api_groups = [""]
+    resources  = ["pods"]
+    verbs      = ["get", "list", "watch"]
+  }
+
+  rule {
+    api_groups = [""]
+    resources  = ["pods/log"]
+    verbs      = ["get"]
+  }
+
+  ##############################################################################
+  # 9. For the `secrets` path. THIS IS THE WIDEST GRANT IN THE MIGRATION, and it was
+  # authorised explicitly after being priced, not inferred from a convention.
+  #
+  # flux/secrets/secrets-store-rbac.yaml declares a ClusterRole granting the CSI
+  # driver `secrets` create/delete/get/list/patch/update/watch cluster-wide.
+  # Escalation prevention requires the applier to hold EVERY rule in a ClusterRole it
+  # creates, so Argo CD must hold all seven verbs on every Secret in the cluster for
+  # that object to apply. Measured before asking: all seven were `no`.
+  #
+  # BE CLEAR ABOUT WHAT THIS IS. It is not read access for health assessment. It is
+  # read, write and delete on every Secret in the cluster, including credentials this
+  # repo does not own, reachable by anything that can act as the Argo CD capability
+  # role. There is no narrower version that still applies the object: a subset fails
+  # the escalation check, and the only alternative mechanism is the `escalate` verb,
+  # which is broader still.
+  #
+  # THE EXIT CONDITION, which is cheaper than it looks and should be taken. Narrow the
+  # CSI driver's own ClusterRole to namespaced Roles and this rule can be deleted
+  # outright - Argo CD would then need only namespaced secrets write, which
+  # AmazonEKSAdminPolicy already grants. The measurements say that is viable: the
+  # ClusterRoleBinding's only subject is the single secrets-store-csi-driver
+  # ServiceAccount in aws-secrets-manager, and the only SecretProviderClasses in the
+  # cluster are prow/prow-secrets and test-pods/prow-secrets, so the driver writes
+  # Secrets in two namespaces rather than all of them.
+  #
+  # Mirrors that ClusterRole exactly, including delete. If its verbs change, this must
+  # change with them or the sync fails.
+  ##############################################################################
+  rule {
+    api_groups = [""]
+    resources  = ["secrets"]
+    verbs      = ["create", "delete", "get", "list", "patch", "update", "watch"]
+  }
+}
+
+resource "kubernetes_cluster_role_binding_v1" "argocd_cluster_scoped" {
+  metadata {
+    name = "argocd-cluster-scoped"
+  }
+
+  role_ref {
+    api_group = "rbac.authorization.k8s.io"
+    kind      = "ClusterRole"
+    name      = kubernetes_cluster_role_v1.argocd_cluster_scoped.metadata[0].name
+  }
+
+  subject {
+    api_group = "rbac.authorization.k8s.io"
+    kind      = "Group"
+    name      = local.argocd_rbac_group
+    namespace = ""
+  }
+}
+
+################################################################################
+# Namespaced grants: one RoleBinding to the built-in `admin` ClusterRole per namespace.
+#
+# WHY THIS SHAPE, and why it is not a privilege increase. The first four paths were
+# unblocked one rule at a time, each discovered by a failed sync. That does not
+# converge: every chart that adds a Role adds another round trip. Measured across the
+# remaining paths, 13 more triples were missing across two namespaces - and 12 of the
+# 13 fall inside the built-in aggregated `admin` ClusterRole.
+#
+# AmazonEKSAdminPolicy is already associated to this principal scoped to exactly these
+# namespaces (argocd_hub_namespaces, in argocd-access.tf). So a RoleBinding to `admin`
+# in them grants NO NEW EFFECTIVE PRIVILEGE - it mirrors the access policy the EKS
+# authorizer already honours into the authorizer that escalation prevention consults.
+# One binding per namespace replaces the open-ended rule list, and any future
+# namespaced Role in those namespaces just works.
+#
+# WHAT IS DELIBERATELY NOT DONE: binding cluster-admin. That would be a genuine
+# expansion, and after this change the remaining whack-a-mole is small - only
+# cluster-scoped grants and custom resource types need explicit rules, and both are
+# rare enough that explicitness is worth more than brevity.
+#
+# for_each over argocd_hub_namespaces rather than a literal list, because the equality
+# with that list is the whole argument for this being privilege-neutral. Adding a
+# namespace to the access policy now adds its binding in the same change, and the two
+# cannot drift apart silently.
+################################################################################
+
+resource "kubernetes_role_binding_v1" "argocd_namespace_admin" {
+  for_each = toset(local.argocd_hub_namespaces)
+
+  metadata {
+    name      = "argocd-namespace-admin"
+    namespace = each.value
+  }
+
+  role_ref {
+    api_group = "rbac.authorization.k8s.io"
+    kind      = "ClusterRole"
+    name      = "admin"
+  }
+
+  subject {
+    api_group = "rbac.authorization.k8s.io"
+    kind      = "Group"
+    name      = local.argocd_rbac_group
+    namespace = ""
+  }
+}
+
+################################################################################
+# Custom resource types, which the aggregated `admin` ClusterRole does not cover. One
+# Role per namespace, holding only CR types - kept as four explicit resources rather
+# than a for_each with dynamic rules, because the rules differ per namespace and the
+# point of them is to be read.
+################################################################################
+
+# ack-system: the connection Job's chart reads the build-cluster Cluster CR status.
+resource "kubernetes_role_v1" "argocd_grantor_ack_system" {
+  metadata {
+    name      = local.argocd_grantor_name
+    namespace = "ack-system"
+  }
+
+  rule {
+    api_groups = ["eks.services.k8s.aws"]
+    resources  = ["clusters"]
+    verbs      = ["get", "list", "watch"]
+  }
+}
+
+# prow: the secrets path declares a SecretProviderClass here, and prow-config's Roles
+# grant prowjobs including `delete`, which the cluster-scoped rule deliberately omits -
+# sinker deletes ProwJobs, so the permission is real, but it is granted here rather
+# than cluster-wide.
+resource "kubernetes_role_v1" "argocd_grantor_prow" {
+  metadata {
+    name      = local.argocd_grantor_name
+    namespace = "prow"
+  }
+
+  rule {
+    api_groups = ["secrets-store.csi.x-k8s.io"]
+    resources  = ["secretproviderclasses"]
+    verbs      = ["get", "create", "update", "patch"]
+  }
+
+  rule {
+    api_groups = ["prow.k8s.io"]
+    resources  = ["prowjobs"]
+    verbs      = ["get", "list", "watch", "create", "update", "patch", "delete"]
+  }
+}
+
+# test-pods: the second SecretProviderClass. Job pods mount it via the CSI driver.
+resource "kubernetes_role_v1" "argocd_grantor_test_pods" {
+  metadata {
+    name      = local.argocd_grantor_name
+    namespace = "test-pods"
+  }
+
+  rule {
+    api_groups = ["secrets-store.csi.x-k8s.io"]
+    resources  = ["secretproviderclasses"]
+    verbs      = ["get", "create", "update", "patch"]
+  }
+}
+
+# argocd: the one namespace no access policy covers, so nothing here comes for free.
+#
+# AmazonEKSAdminPolicy is scoped to argocd_hub_namespaces and excludes this one;
+# AmazonEKSArgoCDPolicy covers it but is the capability's own-operation grant, which
+# reads cluster registration Secrets rather than managing RBAC. So this namespace gets
+# no admin binding and needs both halves spelled out:
+#
+#   1. the ability to create roles and rolebindings at all. Elsewhere the admin binding
+#      provides it. Without it the failure is a plain "cannot create resource roles in
+#      API group rbac.authorization.k8s.io in the namespace argocd" - not an escalation
+#      error, and easy to mistake for one.
+#   2. holding whatever the created Role grants, so escalation prevention passes: the
+#      secrets, appprojects and applications rules, matching
+#      build-cluster-connection-registrar.
+#
+# Granting roles/rolebindings write here does not let Argo CD widen its own access:
+# escalation prevention still caps any Role it creates at what it already holds.
+resource "kubernetes_role_v1" "argocd_grantor_argocd" {
+  metadata {
+    name      = local.argocd_grantor_name
+    namespace = "argocd"
+  }
+
+  rule {
+    api_groups = ["rbac.authorization.k8s.io"]
+    resources  = ["roles", "rolebindings"]
+    verbs      = ["get", "create", "update", "patch"]
+  }
+
+  rule {
+    api_groups = [""]
+    resources  = ["secrets"]
+    verbs      = ["get", "create", "update", "patch"]
+  }
+
+  # The connection Job appends the build cluster to the AppProject's destinations, and
+  # applies the prow-build-cluster-resources Application. Both are runtime work because
+  # they name a cluster ACK owns and Terraform must hold nothing keyed to it (D13).
+  # appprojects is get and patch only - the AppProject is Terraform-owned and the Job
+  # amends one field - while applications needs create, because the Job owns that object
+  # outright. No delete on either.
+  rule {
+    api_groups = ["argoproj.io"]
+    resources  = ["appprojects"]
+    verbs      = ["get", "patch"]
+  }
+
+  rule {
+    api_groups = ["argoproj.io"]
+    resources  = ["applications"]
+    verbs      = ["get", "create", "update", "patch"]
+  }
+}
+
+# One binding per grantor Role. All four Roles share a name, so role_ref is the same
+# symbol in each; depends_on is implicit through local.argocd_grantor_name only, so the
+# Roles are listed explicitly to keep the binding from being created first.
+resource "kubernetes_role_binding_v1" "argocd_grantor" {
+  for_each = toset(local.argocd_grantor_namespaces)
+
+  metadata {
+    name      = local.argocd_grantor_name
+    namespace = each.value
+  }
+
+  role_ref {
+    api_group = "rbac.authorization.k8s.io"
+    kind      = "Role"
+    name      = local.argocd_grantor_name
+  }
+
+  subject {
+    api_group = "rbac.authorization.k8s.io"
+    kind      = "Group"
+    name      = local.argocd_rbac_group
+    namespace = ""
+  }
+
+  depends_on = [
+    kubernetes_role_v1.argocd_grantor_ack_system,
+    kubernetes_role_v1.argocd_grantor_prow,
+    kubernetes_role_v1.argocd_grantor_test_pods,
+    kubernetes_role_v1.argocd_grantor_argocd,
+  ]
+}

--- a/bootstrap/argocd.tf
+++ b/bootstrap/argocd.tf
@@ -1,0 +1,155 @@
+################################################################################
+# Argo CD Capability — Identity Center lookup
+#
+# The IdC account instance and the Argo CD admin group are created by the
+# separate bootstrap/identity/ module, which holds its own Terraform state so the
+# routine destroy/apply cycle of this stack can never delete them. They are
+# consumed here by data source rather than cross-state reference, which keeps the
+# two modules decoupled.
+#
+# Apply bootstrap/identity/ first. There is at most one IdC account instance per
+# account, so the lookup is deterministic.
+################################################################################
+
+data "aws_ssoadmin_instances" "this" {}
+
+data "aws_identitystore_group" "argocd_admins" {
+  identity_store_id = one(data.aws_ssoadmin_instances.this.identity_store_ids)
+
+  alternate_identifier {
+    unique_attribute {
+      attribute_path  = "DisplayName"
+      attribute_value = "${local.stack_name}-argocd-admins"
+    }
+  }
+}
+
+################################################################################
+# Argo CD Capability IAM Role
+#
+# Unlike the ACK capability role, nothing else adopts or widens this role, so
+# Terraform owns it outright and no ignore_changes is needed.
+#
+# Note what is NOT here: no Kubernetes RBAC. EKS automatically creates access
+# entries carrying AmazonEKSArgoCDPolicy and AmazonEKSArgoCDClusterPolicy when the
+# capability is created, which cover Argo CD's own operation. Workload deploy
+# permissions are granted separately — see argocd-access.tf.
+#
+# Git access needs no IAM: the source repository is public HTTPS, so neither
+# CodeConnections nor CodeCommit permissions are required.
+################################################################################
+
+resource "aws_iam_role" "argocd_capability" {
+  name = "${local.stack_name}-argocd-capability-role"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect    = "Allow"
+      Principal = { Service = "capabilities.eks.amazonaws.com" }
+      Action    = ["sts:AssumeRole", "sts:TagSession"]
+    }]
+  })
+}
+
+resource "aws_iam_role_policy" "argocd_capability" {
+  name = "ArgoCDCapabilityPermissions"
+  role = aws_iam_role.argocd_capability.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      # Secrets referenced directly from Application resources.
+      {
+        Effect = "Allow"
+        Action = [
+          "secretsmanager:GetSecretValue",
+          "secretsmanager:DescribeSecret"
+        ]
+        Resource = "arn:${local.partition}:secretsmanager:${var.region}:${local.account_id}:secret:ack/prow/*"
+      },
+      # Helm charts sourced from ECR. GetAuthorizationToken is not resource-scopable.
+      {
+        Effect   = "Allow"
+        Action   = ["ecr:GetAuthorizationToken"]
+        Resource = "*"
+      },
+      {
+        Effect = "Allow"
+        Action = [
+          "ecr:BatchCheckLayerAvailability",
+          "ecr:GetDownloadUrlForLayer",
+          "ecr:BatchGetImage"
+        ]
+        Resource = "arn:${local.partition}:ecr:${var.region}:${local.account_id}:repository/*"
+      }
+    ]
+  })
+}
+
+################################################################################
+# Argo CD Capability
+#
+# Terraform must own this because Argo CD cannot bootstrap itself.
+#
+# ignore_changes = all because AWS upgrades the capability automatically and
+# reports the running version back on the resource; Terraform must not fight it.
+#
+# The sleep guards an IAM propagation race. CreateCapability validates the role's
+# trust policy server-side, and when the role was just created that validation can
+# fail with "The trust policy for the provided role is invalid" even though the
+# policy is correct. On a fresh bootstrap the ~10 minute cluster creation hides the
+# race; when adding the capability to an existing cluster there is nothing to hide
+# behind, and it fails reliably without this.
+################################################################################
+
+resource "time_sleep" "argocd_role_propagation" {
+  depends_on = [
+    aws_iam_role.argocd_capability,
+    aws_iam_role_policy.argocd_capability,
+  ]
+
+  create_duration = "30s"
+}
+
+resource "awscc_eks_capability" "argocd" {
+  cluster_name              = aws_eks_cluster.this.name
+  capability_name           = "argocd"
+  type                      = "ARGOCD"
+  role_arn                  = aws_iam_role.argocd_capability.arn
+  delete_propagation_policy = "RETAIN"
+
+  configuration = {
+    argo_cd = {
+      namespace = "argocd"
+
+      aws_idc = {
+        idc_instance_arn = one(data.aws_ssoadmin_instances.this.arns)
+      }
+
+      # SsoIdentityType enum is SSO_USER | SSO_GROUP. Plain "GROUP" is invalid and
+      # fails at runtime rather than at plan time.
+      rbac_role_mappings = [{
+        role = "ADMIN"
+        identities = [{
+          id   = data.aws_identitystore_group.argocd_admins.group_id
+          type = "SSO_GROUP"
+        }]
+      }]
+    }
+  }
+
+  lifecycle {
+    ignore_changes = all
+  }
+
+  depends_on = [
+    aws_eks_cluster.this,
+    time_sleep.argocd_role_propagation,
+  ]
+}
+
+output "argocd_server_url" {
+  description = "Argo CD UI URL, reported back by the capability once ACTIVE."
+  value       = try(awscc_eks_capability.argocd.configuration.argo_cd.server_url, null)
+}

--- a/bootstrap/capability.tf
+++ b/bootstrap/capability.tf
@@ -27,7 +27,31 @@ resource "aws_iam_role" "ack_capability" {
 # Minimal bootstrap permissions — just enough for ACK to:
 # 1. Manage the capability itself (eks:*)
 # 2. Update its own role policies (iam:* on itself)
+#
+# SEED ONLY. This exists so ACK can bootstrap, and ACK replaces it once it adopts the
+# role: on a live cluster the role carries ACK's own six inline policies
+# (EC2Management, ECRManagement, EKSSelfManagement, IAMManagement, Route53Management,
+# S3ProwLogs) and BootstrapPermissions is GONE. EKSSelfManagement grants the same eks:*
+# on the same five ARN patterns, and IAMManagement grants iam:* on
+# role/<stack>-* which is a superset of the one role this granted. So it is fully
+# superseded, and the capability is ACTIVE without it.
+#
+# WHY THE COUNT, rather than just ignore_changes. `ignore_changes` suppresses diffs on an
+# EXISTING object; it does nothing when the object is absent. Because ACK deletes this
+# policy, every subsequent plan wanted to CREATE it again -- permanent noise on an
+# otherwise clean plan, and it would re-add a policy ACK deliberately replaced. Gating on
+# a variable expresses the real lifecycle: Terraform seeds it on a fresh bootstrap and
+# never touches it again.
+#
+# Fresh bootstrap:  terraform apply -var seed_ack_bootstrap_policy=true
+# Then, once ACK has adopted the role and written its own policies, drop the flag (the
+# default) and remove the seed from state WITHOUT destroying it:
+#   terraform state rm 'aws_iam_role_policy.ack_capability_bootstrap[0]'
+# Check `aws iam list-role-policies` first: if BootstrapPermissions is somehow still
+# present, flipping the flag would DELETE it rather than orphan it.
 resource "aws_iam_role_policy" "ack_capability_bootstrap" {
+  count = var.seed_ack_bootstrap_policy ? 1 : 0
+
   name = "BootstrapPermissions"
   role = aws_iam_role.ack_capability.id
 
@@ -35,8 +59,8 @@ resource "aws_iam_role_policy" "ack_capability_bootstrap" {
     Version = "2012-10-17"
     Statement = [
       {
-        Effect   = "Allow"
-        Action   = ["eks:*"]
+        Effect = "Allow"
+        Action = ["eks:*"]
         Resource = [
           "arn:${local.partition}:eks:${var.region}:${local.account_id}:capability/${local.cluster_name}/*",
           "arn:${local.partition}:eks:${var.region}:${local.account_id}:access-entry/${local.cluster_name}/*",

--- a/bootstrap/flux.tf
+++ b/bootstrap/flux.tf
@@ -28,23 +28,23 @@ resource "kubernetes_config_map_v1" "self_managed_vars" {
   }
 
   data = {
-    STACK_NAME               = local.stack_name
-    ACCOUNT_ID               = local.account_id
-    REGION                   = var.region
-    CLUSTER_SG_ID            = aws_eks_cluster.this.vpc_config[0].cluster_security_group_id
-    VPC_ID                   = module.vpc.vpc_id
-    GHCR_PTC_SECRET_ARN      = data.aws_secretsmanager_secret.ghcr_ptc.arn
-    PROW_DOMAIN              = var.prow_domain
-    PROW_IMAGES_REPO_URI     = local.prow_images_repo_uri
-    TEST_INFRA_ORG           = var.test_infra_org
-    TEST_INFRA_REPO          = var.test_infra_repo
-    TEST_INFRA_BRANCH        = var.test_infra_branch
-    FLUX_IMAGE_REGISTRY      = "${local.account_id}.dkr.ecr.${var.region}.amazonaws.com/fluxcd/fluxcd"
-    CONTROLLER_ECR_REGISTRY      = "public.ecr.aws/${local.controller_ecr_alias}"
-    PUBLISH_ACCOUNT_ID           = var.publish_account_id
-    STAGE                        = var.stage
-    KUBERNETES_ORG               = var.kubernetes_org
-    REDHAT_ORG                   = var.redhat_org
+    STACK_NAME              = local.stack_name
+    ACCOUNT_ID              = local.account_id
+    REGION                  = var.region
+    CLUSTER_SG_ID           = aws_eks_cluster.this.vpc_config[0].cluster_security_group_id
+    VPC_ID                  = module.vpc.vpc_id
+    GHCR_PTC_SECRET_ARN     = data.aws_secretsmanager_secret.ghcr_ptc.arn
+    PROW_DOMAIN             = var.prow_domain
+    PROW_IMAGES_REPO_URI    = local.prow_images_repo_uri
+    TEST_INFRA_ORG          = var.test_infra_org
+    TEST_INFRA_REPO         = var.test_infra_repo
+    TEST_INFRA_BRANCH       = var.test_infra_branch
+    FLUX_IMAGE_REGISTRY     = "${local.account_id}.dkr.ecr.${var.region}.amazonaws.com/fluxcd/fluxcd"
+    CONTROLLER_ECR_REGISTRY = "public.ecr.aws/${local.controller_ecr_alias}"
+    PUBLISH_ACCOUNT_ID      = var.publish_account_id
+    STAGE                   = var.stage
+    KUBERNETES_ORG          = var.kubernetes_org
+    REDHAT_ORG              = var.redhat_org
   }
 
   depends_on = [null_resource.flux_system_namespace]
@@ -151,7 +151,19 @@ resource "null_resource" "restore_flux_registry" {
 # secrets are in place.
 ################################################################################
 
+# GATED, because "one-shot" was only ever a comment. A local-exec provisioner has no
+# concept of having already run: it re-runs whenever the resource is replaced, and a tainted
+# instance forces exactly that. This one sat tainted, so every plan wanted to rebuild all 15
+# images - roughly an hour - which is why every apply during the migration had to be
+# -target'ed to avoid it. `ignore_changes` does not help: it suppresses attribute diffs and
+# says nothing about replacement.
+#
+# Fresh bootstrap:  terraform apply -var bootstrap_prow_images=true
+# Afterwards the flag stays off (the default) and images are rebuilt by Prow's own jobs, not
+# by Terraform. To force a rebuild deliberately, set the flag again.
 resource "null_resource" "bootstrap_prow_images_job" {
+  count = var.bootstrap_prow_images ? 1 : 0
+
   triggers = {
     cluster_name = aws_eks_cluster.this.name
     region       = var.region

--- a/bootstrap/identity/main.tf
+++ b/bootstrap/identity/main.tf
@@ -1,0 +1,70 @@
+# IAM Identity Center account instance for the Argo CD EKS Capability.
+#
+# This module is deliberately SEPARATE from the main bootstrap stack and holds its
+# own Terraform state. The Argo CD capability requires an IdC instance ARN
+# (argoCd.awsIdc.idcInstanceArn is a required API field), and an account instance is
+# a singleton whose ARN is baked into the capability configuration. Keeping it out of
+# the main stack means the routine destroy/apply cycle can never delete it and force
+# a capability recreation.
+#
+# Apply once per account. The main stack consumes the results through the
+# aws_ssoadmin_instances and aws_identitystore_group data sources, not through a
+# cross-state reference.
+#
+# Teardown is explicit and only for account decommissioning - see the Teardown note in
+# docs/argocd-migration.md. No prevent_destroy is set, because that would make
+# deliberate teardown impossible.
+
+provider "aws" {
+  region = var.region
+}
+
+provider "awscc" {
+  region = var.region
+}
+
+locals {
+  name_prefix = "ack-test-infra-${var.stage}"
+}
+
+# Account instance of IAM Identity Center. Supported for standalone accounts that are
+# not managed by AWS Organizations, which is the case here. One per account, usable
+# only within this account and region.
+resource "awscc_sso_instance" "this" {
+  name = local.name_prefix
+}
+
+# Group mapped to the Argo CD ADMIN role in the capability's rbacRoleMappings.
+# The capability references this by group_id, with identity type SSO_GROUP.
+resource "aws_identitystore_group" "argocd_admins" {
+  identity_store_id = awscc_sso_instance.this.identity_store_id
+  display_name      = "${local.name_prefix}-argocd-admins"
+  description       = "Argo CD ADMIN role for the ACK test-infra EKS capability"
+}
+
+# Optional users. Empty by default - see the argocd_admins variable description.
+resource "aws_identitystore_user" "admins" {
+  for_each = { for u in var.argocd_admins : u.user_name => u }
+
+  identity_store_id = awscc_sso_instance.this.identity_store_id
+  user_name         = each.value.user_name
+  display_name      = "${each.value.given_name} ${each.value.family_name}"
+
+  name {
+    given_name  = each.value.given_name
+    family_name = each.value.family_name
+  }
+
+  emails {
+    value   = each.value.email
+    primary = true
+  }
+}
+
+resource "aws_identitystore_group_membership" "admins" {
+  for_each = aws_identitystore_user.admins
+
+  identity_store_id = awscc_sso_instance.this.identity_store_id
+  group_id          = aws_identitystore_group.argocd_admins.group_id
+  member_id         = each.value.user_id
+}

--- a/bootstrap/identity/outputs.tf
+++ b/bootstrap/identity/outputs.tf
@@ -1,0 +1,19 @@
+output "idc_instance_arn" {
+  description = "IdC instance ARN. Consumed as argoCd.awsIdc.idcInstanceArn by the capability."
+  value       = awscc_sso_instance.this.instance_arn
+}
+
+output "idc_identity_store_id" {
+  description = "Identity Store ID backing the instance."
+  value       = awscc_sso_instance.this.identity_store_id
+}
+
+output "argocd_admin_group_id" {
+  description = "Group ID for the Argo CD ADMIN rbacRoleMapping (identity type SSO_GROUP)."
+  value       = aws_identitystore_group.argocd_admins.group_id
+}
+
+output "argocd_admin_group_display_name" {
+  description = "Display name the main stack looks up via the aws_identitystore_group data source."
+  value       = aws_identitystore_group.argocd_admins.display_name
+}

--- a/bootstrap/identity/variables.tf
+++ b/bootstrap/identity/variables.tf
@@ -1,0 +1,30 @@
+variable "region" {
+  description = "AWS region. The IdC account instance is region-locked and must match the clusters."
+  type        = string
+  default     = "us-west-2"
+}
+
+variable "stage" {
+  description = "Deployment stage (dev, staging, prod). Used to name the instance and admin group."
+  type        = string
+}
+
+variable "argocd_admins" {
+  description = <<-EOT
+    Users to create in the Identity Store and add to the Argo CD ADMIN group.
+
+    Optional. The capability builds successfully against an empty group, so an empty
+    list does not block bootstrap - but nobody can sign in to the Argo CD UI until
+    the group has members. Populate this, or federate an external IdP into the
+    instance instead.
+  EOT
+
+  type = list(object({
+    user_name   = string
+    given_name  = string
+    family_name = string
+    email       = string
+  }))
+
+  default = []
+}

--- a/bootstrap/identity/versions.tf
+++ b/bootstrap/identity/versions.tf
@@ -1,0 +1,14 @@
+terraform {
+  required_version = ">= 1.5"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.49"
+    }
+    awscc = {
+      source  = "hashicorp/awscc"
+      version = ">= 1.0"
+    }
+  }
+}

--- a/bootstrap/images.tf
+++ b/bootstrap/images.tf
@@ -69,7 +69,11 @@ locals {
 # The in-cluster build job handles building all other images.
 ################################################################################
 
+# Same one-shot gate as bootstrap_prow_images_job, which depends on this one: this pushes
+# the builder image that the in-cluster Job then uses to build the rest.
 resource "null_resource" "bootstrap_prow_images" {
+  count = var.bootstrap_prow_images ? 1 : 0
+
   # Only re-run if these change
   triggers = {
     repository_uri = aws_ecrpublic_repository.prow_images.repository_uri
@@ -77,7 +81,7 @@ resource "null_resource" "bootstrap_prow_images" {
   }
 
   provisioner "local-exec" {
-    command     = "${path.module}/../prow/jobs/images/bootstrap-images.sh"
+    command = "${path.module}/../prow/jobs/images/bootstrap-images.sh"
     environment = {
       AWS_ACCOUNT_ID      = local.account_id
       AWS_REGION          = var.region

--- a/bootstrap/variables.tf
+++ b/bootstrap/variables.tf
@@ -70,3 +70,17 @@ variable "seed_ack_bootstrap_policy" {
   type        = bool
   default     = false
 }
+
+variable "bootstrap_prow_images" {
+  description = <<-EOT
+    Build and push the Prow images from Terraform.
+
+    True only on a FRESH bootstrap, where the ECR repo is empty and nothing can pull yet.
+    It drives two local-exec provisioners: one pushes the builder image, the other runs the
+    in-cluster Job that builds the remaining ~15. That takes roughly an hour, and because a
+    provisioner re-runs on every replacement, leaving this on means any taint or trigger
+    change silently costs that hour. Afterwards Prow's own jobs rebuild the images.
+  EOT
+  type        = bool
+  default     = false
+}

--- a/bootstrap/variables.tf
+++ b/bootstrap/variables.tf
@@ -57,3 +57,16 @@ variable "publish_account_id" {
   description = "AWS account ID that owns the ECR Public repositories for publishing controller images and Helm charts"
   type        = string
 }
+
+variable "seed_ack_bootstrap_policy" {
+  description = <<-EOT
+    Seed the ACK capability role with the minimal BootstrapPermissions inline policy.
+
+    True only on a FRESH bootstrap, where ACK has not yet adopted the role and needs
+    eks:* on the capability and iam:* on itself to get started. ACK replaces that policy
+    with its own set once it adopts the role, so leaving this true afterwards makes every
+    plan want to recreate a policy ACK has deliberately superseded. See capability.tf.
+  EOT
+  type        = bool
+  default     = false
+}

--- a/bootstrap/versions.tf
+++ b/bootstrap/versions.tf
@@ -10,5 +10,16 @@ terraform {
       source  = "hashicorp/awscc"
       version = ">= 1.0"
     }
+    # Was resolved implicitly before argocd-rbac.tf, which is fine until an init picks a
+    # different major version. Declared with a floor rather than pinned, matching the
+    # others; the lock file holds the exact version.
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = ">= 3.2"
+    }
+    time = {
+      source  = "hashicorp/time"
+      version = ">= 0.11"
+    }
   }
 }


### PR DESCRIPTION
**Stage 3 of 8** in the Flux → Argo CD migration.

Stands up the Argo CD capability and authorises it **without granting cluster-admin**. Flux still
owns every object; no Applications exist yet, so everything added here is inert until stage 4.

**Terraform only — 13 files, all under `bootstrap/`.** No Flux manifests, no chart changes, nothing
suspended. The path conversions landed separately in #1060 and #1062.

## What this adds

| file | what |
|---|---|
| `argocd.tf`, `capability.tf` | the capability itself, and the Identity Center lookup it consumes |
| `argocd-access.tf` | EKS access policy associations, hub cluster registration, the AppProject |
| `argocd-rbac.tf` | one narrow ClusterRole for the four cluster-scoped kinds no access policy covers |
| `argocd-logs.tf` | CloudWatch vended log delivery for the controllers |
| `identity/` | **a separate Terraform stack** — the IdC instance and the `<stack>-argocd-admins` group |
| `images.tf`, `flux.tf`, `variables.tf` | gate two one-shots behind variables defaulting `false` |

## Apply order, and the step that is easy to miss

**`bootstrap/identity/` must be applied first, and it keeps its own state** — deliberately, so the
main stack's destroy/apply cycle can never delete the IdC instance. It therefore needs its own
generated `backend.tf`. Skip it and the main stack fails *at plan*, not at apply:

> `Error: Missing required argument` — `data.aws_identitystore_group.argocd_admins`,
> `The argument "identity_store_id" is required, but no definition was found.`

which is `one(data.aws_ssoadmin_instances.this.identity_store_ids)` returning `null` in an account
with no instance.

Then, because `kubernetes_manifest` validates against the live API at plan time, the capability must
exist before the rest can plan:

```
cd bootstrap/identity && terraform init && terraform apply     # separate state
cd ..                 && terraform apply -target='awscc_eks_capability.argocd'
                         terraform apply                        # the rest
```

Run prod without `-auto-approve` and read the plan. Expect two `null_resource` destroys —
`bootstrap_prow_images` and `bootstrap_prow_images_job` dropping to `count = 0`. Both are inert:
neither carries a destroy-time provisioner.

## Why the authorisation looks like this

The capability's auto-created access entry has `kubernetesGroups: []` and a session-templated
username, so there is no stable RBAC subject — the `eks-access-entry:<arn>` group the AWS docs suggest
does not exist and binds nothing. The levers are which access *policies* are associated, plus adding a
Kubernetes group to the entry so a narrow ClusterRole can be bound for `StorageClass`, `IngressClass`,
`NodePool` and `NodeClass`. The only single policy covering those is `AmazonEKSClusterAdminPolicy`,
i.e. cluster-admin — which is what this avoids. The files record the alternatives that were tried and
failed, so they are not retried.

## Gate before stage 4

Grants must be live before any Application syncs. A sync attempted first fails on escalation
prevention with a message naming the *chart's* ClusterRole rather than the missing grantor rule, which
sends you to the wrong file.

```
for r in storageclasses ingressclasses nodepools.karpenter.sh namespaces clusterroles; do
  echo "$r: $(kubectl auth can-i create $r -A --as=probe --as-group=argocd-cluster-scoped)"
done
kubectl auth can-i delete namespaces -A --as=probe --as-group=argocd-cluster-scoped   # must be no
```

`can-i` reports `no` for anything granted by an EKS access policy — those are enforced by the EKS
authorizer and invisible to a SubjectAccessReview. Use it only for the in-cluster rules.

## Verification

- `terraform validate` passes
- rebased on `main` @ `7ce1aea`; merge-base diff is exactly the 13 files above
- commit set matches the runbook's Stage 3 assignment exactly
- no `suspend:` changes, no `docs/` changes
