### PR TITLE
[test-infra] Move the build-cluster connection chart out of flux-system (stage 7/8)

### DIFF
--- a/argocd/applications/values.yaml
+++ b/argocd/applications/values.yaml
@@ -177,12 +177,27 @@ applications:
   ##############################################################################
 
   prow-build-cluster-connection:
-    # flux-system, not ack-system: the Job writes build-cluster-kubeconfig there and Prow's
-    # crier, deck, sinker and prow-controller-manager mount it from there. Unlike
-    # prow-build-cluster-kubeconfig this path survives Flux (D16), which is why it has an
-    # Application and that one does not.
+    # ack-system, not flux-system, and the move is the point rather than cosmetic. NOTHING in
+    # this chart is Flux wiring: the Job assembles the kubeconfig Prow mounts (a Prow
+    # requirement under either reconciler), registers the build cluster as an Argo CD spoke,
+    # authorises it in the AppProject and applies its Application - the last three exist only
+    # because of Argo CD. Flux's own route to that cluster was kustomize-controller
+    # remote-applying through build-cluster-flux-kubeconfig, a different ConfigMap from the
+    # prow-build-cluster-kubeconfig chart, which dies with Flux.
+    #
+    # It started in flux-system only because that is where it was written, and staying there
+    # would have left a namespace named after a reconciler that no longer exists holding the
+    # chart that replaced it. ack-system is where the Cluster CR the Job reads already lives,
+    # and it is already in argocd_hub_namespaces, so the admin RoleBinding covers creating the
+    # Roles without a new grant.
+    #
+    # The chart uses .Release.Namespace for its own objects, so stages still on Flux keep
+    # rendering into flux-system from their HelmRelease's targetNamespace - this move is
+    # hub-only. Its ack-system, prow and argocd references stay literal, because those name
+    # where the TARGET objects live: the Cluster CR, the kubeconfig Prow mounts, and the
+    # registration Secret plus AppProject plus Application.
     path: flux/prow/charts/prow-build-cluster-connection
-    targetNamespace: flux-system
+    targetNamespace: ack-system
     wave: 3
 
     # The last three exist so the Job can compose the prow-build-cluster-resources

--- a/flux/prow/charts/prow-build-cluster-connection/templates/application.yaml
+++ b/flux/prow/charts/prow-build-cluster-connection/templates/application.yaml
@@ -38,7 +38,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: build-cluster-resources-application
-  namespace: flux-system
+  namespace: {{ .Release.Namespace }}
 data:
   application.yaml: |
     apiVersion: argoproj.io/v1alpha1

--- a/flux/prow/charts/prow-build-cluster-connection/templates/job.yaml
+++ b/flux/prow/charts/prow-build-cluster-connection/templates/job.yaml
@@ -1,19 +1,18 @@
 {{- $prowImagesRepoUri := required "prowImagesRepoUri is required" .Values.prowImagesRepoUri }}
 {{- $stackName := required "stackName is required" .Values.stackName }}
-# Surfaces the build cluster's endpoint + CA into the build-cluster-connection
-# ConfigMap in flux-system, read from the build-cluster Cluster CR's status.
+# Reads the build cluster's endpoint, CA and ARN from the build-cluster Cluster CR's
+# status, then assembles the kubeconfig Prow mounts, registers the cluster as an Argo CD
+# spoke, authorises it in the AppProject and applies its Application.
 #
-# Why a Job (not a static ConfigMap): the build cluster is created by ACK, not
-# Terraform, so its endpoint/CA aren't in self-managed-vars at bootstrap. Reading
-# the CR status means a cluster re-creation (the only event that changes these) is
-# picked up automatically. prow-charts then substitutes BUILD_CLUSTER_ENDPOINT /
-# BUILD_CLUSTER_CA from this ConfigMap into the components' build-cluster
-# kubeconfig. Runs each reconcile (Flux force-replaces the immutable Job).
+# Why a Job (not static manifests): the build cluster is created by ACK, not Terraform, so
+# none of these values are in self-managed-vars at bootstrap. Reading the CR status means a
+# cluster re-creation - the only event that changes them - is picked up automatically.
+# Runs on every reconcile as a Helm hook.
 apiVersion: batch/v1
 kind: Job
 metadata:
   name: build-cluster-connection
