### PR TITLE
[test-infra] Suspend the eleven paths the cutover missed

### DIFF
--- a/flux/ack/build-cluster/helm-release.yaml
+++ b/flux/ack/build-cluster/helm-release.yaml
@@ -15,6 +15,13 @@ metadata:
   name: ack-build-infra
   namespace: flux-system
 spec:
+  # SUSPENDED: this path is cut over to Argo CD (Application `ack-build-infra`). helm-controller stops
+  # reconciling, so these objects are managed solely by Argo CD.
+  #
+  # Declared here rather than applied with kubectl, because the root test-infra Kustomization
+  # re-applies this spec: an imperative suspend is silently reverted on the next reconcile and
+  # both reconcilers end up owning the same objects.
+  suspend: true
   interval: 60m
   targetNamespace: ack-system
   chart:

--- a/flux/ack/capability/helm-release.yaml
+++ b/flux/ack/capability/helm-release.yaml
@@ -11,6 +11,13 @@ metadata:
   name: ack-capability
   namespace: flux-system
 spec:
+  # SUSPENDED: this path is cut over to Argo CD (Application `ack-capability`). helm-controller stops
+  # reconciling, so these objects are managed solely by Argo CD.
+  #
+  # Declared here rather than applied with kubectl, because the root test-infra Kustomization
+  # re-applies this spec: an imperative suspend is silently reverted on the next reconcile and
+  # both reconcilers end up owning the same objects.
+  suspend: true
   interval: 60m
   targetNamespace: ack-system
   chart:

--- a/flux/ack/capability/role/helm-release.yaml
+++ b/flux/ack/capability/role/helm-release.yaml
@@ -15,6 +15,13 @@ metadata:
   name: ack-capability-role
   namespace: flux-system
 spec:
+  # SUSPENDED: this path is cut over to Argo CD (Application `ack-capability-role`). helm-controller stops
+  # reconciling, so these objects are managed solely by Argo CD.
+  #
+  # Declared here rather than applied with kubectl, because the root test-infra Kustomization
+  # re-applies this spec: an imperative suspend is silently reverted on the next reconcile and
+  # both reconcilers end up owning the same objects.
+  suspend: true
   interval: 60m
   targetNamespace: ack-system
   chart:

--- a/flux/ack/cluster/addons/helm-release.yaml
+++ b/flux/ack/cluster/addons/helm-release.yaml
@@ -8,6 +8,13 @@ metadata:
   name: ack-addons
   namespace: flux-system
 spec:
+  # SUSPENDED: this path is cut over to Argo CD (Application `ack-addons`). helm-controller stops
+  # reconciling, so these objects are managed solely by Argo CD.
+  #
+  # Declared here rather than applied with kubectl, because the root test-infra Kustomization
+  # re-applies this spec: an imperative suspend is silently reverted on the next reconcile and
+  # both reconcilers end up owning the same objects.
+  suspend: true
   interval: 60m
   targetNamespace: ack-system
   chart:

--- a/flux/ack/cluster/addons/roles/helm-release.yaml
+++ b/flux/ack/cluster/addons/roles/helm-release.yaml
@@ -8,6 +8,13 @@ metadata:
   name: ack-addons-roles
   namespace: flux-system
 spec:
+  # SUSPENDED: this path is cut over to Argo CD (Application `ack-addons-roles`). helm-controller stops
+  # reconciling, so these objects are managed solely by Argo CD.
+  #
+  # Declared here rather than applied with kubectl, because the root test-infra Kustomization
+  # re-applies this spec: an imperative suspend is silently reverted on the next reconcile and
+  # both reconcilers end up owning the same objects.
+  suspend: true
   interval: 60m
   targetNamespace: ack-system
   chart:

--- a/flux/ack/cluster/helm-release.yaml
+++ b/flux/ack/cluster/helm-release.yaml
@@ -9,6 +9,13 @@ metadata:
   name: ack-cluster
   namespace: flux-system
 spec:
+  # SUSPENDED: this path is cut over to Argo CD (Application `ack-cluster`). helm-controller stops
+  # reconciling, so these objects are managed solely by Argo CD.
+  #
+  # Declared here rather than applied with kubectl, because the root test-infra Kustomization
+  # re-applies this spec: an imperative suspend is silently reverted on the next reconcile and
+  # both reconcilers end up owning the same objects.
+  suspend: true
   interval: 60m
   targetNamespace: ack-system
   chart:

--- a/flux/ack/cluster/pod-identities/helm-release.yaml
+++ b/flux/ack/cluster/pod-identities/helm-release.yaml
@@ -9,6 +9,13 @@ metadata:
   name: ack-pod-identities
   namespace: flux-system
 spec:
+  # SUSPENDED: this path is cut over to Argo CD (Application `ack-pod-identities`). helm-controller stops
+  # reconciling, so these objects are managed solely by Argo CD.
+  #
+  # Declared here rather than applied with kubectl, because the root test-infra Kustomization
+  # re-applies this spec: an imperative suspend is silently reverted on the next reconcile and
+  # both reconcilers end up owning the same objects.
+  suspend: true
   interval: 60m
   targetNamespace: ack-system
   chart:

--- a/flux/ack/cluster/pod-identities/roles/helm-release.yaml
+++ b/flux/ack/cluster/pod-identities/roles/helm-release.yaml
@@ -9,6 +9,13 @@ metadata:
   name: ack-pod-identity-roles
   namespace: flux-system
 spec:
