### PR TITLE
Allow the identity stack to consume an organization IdC instance

### DIFF
--- a/bootstrap/identity/main.tf
+++ b/bootstrap/identity/main.tf
@@ -27,17 +27,59 @@ locals {
   name_prefix = "ack-test-infra-${var.stage}"
 }
 
-# Account instance of IAM Identity Center. Supported for standalone accounts that are
-# not managed by AWS Organizations, which is the case here. One per account, usable
-# only within this account and region.
+# IAM Identity Center instance.
+#
+# WHICH KIND YOU GET DEPENDS ON THE ACCOUNT, and the two are not interchangeable:
+#
+#   ACCOUNT instance  (create_account_instance = true, the default)
+#     Created here via AWS::SSO::Instance. Only valid for a standalone account, or a
+#     MEMBER account of an organization. One per account, usable only in this account
+#     and region.
+#
+#   ORGANIZATION instance (create_account_instance = false)
+#     Must already exist, and can only be enabled from the organization's MANAGEMENT
+#     account through the IAM Identity Center console -- there is no API for it. This
+#     module then consumes it rather than creating anything.
+#
+# CreateInstance is REJECTED in an organization management account. Prod is the
+# management account of its organization, and the failure is explicit rather than
+# subtle:
+#
+#   Organization management account is not allowed to perform the operation.
+#   (Service: SsoAdmin, Status Code: 400)
+#
+# So prod runs with create_account_instance = false and an organization instance
+# enabled by hand first. Staging is standalone and creates its own account instance.
 resource "awscc_sso_instance" "this" {
+  count = var.create_account_instance ? 1 : 0
+
   name = local.name_prefix
+}
+
+# The existing organization instance, when this module is not creating one. There is at
+# most one instance visible to an account, so the lookup is deterministic.
+data "aws_ssoadmin_instances" "existing" {
+  count = var.create_account_instance ? 0 : 1
+}
+
+locals {
+  identity_store_id = var.create_account_instance ? (
+    awscc_sso_instance.this[0].identity_store_id
+    ) : (
+    one(data.aws_ssoadmin_instances.existing[0].identity_store_ids)
+  )
+
+  instance_arn = var.create_account_instance ? (
+    awscc_sso_instance.this[0].instance_arn
+    ) : (
+    one(data.aws_ssoadmin_instances.existing[0].arns)
+  )
 }
 
 # Group mapped to the Argo CD ADMIN role in the capability's rbacRoleMappings.
 # The capability references this by group_id, with identity type SSO_GROUP.
 resource "aws_identitystore_group" "argocd_admins" {
-  identity_store_id = awscc_sso_instance.this.identity_store_id
+  identity_store_id = local.identity_store_id
   display_name      = "${local.name_prefix}-argocd-admins"
   description       = "Argo CD ADMIN role for the ACK test-infra EKS capability"
 }
@@ -46,7 +88,7 @@ resource "aws_identitystore_group" "argocd_admins" {
 resource "aws_identitystore_user" "admins" {
   for_each = { for u in var.argocd_admins : u.user_name => u }
 
-  identity_store_id = awscc_sso_instance.this.identity_store_id
+  identity_store_id = local.identity_store_id
   user_name         = each.value.user_name
   display_name      = "${each.value.given_name} ${each.value.family_name}"
 
@@ -64,7 +106,7 @@ resource "aws_identitystore_user" "admins" {
 resource "aws_identitystore_group_membership" "admins" {
   for_each = aws_identitystore_user.admins
 
-  identity_store_id = awscc_sso_instance.this.identity_store_id
+  identity_store_id = local.identity_store_id
   group_id          = aws_identitystore_group.argocd_admins.group_id
   member_id         = each.value.user_id
 }

--- a/bootstrap/identity/outputs.tf
+++ b/bootstrap/identity/outputs.tf
@@ -1,11 +1,11 @@
 output "idc_instance_arn" {
   description = "IdC instance ARN. Consumed as argoCd.awsIdc.idcInstanceArn by the capability."
-  value       = awscc_sso_instance.this.instance_arn
+  value       = local.instance_arn
 }
 
 output "idc_identity_store_id" {
   description = "Identity Store ID backing the instance."
-  value       = awscc_sso_instance.this.identity_store_id
+  value       = local.identity_store_id
 }
 
 output "argocd_admin_group_id" {

--- a/bootstrap/identity/variables.tf
+++ b/bootstrap/identity/variables.tf
@@ -28,3 +28,21 @@ variable "argocd_admins" {
 
   default = []
 }
+
+variable "create_account_instance" {
+  description = <<-EOT
+    Create an IAM Identity Center ACCOUNT instance in this account.
+
+    True for a standalone account, or a member account of an organization. FALSE for an
+    organization's MANAGEMENT account, where CreateInstance is rejected outright:
+
+      Organization management account is not allowed to perform the operation.
+      (Service: SsoAdmin, Status Code: 400)
+
+    With false, an ORGANIZATION instance must already exist -- enabled by hand from the
+    management account's IAM Identity Center console, because no API creates one -- and
+    this module consumes it instead of creating anything.
+  EOT
+  type        = bool
+  default     = true
+}


### PR DESCRIPTION
Follow-up to #1061. `bootstrap/identity/` cannot be applied in an organization's **management
account** as written, which is what prod is.

## The problem

The module unconditionally creates an IAM Identity Center **account** instance, with a comment
asserting the account is "not managed by AWS Organizations, which is the case here". True for staging,
false for prod. AWS rejects it:

```
Organization management account is not allowed to perform the operation.
(Service: SsoAdmin, Status Code: 400)
```

`CreateInstance` only ever creates *account* instances, and only for standalone or member accounts, so
this is not fixable by swapping resources. An **organization** instance must be enabled from the
management account's IAM Identity Center console and has no creation API.

## The change

Adds `create_account_instance`, defaulting `true` so standalone and member accounts are unaffected.
With `false`, the module creates nothing and consumes the existing instance via
`data.aws_ssoadmin_instances`; the group, users and outputs read it through a `local`.

The misleading comment is replaced with the actual distinction between the two instance types and the
exact rejection message, so the next account that hits this recognises the cause.

## Applied state

**This was applied to prod before merging**, to unblock stage 3 — flagging it rather than leaving it
to be discovered. An organization instance was enabled by hand in the management account, then:

```
terraform apply -var stage=prod -var region=us-west-2 -var create_account_instance=false
# Plan: 1 to add, 0 to change, 0 to destroy
```

Result:

```
idc_instance_arn      = arn:aws:sso:::instance/ssoins-790726ff08283464
idc_identity_store_id = d-9267c83500
argocd_admin_group_id = 88a18380-5091-7006-1dfe-cf801da598a7
```

So prod's `identity/terraform.tfstate` currently holds exactly one resource, the admin group, built
from this branch. Merging makes `main` agree with that.

## Note

The admin group is empty — `argocd_admins` defaults to `[]`. The capability builds fine, but nobody can
sign in to the Argo CD UI until the group has members or an external IdP is federated into the
instance.
