### PR TITLE
[test-infra] Drop the reference to the deleted nodepool swap script

### DIFF
--- a/flux/ack/charts/ack-build-infra/templates/infra/cluster.yaml
+++ b/flux/ack/charts/ack-build-infra/templates/infra/cluster.yaml
@@ -36,9 +36,12 @@ spec:
   computeConfig:
     # Auto Mode enabled, but NO built-in NodePools. An empty nodePools list keeps
     # EKS from provisioning the general-purpose/system pools (and their small
-    # instances that hit the ENI pod-density limit) — matching the control-plane
-    # cluster's end state (the ack-cluster chart's nodepool.yaml), which deletes
-    # general-purpose post-create via bootstrap/scripts/swap-nodepool.sh.
+    # instances that hit the ENI pod-density limit).
+    #
+    # The hub cluster does NOT do this — it keeps general-purpose (see
+    # bootstrap/cluster.tf). So this file is the only worked example of running
+    # with nodePools: [], which makes it the reference for ever taking the hub
+    # the same way. What that costs is spelled out below.
     #
     # Because no built-in pool is enabled, EKS does NOT auto-provision the managed
     # `default` NodeClass or the node-role AccessEntry. Both are supplied by the


### PR DESCRIPTION
Comment-only follow-up to #1073.

That PR removed `null_resource.swap_nodepool` and `bootstrap/scripts/swap-nodepool.sh`, but the build cluster's `computeConfig` comment still explained its empty `nodePools` list by saying it matched the hub's end state, "which deletes general-purpose post-create via `bootstrap/scripts/swap-nodepool.sh`". That path no longer exists, and the hub no longer behaves that way — it keeps `general-purpose`, since the swap was never durable against the EKS control plane.

The comment now says what is true: the hub keeps `general-purpose`, so this file is the only worked example of running with `nodePools: []`, which makes it the reference if the hub is ever taken the same way.

The text is taken from the staging branch, where it was written alongside the swap removal but landed in a commit the stage-8 cherry-pick did not include — that commit was otherwise docs-only, so the hunk was missed.

After this, no reference to `swap-nodepool` or `swap_nodepool` remains anywhere in the repo.