### PR TITLE
[test-infra] Cut every path over to Argo CD (stage 5/8)

### DIFF
--- a/flux/ack/charts/ack-build-infra/templates/access-entries.yaml
+++ b/flux/ack/charts/ack-build-infra/templates/access-entries.yaml
@@ -162,12 +162,13 @@ spec:
 # WHY ClusterAdminPolicy, when the hub deliberately avoids it.
 #
 # On the hub, cluster-scoped access is granted by adding a kubernetesGroups entry to the
-# access entry and binding a narrow ClusterRole (flux/argocd/cluster-scoped-rbac.yaml),
-# specifically to avoid handing Argo CD cluster-admin. That approach cannot work here.
+# access entry and binding a narrow ClusterRole (bootstrap/argocd-rbac.tf), specifically
+# to avoid handing Argo CD cluster-admin. That approach cannot work here.
 # The ClusterRole would have to live inside THIS cluster, and once Flux is gone the only
 # thing able to apply it is Argo CD - the very thing it authorises. On the hub that
-# circularity is escaped because Flux owns flux/argocd/ until Phase 5 decides otherwise;
-# on a remote cluster there is no such applier. The narrow role would also have to
+# circularity is escaped because Terraform owns those objects and reaches the cluster
+# directly; on a remote cluster there is no such applier - and Terraform must hold nothing
+# keyed to a cluster ACK owns (D13), so it cannot be the applier here. The narrow role would also have to
 # enumerate every permission in those four Roles, or Kubernetes escalation prevention
 # refuses them: a principal may not create a Role granting permissions it lacks.
 #

--- a/flux/prow.yaml
+++ b/flux/prow.yaml
@@ -51,6 +51,10 @@ spec:
   # what makes that dangerous: Flux garbage-collects what a Kustomization applied when it is
   # deleted, and here that is the ProwJob CRD, which would take every ProwJob with it.
   prune: false
+  # SUSPENDED: cut over to Argo CD (Application `prow-crds`). Suspend rather than delete, because
+  # deleting the Kustomization is what would trigger garbage collection; suspending stops
+  # reconciliation and pruning both, and reverses by flipping one field.
+  suspend: true
   dependsOn:
   - name: ack-pod-identities
 ---
@@ -208,6 +212,17 @@ spec:
   # raw object stale, and prune deletes stale objects. Must be live before the
   # content change (D19-P1).
   prune: false
+  # SUSPENDED: cut over to Argo CD (Application `prow-build-cluster-resources`, which is the one
+  # Application the connection Job applies rather than Terraform, because its destination is the
+  # build cluster - D13).
+  #
+  # Suspended rather than deleting the raw manifests in this path, which an earlier plan called
+  # for. Suspend is reversible by one field and stops reconciliation without touching the objects,
+  # and it leaves the remote-apply route intact should the cutover need backing out. The raw
+  # manifests under flux/prow/build-cluster-resources/ are now redundant with the chart at
+  # flux/prow/charts/prow-build-cluster-resources/ and should be deleted in Phase 5, not here -
+  # they are the only fallback while this is still being proven.
+  suspend: true
   kubeConfig:
     configMapRef:
       name: build-cluster-flux-kubeconfig

--- a/flux/prow/build-cluster-connection/helm-release.yaml
+++ b/flux/prow/build-cluster-connection/helm-release.yaml
@@ -45,7 +45,7 @@ spec:
   # ConfigMap, and it spans flux-system, ack-system, prow and argocd -
   # the Job reads the CR in one namespace and writes the ConfigMap in another - so the
   # Application's destination namespace is only a default. Applying them needs
-  # flux/argocd/namespaced-rbac.yaml, which must stay in place.
+  # the grantor Role in bootstrap/argocd-rbac.tf, which must stay in place.
   suspend: true
   interval: 60m
   targetNamespace: flux-system