-  namespace: flux-system
+  namespace: {{ .Release.Namespace }}
   annotations:
     # Run as a Helm hook, not as a tracked release object.
     #
@@ -61,13 +60,6 @@ spec:
 
           echo "  endpoint: $EP"
           echo "  ca: ${CA:0:40}...(truncated)"
-
-          kubectl create configmap build-cluster-connection -n flux-system \
-            --from-literal=BUILD_CLUSTER_ENDPOINT="$EP" \
-            --from-literal=BUILD_CLUSTER_CA="$CA" \
-            --dry-run=client -o yaml | kubectl apply -f -
-
-          echo "build-cluster-connection ConfigMap updated."
 
           # Assemble the kubeconfig the four components mount, here rather than in
           # the prow chart.
@@ -217,7 +209,7 @@ spec:
             #
             # This script's steps are kubectl PIPELINES - `kubectl create ... | kubectl label
             # --local | kubectl apply -f -` runs three Go binaries concurrently, each tens of MB,
-            # and the script now has five such steps rather than three. Peak is concurrent, not
+            # and the script has four such steps. Peak is concurrent, not
             # sequential, so the ceiling has to clear several kubectl processes at once.
             memory: "512Mi"
         volumeMounts:

--- a/flux/prow/charts/prow-build-cluster-connection/templates/rbac.yaml
+++ b/flux/prow/charts/prow-build-cluster-connection/templates/rbac.yaml
@@ -1,23 +1,38 @@
 # RBAC for the build-cluster-connection Job (job.yaml).
 #
-# The Job reads the build cluster's connection details (API server endpoint +
-# cluster CA) from the ACK Cluster CR's status and writes them into the
-# build-cluster-connection ConfigMap, which prow-charts substitutes into the
-# four components' build-cluster kubeconfig (server / certificate-authority-data).
+# The Job reads the build cluster's endpoint, CA and ARN from the ACK Cluster CR's status
+# and does three things with them: assembles the build-cluster-kubeconfig ConfigMap in
+# `prow` that the four components mount, registers the cluster as an Argo CD spoke, and
+# applies the prow-build-cluster-resources Application.
 #
-# It also assembles the finished build-cluster-kubeconfig ConfigMap in the prow
-# namespace, which the four components mount directly. That removes the render-time
-# substitution step, which Argo CD cannot perform.
+# NOTHING HERE IS FLUX WIRING, which is worth stating because the chart began life in
+# flux-system and that is easy to misread. Flux's own route to the build cluster was
+# kustomize-controller remote-applying through build-cluster-flux-kubeconfig, a different
+# ConfigMap from a different chart (prow-build-cluster-kubeconfig), and it dies with Flux.
+# Of the three things above, two exist only BECAUSE of Argo CD, and the kubeconfig is a
+# Prow requirement under either reconciler.
 #
-# Least privilege: read the one Cluster CR in ack-system, write one ConfigMap in
-# flux-system and one in prow. No AWS/IAM credentials needed — the endpoint + CA
-# live in the CR status (ACK keeps them synced), so this is pure in-cluster RBAC.
+# The chart previously also wrote a build-cluster-connection ConfigMap in its own
+# namespace, for prow-charts to substitute BUILD_CLUSTER_ENDPOINT / BUILD_CLUSTER_CA from
+# at render time. Argo CD cannot substitute, so the Job assembles the finished kubeconfig
+# instead and that ConfigMap has no reader - `flux/prow.yaml` records the substitution being
+# removed. It and its Role are gone.
+#
+# The home namespace is .Release.Namespace, not a literal: Argo CD places this in
+# ack-system, next to the Cluster CR the Job reads, while stages still on Flux get
+# flux-system from their HelmRelease's targetNamespace. The ack-system, prow and argocd
+# references below stay literal - those are where the TARGET objects live, not where this
+# chart is installed.
+#
+# Least privilege: read the one Cluster CR in ack-system, write one ConfigMap in prow, and
+# in argocd write the registration Secret, patch the AppProject and apply one Application.
+# No AWS/IAM credentials - the values live in the CR status.
 ---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: build-cluster-connection