+  # SUSPENDED: this path is cut over to Argo CD (Application `ack-pod-identity-roles`). helm-controller stops
+  # reconciling, so these objects are managed solely by Argo CD.
+  #
+  # Declared here rather than applied with kubectl, because the root test-infra Kustomization
+  # re-applies this spec: an imperative suspend is silently reverted on the next reconcile and
+  # both reconcilers end up owning the same objects.
+  suspend: true
   interval: 60m
   targetNamespace: ack-system
   chart:

--- a/flux/ack/flux/helm-release.yaml
+++ b/flux/ack/flux/helm-release.yaml
@@ -12,6 +12,13 @@ metadata:
   name: ack-flux
   namespace: flux-system
 spec:
+  # SUSPENDED: this path is cut over to Argo CD (Application `ack-flux`). helm-controller stops
+  # reconciling, so these objects are managed solely by Argo CD.
+  #
+  # Declared here rather than applied with kubectl, because the root test-infra Kustomization
+  # re-applies this spec: an imperative suspend is silently reverted on the next reconcile and
+  # both reconcilers end up owning the same objects.
+  suspend: true
   interval: 60m
   targetNamespace: ack-system
   chart:

--- a/flux/ack/prow/helm-release.yaml
+++ b/flux/ack/prow/helm-release.yaml
@@ -9,6 +9,13 @@ metadata:
   name: ack-prow
   namespace: flux-system
 spec:
+  # SUSPENDED: this path is cut over to Argo CD (Application `ack-prow`). helm-controller stops
+  # reconciling, so these objects are managed solely by Argo CD.
+  #
+  # Declared here rather than applied with kubectl, because the root test-infra Kustomization
+  # re-applies this spec: an imperative suspend is silently reverted on the next reconcile and
+  # both reconcilers end up owning the same objects.
+  suspend: true
   interval: 60m
   targetNamespace: ack-system
   chart:

--- a/flux/prow/mirror/helm-release.yaml
+++ b/flux/prow/mirror/helm-release.yaml
@@ -10,6 +10,13 @@ metadata:
   name: prow-mirror
   namespace: flux-system
 spec:
+  # SUSPENDED: this path is cut over to Argo CD (Application `prow-mirror`). helm-controller stops
+  # reconciling, so these objects are managed solely by Argo CD.
+  #
+  # Declared here rather than applied with kubectl, because the root test-infra Kustomization
+  # re-applies this spec: an imperative suspend is silently reverted on the next reconcile and
+  # both reconcilers end up owning the same objects.
+  suspend: true
   interval: 60m
   targetNamespace: test-pods
   chart:


### PR DESCRIPTION
Follows #1067. **This closes a gap that leaves prod with two reconcilers on eleven paths, so it should go in promptly.**

## What I found

After #1067 merged, the cutover gate is "nothing unsuspended is unhealthy and every Application is automated". Checking it by enumerating both sides — every Flux `HelmRelease`/`Kustomization` and its suspend state, cross-referenced against every automated Application — turned up twelve paths with **both** a live Flux reconciler and an automated Argo CD Application:

```
ack-addons          ack-capability       ack-flux                 ack-prow
ack-addons-roles    ack-capability-role  ack-pod-identities       prow-mirror
ack-build-infra     ack-cluster          ack-pod-identity-roles
```

(The twelfth, `prow-build-cluster-connection`, is fine — its HelmRelease is already suspended.)

This is the state the runbook calls the worst in the migration: `automated` is on while helm-controller is still reconciling the same objects, so both own them. The first symptom on prod was `ack-capability-role` reporting `OutOfSync` on an adopted ACK `Role`, where the two appliers resolve controller-written defaults (`path`, `maxSessionDuration`) differently.

## Why the sequence missed it

These eleven are exactly the suspends deferred out of the chart-conversion stage, which kept only `prow-build-cluster-connection` — the one path whose chart cannot render under Flux at all. The plan was for the cutover to carry the remaining eleven. It does not: #1067 suspends eight *different* paths, all under `prow/`.

So no individual stage is wrong, which is why this survived review. The gap is in the hand-off between two stages, and only shows up if you enumerate the live state rather than read either stage's diff.

## The change

`suspend: true` on eleven HelmReleases, same comment shape as the eight in #1067.

Declared in git rather than applied with `kubectl`, because the root `test-infra` Kustomization re-applies these specs — an imperative suspend is silently reverted on the next reconcile, which is the trap the existing comments already warn about.

Suspending the HelmRelease is sufficient, and the Kustomization above each one stays live on purpose: every one of these directories contains nothing but `helm-release.yaml` and `kustomization.yaml`, so the Kustomization's only job is to apply the HelmRelease — which is also the mechanism that makes the suspend stick.

## Verification

- All 11 files parse; each has `suspend: true` and a matching **automated** Application.
- Suspends in git go from 9 to 20.
- `kustomize build ./flux` still yields 21 objects.
- Afterwards the only unsuspended HelmReleases are the three that must outlive this: `flux2` (Flux itself, Stage 7), `prometheus` (Stage 6), `prow-build-cluster-kubeconfig` (does not outlive Flux). None has an Application.
- No Terraform change, so no `terraform apply`.

## Post-merge

Re-run the both-reconcilers enumeration and confirm it comes back empty, then check the ACK-adopted resources settle — in particular that `ack-capability-role` returns to `Synced`.