--- a/flux/prow/charts/prow-agent-workflows.yaml
+++ b/flux/prow/charts/prow-agent-workflows.yaml
@@ -5,6 +5,13 @@ metadata:
   namespace: flux-system
 spec:
   interval: 5m
+  # SUSPENDED: this path is cut over to Argo CD (Application `prow-agent-workflows`). kustomize-controller stops
+  # reconciling, so these objects are managed solely by Argo CD.
+  #
+  # Declared here rather than applied with kubectl, because the root test-infra Kustomization
+  # re-applies this spec: an imperative suspend is silently reverted on the next reconcile and
+  # both reconcilers end up owning the same objects.
+  suspend: true
   sourceRef:
     kind: GitRepository
     name: test-infra

--- a/flux/prow/charts/prow-build-cluster-connection/templates/application.yaml
+++ b/flux/prow/charts/prow-build-cluster-connection/templates/application.yaml
@@ -78,18 +78,20 @@ data:
         # namespaces itself, here or on the hub.
         - CreateNamespace=false
 
-        # NOT CUT OVER YET. automated is absent deliberately: the Application is created in
-        # manual sync so Argo CD computes the diff and applies nothing, while
-        # kustomize-controller still owns the 13 objects from
-        # flux/prow/build-cluster-resources/. Enabling it before that path is removed would
-        # give the objects two reconcilers.
+        # CUT OVER. The prow-build-cluster-resources Kustomization is suspended in git, so
+        # kustomize-controller no longer remote-applies the 13 objects and this Application owns
+        # them alone.
         #
-        # Cutover, once the first manual sync confirms all 13 uids held:
-        #   1. delete flux/prow/build-cluster-resources/ (prune: false is already live on
-        #      its Kustomization, so the live objects survive - D19-P1)
-        #   2. add the block below here, which is drift on this ConfigMap, so the sync that
-        #      picks it up also re-runs the Job that applies it
+        # Note how this change reaches the Application: editing it here is drift on the
+        # build-cluster-resources-application ConfigMap, which is a TRACKED object of this chart, so
+        # Argo CD syncs it, which re-runs the PostSync Job, which applies the updated Application.
+        # That is exactly why the manifest lives in a tracked ConfigMap rather than in the Job's
+        # shell - a chart of nothing but hooks could not have delivered this.
         #
-        # automated:
-        #   prune: false
-        #   selfHeal: false
+        # prune and selfHeal stay false, as everywhere else. prune because Argo CD deleting whatever
+        # its rendered set does not contain is the failure this migration was shaped to avoid, and
+        # selfHeal because these 13 objects have no AWS resource behind them but do sit on a remote
+        # cluster, where reasserting desired state during a diagnosis is unhelpful.
+        automated:
+          prune: false
+          selfHeal: false

--- a/flux/prow/charts/prow-build-cluster-connection/templates/job.yaml
+++ b/flux/prow/charts/prow-build-cluster-connection/templates/job.yaml
@@ -209,10 +209,17 @@ spec:
         resources:
           requests:
             cpu: "50m"
-            memory: "64Mi"
+            memory: "128Mi"
           limits:
             cpu: "200m"
-            memory: "128Mi"
+            # 128Mi was not enough and the failure mode was opaque: the pod was OOMKilled three
+            # times in a row, which Argo CD surfaces only as a PostSync hook stuck in Running.
+            #
+            # This script's steps are kubectl PIPELINES - `kubectl create ... | kubectl label
+            # --local | kubectl apply -f -` runs three Go binaries concurrently, each tens of MB,
+            # and the script now has five such steps rather than three. Peak is concurrent, not
+            # sequential, so the ceiling has to clear several kubectl processes at once.
+            memory: "512Mi"
         volumeMounts:
         - name: application
           mountPath: /etc/application

