### PR TITLE
[test-infra] Use computed_fields for the AppProject spoke destination

### DIFF
--- a/bootstrap/argocd-access.tf
+++ b/bootstrap/argocd-access.tf
@@ -156,9 +156,6 @@ resource "kubernetes_manifest" "argocd_project" {
         "https://github.com/${var.test_infra_org}/${var.test_infra_repo}",
       ]
 
-      # Hub only. The build cluster is added as a destination in Phase 4, when it is
-      # registered as a spoke - not before. A destination for an unregistered cluster
-      # would be misleading.
       # HUB ONLY. Spoke destinations are added at runtime, not here.
       #
       # A destination naming the build cluster is keyed to a cluster ACK owns, and
@@ -166,10 +163,8 @@ resource "kubernetes_manifest" "argocd_project" {
       # registration Secret is written by the prow-build-cluster-connection Job rather
       # than by Terraform. Terraform authorises only the cluster it owns and bootstraps.
       #
-      # The Job appends the spoke destination, which is why destinations is in
-      # ignore_changes below. Without that, the next terraform apply would silently
-      # revert the addition and Applications targeting the build cluster would start
-      # being rejected.
+      # The Job appends the spoke destination, which is why spec.destinations is in
+      # computed_fields below. Read that block before changing this list.
       destinations = [
         {
           server    = aws_eks_cluster.this.arn
@@ -188,20 +183,40 @@ resource "kubernetes_manifest" "argocd_project" {
 
   depends_on = [awscc_eks_capability.argocd]
 
-  lifecycle {
-    # Spoke destinations are appended at runtime by the prow-build-cluster-connection
-    # Job, because a destination naming the build cluster is keyed to a cluster ACK owns
-    # and Terraform must not hold that (D13).
-    #
-    # Without this, every terraform apply would rewrite destinations back to the hub-only
-    # list. Nothing would error - the Job re-adds it on its next run - but in between,
-    # Applications targeting the build cluster are REJECTED rather than failing at sync,
-    # so the symptom appears at a distance from the apply that caused it.
-    #
-    # Scoped to destinations alone. sourceRepos, sourceNamespaces and
-    # clusterResourceWhitelist stay Terraform-managed and drift-corrected.
-    ignore_changes = [manifest.spec.destinations]
-  }
+  # Spoke destinations are appended at runtime by the prow-build-cluster-connection Job,
+  # because a destination naming the build cluster is keyed to a cluster ACK owns and
+  # Terraform must not hold that (D13). This is what stops Terraform reconciling the
+  # addition away.
+  #
+  # THIS WAS `lifecycle { ignore_changes = [manifest.spec.destinations] }` AND THAT DOES
+  # NOT WORK. ignore_changes substitutes the prior STATE value for the CONFIG value of an
+  # argument. Config and state both say hub-only here, so there is nothing to ignore - the
+  # divergence is in `object`, which is computed, and ignore_changes cannot reach a computed
+  # attribute. The provider then plans `manifest` against `object` and applies `manifest`
+  # through server-side apply, and spec.destinations is an atomic list with no merge key, so
+  # applying a one-entry list means "the list is exactly this one entry".
+  #
+  # Which way that breaks depends on who wrote the field last, because a JSON patch takes
+  # ownership from the applying manager:
+  #
+  #   Job last       -> apply FAILS: conflict with "kubectl-patch" on .spec.destinations,
+  #                     and kubernetes_manifest.argocd_root depends on this resource, so
+  #                     every later apply fails too - including unrelated work.
+  #   Terraform last -> apply SUCCEEDS and absorbs the spoke ARN into `manifest` in state,
+  #                     which is the D13 coupling this list exists to avoid, arrived at
+  #                     silently. Staging is in this state.
+  #
+  # computed_fields is the mechanism the provider documents for a field written by someone
+  # else: "manifest fields whose values can be altered by the API server during 'apply'".
+  # Verified against a throwaway AppProject: declare the hub destination, mark the field
+  # computed, let an external JSON patch take ownership and append a spoke, re-plan ->
+  # "No changes", and `manifest` stays hub-only so the ARN never enters state.
+  #
+  # The two metadata entries are the provider's DEFAULT and must be restated - supplying
+  # computed_fields replaces the default list rather than appending to it, and dropping them
+  # reintroduces churn from the annotations Argo CD and ACK write. sourceRepos,
+  # sourceNamespaces and clusterResourceWhitelist stay Terraform-managed and drift-corrected.
+  computed_fields = ["metadata.annotations", "metadata.labels", "spec.destinations"]
 }
 
 ################################################################################


### PR DESCRIPTION
Unblocks `terraform apply`, which has been failing since #1071 on a field-manager conflict.

## The problem

`kubernetes_manifest.argocd_project` declares the hub destination only, because a destination naming the build cluster is keyed to a cluster ACK owns and Terraform must not hold that (D13). The `prow-build-cluster-connection` Job appends the spoke destination at runtime instead.

The resource carried `lifecycle { ignore_changes = [manifest.spec.destinations] }` to stop Terraform reconciling that addition away. **That does not work.** `ignore_changes` substitutes the prior *state* value for the *config* value of an argument, and here config and state both say hub-only, so there is nothing to ignore. The divergence lives in `object`, which is `computed`, and `ignore_changes` cannot reach a computed attribute. The provider then plans `manifest` against `object` and applies `manifest` via server-side apply — and `spec.destinations` is an atomic list with no merge key, so applying a one-entry list means "the list is exactly this one entry".

Which way it breaks depends on who wrote the field last, because a JSON patch takes ownership from the applying manager:

| last writer | next `terraform apply` |
|---|---|
| the Job | fails: `conflict with "kubectl-patch" ... .spec.destinations`. `kubernetes_manifest.argocd_root` depends on this resource, so every later apply fails too, including unrelated work. This is prod today. |
| Terraform | succeeds, and absorbs the spoke ARN into `manifest` in state — the D13 coupling this list exists to avoid, arrived at silently. This is staging today. |

## The fix

`computed_fields` is the mechanism the provider documents for a field written by someone else: "list of manifest fields whose values can be altered by the API server during 'apply'".

```hcl
computed_fields = ["metadata.annotations", "metadata.labels", "spec.destinations"]
```

The two `metadata.*` entries are the provider's default and must be restated, because supplying `computed_fields` replaces the default list rather than appending to it; dropping them would reintroduce churn from the annotations Argo CD and ACK write. `sourceRepos`, `sourceNamespaces` and `clusterResourceWhitelist` stay Terraform-managed and drift-corrected.

## Verification

Tested on throwaway AppProjects rather than reasoned about, in both accounts.

1. Applied a probe mirroring this resource, then ran the Job's exact verb — `kubectl patch appproject --type=json` appending a spoke. `managedFields` confirms ownership of `destinations` moves from `Terraform`/`Apply` to `kubectl-patch`/`Update`, reproducing prod's condition.
2. `terraform plan` against that state: `No changes. Your infrastructure matches the configuration.`
3. Then the case that matters here, since this PR's own apply re-applies the manifest: changed an unrelated field to force a genuine re-apply while `kubectl-patch` owned `destinations`. The apply **succeeded**, the changed field took effect, and the externally-added destination **survived**. So `computed_fields` excludes the field from the SSA payload, not merely from the diff, and no `force_conflicts` is needed.
4. `manifest` stays hub-only in state, so the spoke ARN never enters Terraform's state — strictly better than staging's current position.
5. Both probes destroyed; the real `test-infra` AppProject was never touched and still holds both destinations.

`terraform plan` against prod with this change is `0 to add, 2 to change, 0 to destroy`: recording `computed_fields` on the project, and removing the now-dead `ghcrPtcSecretArn` from the root Application's values — the destinations diff is gone.

## Staging

Staging needs the same change plus one apply, to drop the absorbed ARN from its state. Being handled separately.
