### PR TITLE
[argocd] Pass helm parameters as strings, not bare --set values

### DIFF
--- a/argocd/applications/templates/application.yaml
+++ b/argocd/applications/templates/application.yaml
@@ -80,15 +80,30 @@ spec:
       to the implicit rule that finds kustomization.yaml.
     */}}
     helm:
+      {{- /*
+        forceString on EVERY parameter, which is what makes Argo CD emit --set-string
+        instead of --set. Quoting the value here is not enough: it makes this manifest a
+        YAML string, but Argo CD then hands the value to Helm's --set, whose parser coerces
+        anything that looks like a number. A 12-digit account id becomes an int64, and a
+        chart that feeds it to `replace` or any other string function dies at render time
+        with "wrong type for value; expected string; got int64" - which is how prow-jobs and
+        prow-plugins failed on the first prod sync, while the ten other paths passing the
+        same accountId rendered fine because they only interpolate it.
+
+        Every key in chartValues is a string by construction - argocd-applications.value
+        fails on a non-string - so there is no parameter here that wants to stay numeric.
+      */}}
       {{- if $params }}
       parameters:
         {{- range $key := (default (list) $app.values) }}
         - name: {{ $key }}
           value: {{ include "argocd-applications.value" (list $cv $key $name) | quote }}
+          forceString: true
         {{- end }}
         {{- range $path, $key := (default (dict) $app.valuePaths) }}
         - name: {{ $path }}
           value: {{ include "argocd-applications.value" (list $cv $key $name) | quote }}
+          forceString: true
         {{- end }}
       {{- end }}
       {{- if default false $app.valuesFromTerraform }}


### PR DESCRIPTION
## Summary

`prow-jobs` and `prow-plugins` failed to render on the first prod sync after #1064:

```
wrong type for value; expected string; got int64
```

The app-of-apps chart quotes each parameter value, but that only makes it a YAML string in the rendered Application. Argo CD hands the value to Helm's `--set`, whose parser coerces anything numeric-looking, so a 12-digit account id arrives as an `int64`. Both charts feed `$accountId` to `replace`, which requires a string.

The other ten paths passing the same `accountId` render fine because they only interpolate it, never call a string function on it — so this presented as two broken Applications rather than a systemic failure.

## Fix

`forceString: true` on every threaded parameter, which makes Argo CD emit `--set-string`. That is the behaviour the chart already assumed: `argocd-applications.value` fails outright on a non-string `chartValues` entry, so no parameter here is meant to stay numeric. Applied to all of them rather than just `accountId`, since the next id-shaped value would hit this identically.

## Verification

- `helm template prow/jobs --set accountId=453735116143` reproduces the failure; `--set-string` renders 7 documents clean.
- App-of-apps chart renders 20 Applications with `forceString: true` on all 54 parameters, 0 missing.
- No Terraform change: the root Application and the values blob are untouched, so this is a git-only fix that Argo CD picks up on its next refresh.

## Post-merge

`automated: true` is already in effect, so the root re-renders and wave 5 should complete without a `terraform apply`.