--- a/flux/prow/charts/prow-build-cluster-connection/templates/rbac.yaml
+++ b/flux/prow/charts/prow-build-cluster-connection/templates/rbac.yaml
@@ -104,7 +104,7 @@ subjects:
 # cluster existed, and on destroy it would remove the registration while Applications
 # still referenced it. The Job already reads that CR, so it is the natural place.
 #
-# Argo CD can only apply this Role because flux/argocd/namespaced-rbac.yaml grants the
+# Argo CD can only apply this Role because bootstrap/argocd-rbac.tf grants the
 # capability the same permission in this namespace. argocd is the one namespace the
 # associated access policies leave uncovered - AmazonEKSAdminPolicy excludes it, and
 # AmazonEKSArgoCDPolicy is the capability's own-operation grant. Without that grantor rule

--- a/flux/prow/charts/prow-build-cluster-resources/templates/rbac.yaml
+++ b/flux/prow/charts/prow-build-cluster-resources/templates/rbac.yaml
@@ -12,7 +12,7 @@
 # Argo CD can apply these unaided, unlike the Role and RoleBinding objects it applies on
 # the hub. Escalation prevention requires the applier to already hold every permission it
 # grants, and it only sees in-cluster RBAC — which on the hub meant EKS access policies
-# counted for nothing and flux/argocd/namespaced-rbac.yaml had to grant the rules
+# counted for nothing and bootstrap/argocd-rbac.tf had to grant the rules
 # explicitly. On the build cluster the capability holds cluster-admin
 # (argocd-build-cluster-access, in the ack-build-infra chart), so the check is satisfied
 # directly. That grant is what makes this path work without a namespaced-rbac equivalent

--- a/flux/prow/charts/prow-config.yaml
+++ b/flux/prow/charts/prow-config.yaml
@@ -6,6 +6,13 @@ metadata:
 spec:
   interval: 5m
   targetNamespace: prow
+  # SUSPENDED: this path is cut over to Argo CD (Application `prow-config`). helm-controller stops
+  # reconciling, so these objects are managed solely by Argo CD.
+  #
+  # Declared here rather than applied with kubectl, because the root test-infra Kustomization
+  # re-applies this spec: an imperative suspend is silently reverted on the next reconcile and
+  # both reconcilers end up owning the same objects.
+  suspend: true
   values:
     controllerEcrRegistry: "${CONTROLLER_ECR_REGISTRY}"
     ecrPublicAccountId: "${PUBLISH_ACCOUNT_ID}"

--- a/flux/prow/charts/prow-data-plane.yaml
+++ b/flux/prow/charts/prow-data-plane.yaml
@@ -6,6 +6,13 @@ metadata:
 spec:
   interval: 5m
   targetNamespace: test-pods
+  # SUSPENDED: this path is cut over to Argo CD (Application `prow-data-plane`). helm-controller stops
+  # reconciling, so these objects are managed solely by Argo CD.
+  #
+  # Declared here rather than applied with kubectl, because the root test-infra Kustomization
+  # re-applies this spec: an imperative suspend is silently reverted on the next reconcile and
+  # both reconcilers end up owning the same objects.
+  suspend: true
   values:
     region: "us-west-2"
     crier:

--- a/flux/prow/charts/prow-jobs.yaml
+++ b/flux/prow/charts/prow-jobs.yaml
@@ -5,6 +5,17 @@ metadata:
   namespace: flux-system
 spec:
   interval: 5m
+  # SUSPENDED: this path is cut over to Argo CD (Application `prow-jobs`). kustomize-controller stops
+  # reconciling, so these objects are managed solely by Argo CD.
+  #
+  # Declared here rather than applied with kubectl, because the root test-infra Kustomization
+  # re-applies this spec: an imperative suspend is silently reverted on the next reconcile and
+  # both reconcilers end up owning the same objects.
+  #
+  # The kustomization.yaml on this path stays for stages still on Flux; Argo CD renders the
+  # chart in the same directory. Tool detection prefers Chart.yaml, and the Application sets
+  # source.helm explicitly, so the two cannot pick each other's source.
+  suspend: true
   sourceRef:
     kind: GitRepository
     name: test-infra