-  namespace: flux-system
+  namespace: {{ .Release.Namespace }}
 ---
 # Read the build-cluster Cluster CR's status (endpoint + certificateAuthority).
 apiVersion: rbac.authorization.k8s.io/v1
@@ -42,32 +57,7 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: build-cluster-connection
-  namespace: flux-system
----
-# Write the build-cluster-connection ConfigMap in flux-system.
-apiVersion: rbac.authorization.k8s.io/v1
-kind: Role
-metadata:
-  name: build-cluster-connection-write
-  namespace: flux-system
-rules:
-- apiGroups: [""]
-  resources: ["configmaps"]
-  verbs: ["get", "create", "update", "patch"]
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
-  name: build-cluster-connection-write
-  namespace: flux-system
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: Role
-  name: build-cluster-connection-write
-subjects:
-- kind: ServiceAccount
-  name: build-cluster-connection
-  namespace: flux-system
+  namespace: {{ .Release.Namespace }}
 ---
 # Write the assembled kubeconfig ConfigMap that crier, deck, sinker and
 # prow-controller-manager mount. Scoped to configmaps in prow only.
@@ -93,7 +83,7 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: build-cluster-connection
-  namespace: flux-system
+  namespace: {{ .Release.Namespace }}
 ---
 # Register the build cluster as an Argo CD spoke by writing a labelled cluster Secret in
 # the argocd namespace. Scoped to secrets in argocd only.
@@ -151,4 +141,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: build-cluster-connection
-  namespace: flux-system
+  namespace: {{ .Release.Namespace }}


### PR DESCRIPTION
Stage 7 of the Flux to Argo CD migration, first of two PRs. This one moves the build-cluster connection chart out of `flux-system` so the namespace can be deleted; the Flux removal itself follows once this has synced.

## What this does

The chart's own objects switch from a literal `flux-system` to `.Release.Namespace`, which puts them in `ack-system` next to the ACK `Cluster` CR the Job reads. Nothing in the chart is Flux wiring — the Job assembles the kubeconfig Prow mounts, registers the build cluster as an Argo CD spoke, authorises it in the AppProject, and applies its Application. Flux's own route to that cluster was kustomize-controller remote-applying through `build-cluster-flux-kubeconfig`, a different ConfigMap from a different chart.

Also drops the `build-cluster-connection` ConfigMap and its write Role. That ConfigMap existed for `prow-charts` to substitute `BUILD_CLUSTER_ENDPOINT` and `BUILD_CLUSTER_CA` at render time; Argo CD cannot substitute, so the Job assembles the finished kubeconfig instead and the ConfigMap has no reader.

The `ack-system`, `prow` and `argocd` references stay literal, because those name where the target objects live rather than where the chart is installed.

## Prow is unaffected

The kubeconfig Prow's four components mount is `build-cluster-kubeconfig` in the `prow` namespace, written by the Job with an explicit `-n prow`. Confirmed against the live cluster: the ConfigMap is in `prow`, and `crier`, `deck`, `sinker` and `prow-controller-manager` all mount it from there. The comment this PR replaces claimed it lived in `flux-system`, which is what made the move look riskier than it is.

## Cleanup after sync

Moving a namespace is a recreate rather than an adoption, so the six objects in `flux-system` are left behind: the ServiceAccount, the write Role and RoleBinding, the Job, and the `build-cluster-connection` and `build-cluster-resources-application` ConfigMaps. Deleting the `flux-system` namespace in the next PR collects them, so no separate sweep is needed.

## Verification

- Chart renders 9 objects with `--namespace ack-system`: ServiceAccount, `build-cluster-resources-application` ConfigMap, read Role and RoleBinding and the Job in `ack-system`, plus the kubeconfig pair in `prow` and the registrar pair in `argocd`.
- App-of-apps still renders 20 Applications.
- `terraform validate` passes. No Terraform change, so no `terraform apply`.

## Before merging the Flux removal

Let this sync and confirm `prow-build-cluster-connection` is Healthy with its objects in `ack-system`.