--- a/flux/prow/charts/prow-plugins.yaml
+++ b/flux/prow/charts/prow-plugins.yaml
@@ -5,6 +5,13 @@ metadata:
   namespace: flux-system
 spec:
   interval: 5m
+  # SUSPENDED: this path is cut over to Argo CD (Application `prow-plugins`). kustomize-controller stops
+  # reconciling, so these objects are managed solely by Argo CD.
+  #
+  # Declared here rather than applied with kubectl, because the root test-infra Kustomization
+  # re-applies this spec: an imperative suspend is silently reverted on the next reconcile and
+  # both reconcilers end up owning the same objects.
+  suspend: true
   sourceRef:
     kind: GitRepository
     name: test-infra

--- a/flux/prow/crds/prowjob_customresourcedefinition.yaml
+++ b/flux/prow/crds/prowjob_customresourcedefinition.yaml
@@ -5,6 +5,22 @@ metadata:
   annotations:
     api-approved.kubernetes.io: https://github.com/kubernetes/test-infra/pull/8669
     controller-gen.kubebuilder.io/version: v0.17.3
+    # THE ONLY LOCAL EDIT TO THIS UPSTREAM FILE. scripts/upgrade-prow.sh regenerates it from
+    # kubernetes/test-infra, so this line has to be re-added after an upgrade or Argo CD stops
+    # being able to apply the CRD at all.
+    #
+    # This manifest is 667 KB. Client-side apply stores the whole thing in
+    # kubectl.kubernetes.io/last-applied-configuration, which the API server rejects:
+    #   metadata.annotations: Too long: may not be more than 262144 bytes
+    # Reproduced outside Argo CD - `kubectl apply --dry-run=server` fails with exactly that,
+    # while `kubectl apply --server-side --dry-run=server` succeeds - so the object is fine and
+    # only the apply mode matters.
+    #
+    # ServerSideApply=true is already set on the Application, but Argo CD applied this resource
+    # client-side regardless, through a manually requested sync, an automated sync, and with
+    # Replace=true. A per-resource sync-option annotation is the documented way to set it on the
+    # object itself, and unlike the Application-level option it travels with the manifest.
+    argocd.argoproj.io/sync-options: ServerSideApply=true
   name: prowjobs.prow.k8s.io
 spec:
   preserveUnknownFields: false

--- a/flux/secrets.yaml
+++ b/flux/secrets.yaml
@@ -19,6 +19,10 @@ spec:
   # driver's ClusterRole and both SecretProviderClasses, so pruning would stop every Prow
   # component and every job pod from obtaining its GitHub credentials.
   prune: false
+  # SUSPENDED: cut over to Argo CD (Application `secrets`). Argo CD can apply the ClusterRole here
+  # only because cluster-scoped-rbac.yaml grants it all seven secrets verbs cluster-wide - see the
+  # block there, including the exit condition, before changing anything on this path.
+  suspend: true
   postBuild:
     substituteFrom:
     - kind: ConfigMap

--- a/prow/plugins/deployments/templates/agent-plugin.yaml
+++ b/prow/plugins/deployments/templates/agent-plugin.yaml
@@ -20,7 +20,7 @@
 #   THIS PATH NEEDED AN RBAC DECISION. rbac.yaml carries a ClusterRole and
 #   ClusterRoleBinding, and Argo CD could neither create those nor hold cluster-wide what
 #   they grant, so escalation prevention would refuse them. The grant was added to
-#   flux/argocd/cluster-scoped-rbac.yaml as a deliberate privilege expansion - read the
+#   bootstrap/argocd-rbac.tf as a deliberate privilege expansion - read the
 #   block there before changing anything here, and note the ordering requirement: those
 #   rules must be LIVE before this Application first syncs, or the sync fails on
 #   escalation with a message that points at the ClusterRole rather than at the missing


### PR DESCRIPTION
Stage 5 of the Flux to Argo CD migration. Follows #1064 and #1066.

## What this does

Suspends every converted path's HelmRelease or Kustomization in git, so Flux stops reconciling objects Argo CD already owns.

**It does not enable `automated` sync — that happened in Stage 4**, where the Applications are rendered with `automated: true` from the start. So the transition is the reverse of how it reads: Stage 4 is where Argo CD started acting, adopting objects under `ServerSideApply=true` while Flux was still reconciling them. This is where Flux stops. The window with both reconcilers live was #1064 to here.

Eight suspends, split across the two Kustomizations that deliver them:

| Delivered by | Suspends |
|---|---|
| `test-infra` (`./flux`) | `prow-crds`, `prow-build-cluster-resources`, `secrets` |
| `prow-charts` (`./flux/prow/charts`) | `prow-config`, `prow-data-plane`, `prow-agent-workflows`, `prow-jobs`, `prow-plugins` |

Suspend rather than delete throughout: deleting a Kustomization is what triggers garbage collection, whereas suspending stops reconciliation and pruning both and reverses by flipping one field.

## Also in this commit

- **`prow-build-cluster-resources` gets `automated`.** Its Application is composed at runtime by the connection Job rather than rendered from the chart, and it had no sync policy, so suspending the Flux Kustomization without this would leave those 13 build-cluster objects reconciled by nothing. Both halves are in this one commit for that reason. The edit reaches the live Application because it is drift on a *tracked* ConfigMap, so Argo CD syncs it, which re-runs the PostSync Job, which applies the updated Application.
- **`ServerSideApply=true` as a per-resource annotation on the ProwJob CRD.** The manifest is 667 KB and client-side apply stores it in `last-applied-configuration`, which the API server rejects at 262144 bytes. The Application-level sync option was not enough — Argo CD applied it client-side anyway through a manual sync, an automated sync, and with `Replace=true`. The annotation travels with the manifest.
- **Connection Job memory limit to 512Mi.** 128Mi was OOMKilled three times, surfacing only as a PostSync hook stuck in `Running`. The script's steps are `kubectl` pipelines, so peak is several concurrent Go binaries, not sequential.
- Comment-only fixes replacing references to `flux/argocd/`, which no longer exists, with `bootstrap/argocd-rbac.tf`.

## Pre-merge state on prod

The runbook's gate for this stage is that every Kustomization delivering a suspend is at current `main`, since a stale one silently swallows the change:

- `test-infra` and `prow-charts` both at `ceb02f5c`, `Ready=True`.
- 24 of 25 Kustomizations at `ceb02f5c`; the exception is `prow-build-cluster-connection`, which cannot render under Flux by design.
- 7 of the 8 suspended paths' Applications are `Synced/Healthy` with `automated`. The 8th is `prow-build-cluster-resources`, which this commit fixes.

## Verification

- `kustomize build ./flux` → 21 objects, 3 suspended; `./flux/prow/charts` → 5 objects, 5 suspended. Eight total, matching the table.
- Both modified Helm charts render; rendered Application carries `automated: {prune: false, selfHeal: false}` and the Job carries a 512Mi limit.
- `terraform validate` passes; no Terraform change in this stage, so **no `terraform apply` needed**.
- `flux/kustomization.yaml` is unchanged from `main`: the staged commit also removed `argocd.yaml` there, which #1065 already did, and dropped `prometheus.yaml`, which must stay until Stage 6.

## Post-merge

Gate is that nothing unsuspended is unhealthy and every Application is automated, then exercise it end to end by triggering a presubmit and confirming it schedules onto the build cluster.

Expect Flux to briefly report a batch of `DependencyNotReady` failures right after merge. That is it re-walking its graph as the revision propagates and it drains in about two minutes.