### PR TITLE
[test-infra] Drop references to the unmerged migration doc and trim comments

### DIFF
--- a/argocd/applications/templates/application.yaml
+++ b/argocd/applications/templates/application.yaml
@@ -48,7 +48,7 @@ fails at pull time. All are cheaper to catch here than in a cluster.
 
 {{- range $name, $app := $root.Values.applications }}
 {{- if kindIs "invalid" $app.wave }}
-  {{- fail (printf "application %q has no wave. Waves are derived from the dependsOn graph, not optional - see docs/argocd-migration.md." $name) }}
+  {{- fail (printf "application %q has no wave. Waves order the rollout and are not optional." $name) }}
 {{- end }}
 {{- $params := concat
       (default (list) $app.values)

--- a/argocd/applications/values.yaml
+++ b/argocd/applications/values.yaml
@@ -1,23 +1,19 @@
 ################################################################################
 # INPUTS TERRAFORM SUPPLIES.
 #
-# All of these arrive as ONE helm.values string on the root Application, not as
-# parameters. Parameters are --set, and --set reads `.` as a path separator and `,` as a
-# list separator, so threading 17 values through a root chart into 19 children as
-# parameters multiplies every escaping hazard the migration already hit. A single
-# yamlencode blob has none of them.
+# These arrive as ONE helm.values string on the root Application, not as parameters.
+# Parameters are --set, which reads `.` as a path separator and `,` as a list separator; a
+# single yamlencode blob has none of those hazards.
 #
 # No usable defaults on purpose. A blank cluster ARN does not fail, it produces an
 # Application the AppProject rejects, and a blank branch silently renders the wrong
-# revision. templates/application.yaml fails the render instead - see the guards there.
+# revision. templates/application.yaml fails the render instead.
 ################################################################################
 
-# The AppProject. Terraform owns it (bootstrap/argocd-access.tf) because it authorises
-# the repo and the destinations, and children reference it by name.
+# The AppProject. Terraform owns it (bootstrap/argocd-access.tf); children reference it by
+# name.
 project: ""
 
-# Repo coordinates. Terraform already uses these for the root's own source and for the
-# AppProject's sourceRepos, so children get the same data by the same route.
 repoURL: ""
 targetRevision: ""
 
@@ -25,65 +21,46 @@ targetRevision: ""
 # not match the AppProject destination and the Application is REJECTED rather than failing
 # at sync, so the symptom appears far from the cause.
 #
-# Always the hub. The one Application whose destination is the build cluster is composed
-# at runtime by the prow-build-cluster-connection Job, because Terraform must hold nothing
-# keyed to a cluster ACK owns (D13). It is not in this chart and must not be added.
+# Always the hub. The one Application whose destination is the build cluster is composed at
+# runtime by the prow-build-cluster-connection Job, because nothing keyed to a cluster ACK
+# owns may be declared here.
 destinationServer: ""
 
-# Where the Applications live. Must be in the AppProject's sourceNamespaces.
+# Must be in the AppProject's sourceNamespaces.
 argocdNamespace: argocd
 
-# The per-environment values every child draws parameters from, keyed by chart value name.
-# Terraform composes this from the same locals as self-managed-vars, so the two cannot
-# drift while both exist.
+# Per-environment values every child draws parameters from, keyed by chart value name.
 #
 # Every entry must be a STRING. A 12-digit AWS account id written unquoted is read as a
-# float, and printf %s then yields %!s(float64=8.6987147623e+10) - a syntactically valid
-# image reference that fails at pull time rather than at render time. Guarded.
+# float and renders as %!s(float64=...) - a syntactically valid image reference that fails
+# at pull time rather than at render time. Guarded in the template.
 chartValues: {}
 
-# helm.values for prow-build-cluster-connection, composed by Terraform with yamlencode
-# rather than by this chart.
-#
-# The chart cannot compose it: the content is prow/jobs/test_config.yaml, and .Files.Get
-# is chart-rooted, so a chart under argocd/ cannot read a file under prow/. Terraform
-# reads it with file() and passes the yamlencode output verbatim, which also keeps the
-# rendered string byte-identical to what the Application already carries.
+# helm.values for prow-build-cluster-connection, composed by Terraform because this chart
+# cannot: the content is prow/jobs/test_config.yaml and .Files.Get is chart-rooted, so a
+# chart under argocd/ cannot read a file under prow/.
 testConfigValues: ""
 
 ################################################################################
-# THE APPLICATIONS.
+# THE APPLICATIONS. Structure only - paths, namespaces, parameters, sync behaviour.
 #
-# Structure only - paths, namespaces, which parameters each chart needs, sync behaviour.
-# All git-authored, which is why it belongs here and not in HCL: the `prow-mirror` rule,
-# applied once more at the level above the charts.
-#
-# `wave` is the Argo CD sync wave. It is DERIVED from Flux's dependsOn graph rather than
-# chosen, plus three edges Flux omitted - see docs/argocd-migration.md for the derivation
-# and the evidence for each added edge. A node's wave is one deeper than its deepest
-# dependency, not its shallowest, so nothing can sync ahead of a transitive dependency it
-# shares no direct edge with.
+# `wave` is the Argo CD sync wave, derived from the dependency graph rather than chosen. A
+# node's wave is one deeper than its DEEPEST dependency, not its shallowest, so nothing can
+# sync ahead of a transitive dependency it shares no direct edge with.
 #
 # Waves matter only on a bootstrap into an empty cluster. In a converged cluster every
 # Application is already Synced and the ordering is inert.
 ################################################################################
 applications:
 
-  # WAVE 0, and it has to be first: the prow and test-pods Namespaces and the five
+  # WAVE 0, and it has to be first: the prow and test-pods Namespaces plus the five
   # ServiceAccounts every PodIdentityAssociation binds to.
   #
-  # This path exists because the conversion left a hole. Flux applied prow-namespaces.yaml
-  # directly from flux/ack/cluster/pod-identities/, alongside the chart rather than inside
-  # it, because no chart may own a Namespace - a Helm uninstall or rollback targets the
-  # namespace and cascades to everything in it. So the ack-pod-identities Application, which
-  # points at the chart, never covered these seven objects: they survived only because prune
-  # is disabled on the Flux side, and a fresh bootstrap would not have created them at all.
-  #
-  # Everything targeting prow or test-pods therefore depends on this, not on
-  # ack-pod-identities as the wave derivation originally recorded. With
-  # CreateNamespace=false everywhere, a path that syncs first fails on a missing namespace.
-  # The later waves are left as they are: they were derived against ack-pod-identities and
-  # remain a correct, if conservative, ordering now that this sits ahead of all of them.
+  # These have their own path because no chart may own a Namespace - a Helm uninstall or
+  # rollback would target it and cascade to everything inside - so the ack-pod-identities
+  # chart deliberately excludes them. Everything targeting prow or test-pods depends on
+  # this: with CreateNamespace=false everywhere, a path that syncs first fails on a missing
+  # namespace.
   #
   # A plain kustomize directory, no tokens, so no values and no helm block.
   prow-namespaces:
@@ -93,9 +70,9 @@ applications:
     automated: true
 
   ##############################################################################
-  # WAVE 0-3: the ACK layer. Order here is the dependsOn chain Flux encodes, which exists
-  # because these paths create the controllers that reconcile each other's CRs - a CR
-  # applied before its controller sits unreconciled with no error to read.
+  # WAVE 0-3: the ACK layer. This order exists because these paths create the controllers
+  # that reconcile each other's CRs - a CR applied before its controller sits unreconciled
+  # with no error to read.
   ##############################################################################
 
   ack-capability-role:
@@ -154,10 +131,6 @@ applications:
     values: [accountId, stackName]
     automated: true
 
-  # Creates the prow and test-pods namespaces
-  # (flux/ack/cluster/pod-identities/prow-namespaces.yaml), which is why every path
-  # targeting either one sits in a later wave. With CreateNamespace=false everywhere, a
-  # path that syncs first fails on a missing namespace rather than creating it.
   ack-pod-identities:
     path: flux/ack/charts/ack-pod-identities
     targetNamespace: ack-system
@@ -170,98 +143,71 @@ applications:
   ##############################################################################
 
   prow-build-cluster-connection:
-    # ack-system, not flux-system, and the move is the point rather than cosmetic. NOTHING in
-    # this chart is Flux wiring: the Job assembles the kubeconfig Prow mounts (a Prow
-    # requirement under either reconciler), registers the build cluster as an Argo CD spoke,
-    # authorises it in the AppProject and applies its Application - the last three exist only
-    # because of Argo CD. Flux's own route to that cluster was kustomize-controller
-    # remote-applying through build-cluster-flux-kubeconfig, a different ConfigMap from the
-    # prow-build-cluster-kubeconfig chart, deleted with Flux.
+    # ack-system because that is where the Cluster CR the Job reads lives, and it is already
+    # in argocd_hub_namespaces so the admin RoleBinding covers creating the Roles without a
+    # new grant. Nothing in this chart is Flux wiring: the Job assembles the kubeconfig Prow
+    # mounts, registers the build cluster as an Argo CD spoke, authorises it in the
+    # AppProject and applies its Application.
     #
-    # It started in flux-system only because that is where it was written, and staying there
-    # would have left a namespace named after a reconciler that no longer exists holding the
-    # chart that replaced it. ack-system is where the Cluster CR the Job reads already lives,
-    # and it is already in argocd_hub_namespaces, so the admin RoleBinding covers creating the
-    # Roles without a new grant.
-    #
-    # The chart uses .Release.Namespace for its own objects rather than a literal, which is
-    # what made this move possible without editing every template; environments still on Flux
-    # render into flux-system from their HelmRelease's targetNamespace. Its ack-system, prow
-    # and argocd references stay literal, because those name
-    # where the TARGET objects live: the Cluster CR, the kubeconfig Prow mounts, and the
-    # registration Secret plus AppProject plus Application.
+    # The chart uses .Release.Namespace for its own objects rather than a literal. Its
+    # ack-system, prow and argocd references stay literal, because those name where the
+    # TARGET objects live: the Cluster CR, the kubeconfig Prow mounts, and the registration
+    # Secret plus AppProject plus Application.
     path: flux/prow/charts/prow-build-cluster-connection
     targetNamespace: ack-system
     wave: 3
 
-    # The last three exist so the Job can compose the prow-build-cluster-resources
-    # Application, whose destination is the build cluster and which Terraform therefore
-    # must not declare (D13). The Job supplies the one field Terraform cannot know - the
-    # cluster ARN, read from the CR status - and the chart supplies the rest.
+    # The last three let the Job compose the prow-build-cluster-resources Application. The
+    # Job supplies the one field nothing here can know - the cluster ARN, from the CR status.
     values: [prowImagesRepoUri, stackName, testInfraOrg, testInfraRepo, testInfraBranch]
 
     # The content of prow/jobs/test_config.yaml, so the build cluster's test-config
-    # ConfigMap comes from the same file the hub's does. It travels as a value because the
-    # target chart cannot read it: the directory it replaced used a `../../../`
-    # configMapGenerator reference, which only kustomize-controller permits, and Helm's
-    # .Files.Get is chart-rooted. Relocating the file is not an option - prow/jobs/ and
-    # that chart share only the repo root, so "relocating" means duplicating.
-    #
-    # A values string, NOT a parameter: --set would read the file's `.` and `,` as path and
-    # list separators.
+    # ConfigMap comes from the same file the hub's does. A values string, NOT a parameter:
+    # --set would read the file's `.` and `,` as path and list separators.
     valuesFromTerraform: true
 
-    # The only paths with selfHeal on are this one and prow-jobs, and here it is
-    # deliberate. The Job is a Helm post-install/post-upgrade hook, which Argo CD maps to
-    # PostSync and runs whenever a sync has work to do - so making live drift a sync
-    # trigger is also what gives the Job a re-run trigger. Verified: deleting one Role and
-    # the Job caused Argo CD to restore the Role and re-run the hook, rebuilding
-    # build-cluster-kubeconfig byte-identically.
+    # selfHeal is deliberate here, and one of only two paths that set it. The Job is a Helm
+    # post-install/post-upgrade hook, which Argo CD maps to PostSync and runs whenever a sync
+    # has work to do - so making live drift a sync trigger is also what gives the Job a
+    # re-run trigger.
     #
-    # Safe here in a way it is not on the ACK paths: this chart owns only in-cluster RBAC
-    # and a Job. There is no AWS resource behind any of it, so Argo CD reasserting desired
-    # state cannot fight ACK or overwrite someone mid-diagnosis of AWS state.
+    # Safe here in a way it is not on the ACK paths: this chart owns only in-cluster RBAC and
+    # a Job. No AWS resource sits behind any of it, so reasserting desired state cannot fight
+    # ACK or overwrite someone mid-diagnosis.
     selfHeal: true
     automated: true
 
   prow-mirror:
-    # Runs Job/prow-mirror-images, which populates the repo prowImagesRepoUri points at.
-    # Anything that PULLS from that repo depends on this, which is the second edge Flux
-    # omitted - see prow-jobs and prow-plugins.
+    # Runs Job/prow-mirror-images, which populates the repo prowImagesRepoUri points at, so
+    # anything that PULLS from that repo depends on this - see prow-jobs and prow-plugins.
     path: flux/prow/charts/prow-mirror
     targetNamespace: test-pods
     wave: 4
     # prowVersion, toolsVersion and prowPatchRevision are deliberately absent: static
-    # git-authored strings, so they live as defaults in the chart's values.yaml rather than
-    # as per-environment parameters Terraform supplies.
+    # git-authored strings, so chart defaults rather than per-environment parameters.
     values: [accountId, region]
     automated: true
 
   prow-crds:
     # One CustomResourceDefinition, cluster-scoped, so targetNamespace is only a default.
+    # bootstrap/argocd-access.tf carries the narrow CRD grant this path needs, so
+    # scripts/upgrade-prow.sh can refresh it.
     #
-    # Argo CD can manage it because AmazonEKSArgoCDClusterPolicy grants CRD create, and
-    # bootstrap/argocd-access.tf adds the narrow in-cluster rule for get/update/patch that
-    # the policy withholds for CRDs Argo CD does not own. That exception exists for this
-    # path: scripts/upgrade-prow.sh needs to refresh this CRD.
-    #
-    # THE APPLY MODE FOR THIS PATH IS PINNED ON THE MANIFEST, not here. The ProwJob CRD is
-    # 667 KB and Argo CD applied it CLIENT-side despite ServerSideApply=true at the
-    # Application level, which fails outright on the 262144-byte annotation limit. The fix
-    # is the per-resource argocd.argoproj.io/sync-options annotation on the CRD itself;
-    # Replace=true was tried and did not help, because Replace takes precedence over
-    # ServerSideApply, which is the opposite of what this path needs.
+    # THE APPLY MODE IS PINNED ON THE MANIFEST, not here. The ProwJob CRD is 667 KB and Argo
+    # CD applied it CLIENT-side despite ServerSideApply=true at the Application level, which
+    # fails on the 262144-byte annotation limit. The fix is the per-resource
+    # argocd.argoproj.io/sync-options annotation on the CRD itself. Replace=true does not
+    # help: it takes precedence over ServerSideApply, which is the opposite of what this
+    # path needs.
     path: flux/prow/crds
     targetNamespace: prow
     wave: 4
     automated: true
 
-    # The one ignoreDifferences entry anywhere, and it was earned rather than assumed. The
-    # manifest sets spec.preserveUnknownFields: false, which is the v1 default and
-    # deprecated, so the API server accepts it and drops it - leaving a diff no sync can
-    # ever close. Predicted when the path was wired and deliberately NOT added then, per
-    # the rule in the migration doc: add an exception only for a field Argo CD itself calls
-    # OutOfSync. It did, on the first successful sync, with this as the only difference.
+    # The only ignoreDifferences entry anywhere. The manifest sets
+    # spec.preserveUnknownFields: false, which is the v1 default and deprecated, so the API
+    # server accepts it and drops it - leaving a diff no sync can close. Added only after
+    # Argo CD actually reported it OutOfSync, not in anticipation.
     ignoreDifferences:
       - group: apiextensions.k8s.io
         kind: CustomResourceDefinition
@@ -271,20 +217,14 @@ applications:
 
   secrets:
     # Four objects: the CSI driver's ClusterRole and ClusterRoleBinding, and a
-    # SecretProviderClass in each of prow and test-pods. No tokens, so no conversion and no
-    # helm block - Argo CD reads the same kustomize directory Flux reads. targetNamespace is
-    # only a default: two objects are cluster-scoped and the other two carry their own.
+    # SecretProviderClass in each of prow and test-pods. No tokens, so no helm block.
+    # targetNamespace is only a default - two objects are cluster-scoped, the other two
+    # carry their own.
     #
-    # THIS PATH REQUIRED THE WIDEST RBAC GRANT IN THE MIGRATION, authorised explicitly
-    # rather than by convention. Its ClusterRole gives the CSI driver secrets
-    # create/delete/get/list/patch/update/watch cluster-wide, and escalation prevention
-    # means Argo CD must hold all seven to create it - read, write and delete on every
-    # Secret in the cluster. bootstrap/argocd-rbac.tf carries it with the reasoning and the
-    # exit condition. Read that before touching this, and prefer taking the exit.
-    #
-    # Ordering: that grant must be live before this Application first syncs. It is
-    # Terraform's, and Terraform creates the root Application, so the ordering now holds
-    # structurally rather than by hand.
+    # THIS PATH REQUIRES THE WIDEST RBAC GRANT HERE. Its ClusterRole gives the CSI driver
+    # all seven secrets verbs cluster-wide, and escalation prevention means Argo CD must
+    # hold them too. bootstrap/argocd-rbac.tf carries the reasoning and the exit condition -
+    # read it before touching this, and prefer taking the exit.
     path: flux/secrets
     targetNamespace: prow
     wave: 4
@@ -293,19 +233,18 @@ applications:
   prow-agent-workflows:
     # Smallest of the three generated paths: one ConfigMap, two tokens, no workloads.
     #
-    # The chart is IN prow/agent-workflows/, not under flux/prow/charts/ with the others,
-    # because .Files.Get is chart-rooted and that is the only layout where it can read the
-    # generated agent-workflows.yaml from git. Terraform reading it with file() instead
-    # would mean `make prow-gen` had no effect until someone also ran terraform apply.
+    # The chart lives in prow/agent-workflows/ rather than under flux/prow/charts/ because
+    # .Files.Get is chart-rooted and that is the only layout where it can read the generated
+    # agent-workflows.yaml from git. Terraform reading it with file() would mean
+    # `make prow-gen` had no effect until someone also ran terraform apply.
     #
-    # The generated file keeps its ${TOKEN} placeholders and the generator is untouched:
-    # environments still on Flux resolve them via postBuild, and emitting Helm actions would
-    # break them on merge and rewrite all seven generated files, since the generator
-    # restamps a timestamp on every run. The chart resolves the two tokens with `replace`
-    # and fails the render if an unrecognised one appears.
+    # The generated file keeps its ${TOKEN} placeholders because the generator restamps a
+    # timestamp on every run, so emitting Helm actions would rewrite all seven generated
+    # files. The chart resolves the two tokens with `replace` and fails the render on an
+    # unrecognised one.
     #
-    # Wave 4 for the namespace only. It renders a ConfigMap that NAMES a mirrored image but
-    # never pulls one, so unlike prow-jobs and prow-plugins it takes no edge on prow-mirror.
+    # Wave 4 for the namespace only: it NAMES a mirrored image but never pulls one, so
+    # unlike prow-jobs and prow-plugins it takes no edge on prow-mirror.
     path: prow/agent-workflows
     targetNamespace: prow
     wave: 4
@@ -314,27 +253,26 @@ applications:
 
   prow-config:
     # Prow itself: deck, hook, tide, plank, crier, sinker, horologium, statusreconciler,
-    # ghproxy, the Ingress and the config ConfigMap. The highest blast radius here - the
-    # nine Deployments carry immutable spec.selector, so a recreate takes Prow's control
-    # plane down rather than rolling it.
+    # ghproxy, the Ingress and the config ConfigMap. Highest blast radius here - the nine
+    # Deployments carry immutable spec.selector, so a recreate takes Prow's control plane
+    # down rather than rolling it.
     #
-    # PARAMETERS ONLY, no values block, which took two changes to earn. The 13 component
-    # image references are composed by the chart from imageMirror, because PROW_VERSION and
-    # PROW_PATCH_REVISION are git-authored and not Terraform's to know. And the ALB
-    # annotations - two of them JSON containing commas that --set would misparse as list
-    # separators - moved into the chart as defaults, with the one per-environment
+    # PARAMETERS ONLY, no values block. The 13 component image references are composed by
+    # the chart from imageMirror, because PROW_VERSION and PROW_PATCH_REVISION are
+    # git-authored. The ALB annotations - two of them JSON containing commas that --set would
+    # misparse as list separators - are chart defaults, with the one per-environment
     # annotation composed from prow.domain.
     #
-    # buildCluster.clusterName is deliberately NOT passed. Its only consumer is gated on
+    # buildCluster.clusterName is deliberately NOT passed: its only consumer is gated on
     # buildCluster.server, which nothing sets since the connection Job took over that
-    # ConfigMap (D16), so Terraform never has to compose a string naming the build cluster.
+    # ConfigMap.
     path: prow/config
     targetNamespace: prow
     wave: 5
     values: [controllerEcrRegistry, stage, kubernetesOrg, redhatOrg, ecrPublicReaderRoleArn]
 
-    # Chart paths whose value name differs from the key in chartValues. --set reads the
-    # dots as a path, which is what is wanted.
+    # Chart paths whose value name differs from the key in chartValues. --set reads the dots
+    # as a path, which is what is wanted.
     valuePaths:
       imageMirror.accountId: accountId
       imageMirror.region: region
@@ -346,70 +284,58 @@ applications:
     automated: true
 
   prow-data-plane:
-    # The easy half of the old prow-charts: five Roles and five RoleBindings in test-pods
-    # that let crier, deck, hook, prow-controller-manager and sinker reach test pods.
+    # Five Roles and five RoleBindings in test-pods, letting crier, deck, hook,
+    # prow-controller-manager and sinker reach test pods.
     #
-    # ZERO TOKENS and no values. Its HelmRelease values block was eight identical static
-    # strings, which moved into prow/data-plane/values.yaml as chart defaults - the
-    # prow-mirror rule. Argo CD detects Helm from Chart.yaml and uses those defaults, so
-    # this entry emits no helm block at all, which is what lets tool detection fall through
-    # to kustomization.yaml on the paths that need it.
+    # ZERO TOKENS and no values, so this entry emits no helm block at all - which is what
+    # lets tool detection fall through to kustomization.yaml on the paths that need it.
     path: prow/data-plane
     targetNamespace: test-pods
     wave: 5
     automated: true
 
   prow-jobs:
-    # Largest of the generated paths. Its templates/ holds 25 generator templates across
-    # four subdirectories, all named in .helmignore. jobs.yaml is ignored too: at 1.9 MB it
-    # is the largest file in the repo and never enters the render. It exceeds the 1 MB
-    # ConfigMap limit, so the substitutor Job clones the repo at runtime, resolves it with
-    # envsubst and gzips the result into job-config - a mechanism independent of the
-    # reconciler, which is why the 11,511 tokens in that file are not migration work.
+    # Largest of the generated paths. jobs.yaml is .helmignore'd: at 1.9 MB it is the largest
+    # file in the repo and exceeds the 1 MB ConfigMap limit, so the substitutor Job clones
+    # the repo at runtime, resolves it with envsubst and gzips the result into job-config.
     #
-    # The Job's spec.template is immutable, which is what `force: true` on the Flux
-    # Kustomization handled. The chart annotates that Job alone with
-    # `Force=true,Replace=true`. Scoped by annotation rather than set as a syncOption here:
-    # at Application level it would delete and recreate the ConfigMaps and RBAC too, giving
-    # them new uids, which is exactly what the cutover procedure checks against.
+    # That Job's spec.template is immutable, so the chart annotates it alone with
+    # `Force=true,Replace=true`. Scoped by annotation rather than as an Application
+    # syncOption: at Application level it would delete and recreate the ConfigMaps and RBAC
+    # too, giving them new uids.
     #
-    # It also reproduces Flux's `$$` unescaping in the chart. Getting that wrong is silent:
-    # jobs.yaml would go unsubstituted, or bash would expand `$$` to its PID and write a
-    # corrupt job-config.
+    # The chart also reproduces the old `$$` unescaping. Getting that wrong is silent -
+    # jobs.yaml goes unsubstituted, or bash expands `$$` to its PID and writes a corrupt
+    # job-config.
     #
-    # Wave 5 on two edges Flux omitted: the prow namespace, and the mirrored image the
-    # substitutor Job pulls (${PROW_IMAGES_REPO_URI}:prow-kubectl-0.0.3).
+    # Wave 5 on two edges: the prow namespace, and the mirrored image the substitutor Job
+    # pulls.
     path: prow/jobs
     targetNamespace: prow
     wave: 5
-    # prowVersion, toolsVersion and prowPatchRevision are deliberately absent, as on
-    # prow-mirror: static git-authored strings, so chart defaults rather than parameters.
-    # These are now the only copy - flux/prow/version/ went with Flux.
+    # As on prow-mirror: prowVersion, toolsVersion and prowPatchRevision are chart defaults
+    # rather than parameters, and are now the only copy.
     values: [prowImagesRepoUri, testInfraOrg, testInfraRepo, testInfraBranch, accountId, region, controllerEcrRegistry]
 
-    # Load-bearing here rather than a nicety. ttlSecondsAfterFinished deletes the Job 300s
-    # after it finishes, which Argo CD sees as drift; selfHeal recreates it, which re-runs
-    # it and refreshes job-config. That reproduces the old behaviour, where the same ttl
-    # against a 5m Kustomization interval meant Flux recreated it on most reconciles.
-    # Without it the Job runs once and job-config goes stale the next time jobs.yaml
-    # changes - jobs.yaml is not a tracked object, so its content cannot be the trigger.
+    # selfHeal is load-bearing here, not a nicety. ttlSecondsAfterFinished deletes the Job
+    # 300s after it finishes, which Argo CD sees as drift; selfHeal recreates it, which
+    # re-runs it and refreshes job-config. Without it the Job runs once and job-config goes
+    # stale the next time jobs.yaml changes - jobs.yaml is not a tracked object, so its
+    # content cannot be the trigger.
     selfHeal: true
     automated: true
 
   prow-plugins:
     # Second of the generated paths, same shape as prow-agent-workflows.
     #
-    # What is different: its rbac.yaml carries a ClusterRole and ClusterRoleBinding, and
-    # Argo CD could neither create those nor hold cluster-wide what they grant, so
-    # escalation prevention would have refused them. bootstrap/argocd-rbac.tf now grants
-    # both, and that is the one privilege EXPANSION in this migration rather than a
-    # restatement of access Argo CD already had. The alternative - narrowing the plugin's
-    # own ClusterRole to namespaced Roles - is better and still open, but it changes
-    # generated RBAC and the plugin's effective permissions, so it belongs to whoever owns
-    # agent-plugin. Read the block in that file before touching this.
+    # What differs: its rbac.yaml carries a ClusterRole and ClusterRoleBinding, which Argo CD
+    # could neither create nor hold cluster-wide, so escalation prevention would refuse them.
+    # bootstrap/argocd-rbac.tf grants both, and that is a deliberate privilege expansion
+    # rather than a restatement - read the block there, including the exit condition, before
+    # touching this.
     #
-    # Wave 5 on the same two omitted edges as prow-jobs: the prow namespace, and the
-    # mirrored image its Deployment pulls (…-prow-images:agent-plugin-0.0.7).
+    # Wave 5 on the same two edges as prow-jobs: the prow namespace, and the mirrored image
+    # its Deployment pulls.
     path: prow/plugins/deployments
     targetNamespace: prow
     wave: 5

--- a/bootstrap/README.md
+++ b/bootstrap/README.md
@@ -118,7 +118,7 @@ aws eks describe-capability --cluster-name <cluster> --capability-name argocd --
 
 Flux used to be vendored here as an extracted chart under `charts/` with
 `scripts/pull-flux-chart.sh` to refresh it, because Flux had to upgrade itself from a source it
-could read. Both are gone -- see `docs/argocd-migration.md`.
+could read. Both are gone.
 
 ## Upgrading Prow
 

--- a/bootstrap/argocd-access.tf
+++ b/bootstrap/argocd-access.tf
@@ -1,49 +1,31 @@
 ################################################################################
-# Argo CD authorization and cluster registration
+# Argo CD authorization and cluster registration. Pure Terraform; no local-exec.
 #
-# Everything here is pure Terraform. No local-exec, no kubectl.
+# Creating the capability already grants AmazonEKSArgoCDClusterPolicy (cluster) and
+# AmazonEKSArgoCDPolicy (namespace=argocd). Those cover Argo CD's own operation -
+# reading its CRs and registration Secrets, API discovery, namespace and CRD create.
+# They do NOT grant deploying workloads or reading arbitrary resources for health
+# assessment, which is what this file adds.
 #
-# What EKS already did for us when the capability was created (verified live):
-#   AmazonEKSArgoCDClusterPolicy  scope=cluster
-#   AmazonEKSArgoCDPolicy         scope=namespace, namespaces=[argocd]
+# Granted through EKS access policies and one added Kubernetes group rather than
+# in-cluster RBAC alone, because Argo CD cannot apply the objects that authorize
+# Argo CD.
 #
-# Those cover Argo CD's OWN operation - reading its CRs, reading cluster
-# registration Secrets, API discovery, namespace creation, CRD create. They do NOT
-# grant permission to deploy workloads or to read arbitrary resources for health
-# assessment. That is what this file adds.
-#
-# Authorization is granted via EKS access policies rather than in-cluster RBAC,
-# because Argo CD cannot apply the object that authorizes Argo CD. The repo already
-# documents this pattern for Flux in flux/ack/build-cluster/access-entries.yaml.
-################################################################################
-
-################################################################################
-# SCOPE: hub cluster only.
-#
-# Nothing here touches the build cluster, deliberately. The build cluster is not
-# registered as an Argo CD spoke until Phase 4, and when it is, its AccessEntry
-# belongs in flux/ack/build-cluster/access-entries.yaml as an ACK CR alongside the
-# eight already there - not in Terraform. See docs/argocd-migration.md, D13.
+# Hub cluster only. Anything keyed to the build cluster is owned at runtime, never
+# by Terraform, because its ARN is not knowable until ACK creates the cluster; its
+# access entry belongs with the other ACK CRs in
+# flux/ack/build-cluster/access-entries.yaml.
 ################################################################################
 
 locals {
   argocd_capability_role_arn = aws_iam_role.argocd_capability.arn
 
-  # Namespaces Argo CD may write to on the hub. Exactly the namespaces some Application
-  # targets - the list is a statement about what is deployed, not a standing allowance.
+  # Namespaces Argo CD may write to. Exactly the namespaces some Application targets,
+  # so this is a statement about what is deployed rather than a standing allowance.
   #
-  # Two entries have been removed on that basis rather than left to linger:
-  #
-  #   `prometheus`, when kube-prometheus-stack was removed from the repo.
-  #
-  #   `flux-system`, once prow-build-cluster-connection moved to ack-system. It was the last
-  #   Application targeting that namespace, and it only ever lived there because that is
-  #   where it was written - nothing in it is Flux wiring. What remains in flux-system is
-  #   Flux's own machinery, since removed, so Argo CD never needed access to it.
-  #
-  # This list also drives the `admin` RoleBindings in argocd-rbac.tf, deliberately: that
-  # binding is only defensible as privilege-neutral because it mirrors this association, so
-  # the two must move together.
+  # This list also drives the `admin` RoleBindings in argocd-rbac.tf, and that binding
+  # is only defensible as privilege-neutral because it mirrors this association. The
+  # two must move together.
   argocd_hub_namespaces = [
     "ack-system",
     "prow",
@@ -51,12 +33,8 @@ locals {
   ]
 }
 
-################################################################################
-# Hub cluster (control plane) authorization
-################################################################################
-
-# Cluster-wide read for resource discovery and health assessment. Argo CD needs to
-# read all resource types cluster-wide even when it writes to only a few namespaces.
+# Cluster-wide read, for resource discovery and health assessment. Needed even though
+# Argo CD writes to only a few namespaces.
 resource "aws_eks_access_policy_association" "argocd_hub_read" {
   cluster_name  = aws_eks_cluster.this.name
   principal_arn = local.argocd_capability_role_arn
@@ -70,13 +48,10 @@ resource "aws_eks_access_policy_association" "argocd_hub_read" {
 # Write access, namespace-scoped.
 #
 # ONE association carrying the full namespace list - NOT for_each over namespaces.
-# aws_eks_access_policy_association is keyed by (cluster, principal, policy), so its
-# Terraform ID contains no namespace component:
-#   <cluster>#<principal-arn>#<policy-arn>
-# A for_each over namespaces therefore produces N resources all contending for the
-# same AWS resource. They thrash on every apply and only the last writer survives,
-# silently leaving the other namespaces ungranted. namespaces is a list property of
-# a single association, not a key.
+# This resource is keyed by (cluster, principal, policy), so its Terraform ID has no
+# namespace component. A for_each therefore produces N resources contending for the
+# same AWS resource: they thrash on every apply and only the last writer survives,
+# silently leaving the other namespaces ungranted.
 resource "aws_eks_access_policy_association" "argocd_hub_write" {
   cluster_name  = aws_eks_cluster.this.name
   principal_arn = local.argocd_capability_role_arn
@@ -88,18 +63,12 @@ resource "aws_eks_access_policy_association" "argocd_hub_write" {
   }
 }
 
-################################################################################
-# Cluster registration
+# Cluster registration: a labelled Secret in the capability's namespace. `server` must
+# be the EKS cluster ARN - API server URLs and kubernetes.default.svc are not
+# supported. No credentials; the capability derives them from the capability role and
+# the access entries above.
 #
-# Registration is a labelled Secret in the capability's namespace. The server field
-# must be the EKS cluster ARN - API server URLs and kubernetes.default.svc are not
-# supported. No connection credentials are needed; the capability derives them from
-# the capability role and the access entries above.
-#
-# The hub registration must be Terraform-owned: Argo CD cannot deploy anything until
-# at least one cluster is registered, so this is the chicken-and-egg seam.
-################################################################################
-
+# Terraform-owned because Argo CD can deploy nothing until a cluster is registered.
 resource "kubernetes_secret_v1" "argocd_cluster_hub" {
   metadata {
     name      = "in-cluster"
@@ -119,23 +88,15 @@ resource "kubernetes_secret_v1" "argocd_cluster_hub" {
   depends_on = [awscc_eks_capability.argocd]
 }
 
-################################################################################
-# AppProject
+# AppProject.
 #
 # spec.sourceNamespaces is REQUIRED by the managed capability and must contain the
-# capability's configured namespace. Omitting it does not error clearly - Applications
-# in that namespace simply cannot reference the project, surfacing as deployment
-# failures. The built-in "default" project is not relied upon for this reason.
+# capability's namespace. Omitting it does not error clearly - Applications in that
+# namespace simply cannot reference the project, which surfaces as deployment failures.
 #
-# kubernetes_manifest validates against the live API at PLAN time, so the Argo CD
-# CRDs must already exist. That holds here because the capability created them. On a
-# fresh bootstrap the capability and this resource would be in the same apply, so the
-# capability must be applied first:
-#   terraform apply -target=awscc_eks_capability.argocd
-# then a full apply. Only affects an empty account; on an existing stack the CRDs are
-# already present.
-################################################################################
-
+# kubernetes_manifest validates against the live API at PLAN time, so the Argo CD CRDs
+# must already exist. On a fresh bootstrap, apply the capability first
+# (-target=awscc_eks_capability.argocd) and then apply fully.
 resource "kubernetes_manifest" "argocd_project" {
   manifest = {
     apiVersion = "argoproj.io/v1alpha1"
@@ -155,15 +116,9 @@ resource "kubernetes_manifest" "argocd_project" {
         "https://github.com/${var.test_infra_org}/${var.test_infra_repo}",
       ]
 
-      # HUB ONLY. Spoke destinations are added at runtime, not here.
-      #
-      # A destination naming the build cluster is keyed to a cluster ACK owns, and
-      # Terraform must not hold anything keyed to it (D13) - the same reason the
-      # registration Secret is written by the prow-build-cluster-connection Job rather
-      # than by Terraform. Terraform authorises only the cluster it owns and bootstraps.
-      #
-      # The Job appends the spoke destination, which is why spec.destinations is in
-      # computed_fields below. Read that block before changing this list.
+      # HUB ONLY. The spoke destination is appended at runtime by the
+      # prow-build-cluster-connection Job, because it names a cluster ACK owns. See
+      # computed_fields below before changing this list.
       destinations = [
         {
           server    = aws_eks_cluster.this.arn
@@ -182,86 +137,41 @@ resource "kubernetes_manifest" "argocd_project" {
 
   depends_on = [awscc_eks_capability.argocd]
 
-  # Spoke destinations are appended at runtime by the prow-build-cluster-connection Job,
-  # because a destination naming the build cluster is keyed to a cluster ACK owns and
-  # Terraform must not hold that (D13). This is what stops Terraform reconciling the
-  # addition away.
+  # spec.destinations is written by the connection Job, so Terraform must not
+  # reconcile it away.
   #
-  # THIS WAS `lifecycle { ignore_changes = [manifest.spec.destinations] }` AND THAT DOES
-  # NOT WORK. ignore_changes substitutes the prior STATE value for the CONFIG value of an
-  # argument. Config and state both say hub-only here, so there is nothing to ignore - the
-  # divergence is in `object`, which is computed, and ignore_changes cannot reach a computed
-  # attribute. The provider then plans `manifest` against `object` and applies `manifest`
-  # through server-side apply, and spec.destinations is an atomic list with no merge key, so
-  # applying a one-entry list means "the list is exactly this one entry".
+  # `lifecycle { ignore_changes = [manifest.spec.destinations] }` DOES NOT WORK here.
+  # ignore_changes substitutes the prior STATE value for the CONFIG value of an
+  # argument, and both say hub-only - the divergence is in `object`, which is computed,
+  # and ignore_changes cannot reach a computed attribute. The provider then applies
+  # `manifest` through server-side apply, and destinations is an atomic list with no
+  # merge key, so applying a one-entry list means "the list is exactly this".
   #
-  # Which way that breaks depends on who wrote the field last, because a JSON patch takes
-  # ownership from the applying manager:
+  # Whichever manager wrote the field last decides how that breaks: if the Job did,
+  # the apply fails on a field-manager conflict and takes argocd_root with it, since
+  # that resource depends on this one; if Terraform did, the apply succeeds and absorbs
+  # the spoke ARN into state, which is the coupling this list exists to avoid.
   #
-  #   Job last       -> apply FAILS: conflict with "kubectl-patch" on .spec.destinations,
-  #                     and kubernetes_manifest.argocd_root depends on this resource, so
-  #                     every later apply fails too - including unrelated work.
-  #   Terraform last -> apply SUCCEEDS and absorbs the spoke ARN into `manifest` in state,
-  #                     which is the D13 coupling this list exists to avoid, arrived at
-  #                     silently. Staging is in this state.
-  #
-  # computed_fields is the mechanism the provider documents for a field written by someone
-  # else: "manifest fields whose values can be altered by the API server during 'apply'".
-  # Verified against a throwaway AppProject: declare the hub destination, mark the field
-  # computed, let an external JSON patch take ownership and append a spoke, re-plan ->
-  # "No changes", and `manifest` stays hub-only so the ARN never enters state.
-  #
-  # The two metadata entries are the provider's DEFAULT and must be restated - supplying
-  # computed_fields replaces the default list rather than appending to it, and dropping them
-  # reintroduces churn from the annotations Argo CD and ACK write. sourceRepos,
-  # sourceNamespaces and clusterResourceWhitelist stay Terraform-managed and drift-corrected.
+  # computed_fields is the provider's mechanism for a field written by someone else.
+  # The two metadata entries are its DEFAULT and must be restated - supplying
+  # computed_fields replaces the default list rather than appending to it, and dropping
+  # them reintroduces churn from annotations Argo CD and ACK write. sourceRepos,
+  # sourceNamespaces and clusterResourceWhitelist stay Terraform-managed.
   computed_fields = ["metadata.annotations", "metadata.labels", "spec.destinations"]
 }
 
-################################################################################
-# CRD write exception
+# CRD write.
 #
 # AmazonEKSArgoCDClusterPolicy grants customresourcedefinitions `create`, but
-# get/update/patch/delete only on Argo CD's OWN CRDs. Any Application that manages a
-# third-party CRD therefore installs it successfully on first sync and then fails
-# forever on the next one. Confirmed live in staging:
+# get/update/patch/delete only on Argo CD's OWN CRDs. An Application managing a
+# third-party CRD therefore installs it on first sync and fails forever after, and it
+# does not fail fast - the Application retries and sits in Running, so the symptom is
+# a stuck sync rather than a permission error. This matters for prow-crds, which must
+# refresh the ProwJob CRD when scripts/upgrade-prow.sh pulls a new version.
 #
-#   customresourcedefinitions.apiextensions.k8s.io "..." is forbidden: User
-#   ".../ack-test-infra-staging-argocd-capability-role/..." cannot patch resource
-#   "customresourcedefinitions" in API group "apiextensions.k8s.io" at the cluster scope
-#
-# It does not fail fast either - the Application retries indefinitely and sits in
-# Running, so the symptom is a stuck sync rather than a clear permission error.
-#
-# This matters for prow-crds, which installs the ProwJob CRD and must be able to
-# refresh it when scripts/upgrade-prow.sh pulls a new version from upstream.
-#
-# Granted as narrow in-cluster RBAC on exactly one resource type rather than by
-# attaching AmazonEKSClusterAdminPolicy, which would hand over the whole cluster.
-#
-# Terraform must own this: it is the object that authorizes Argo CD, so Argo CD
-# cannot apply it (3.4).
-################################################################################
-
-# Custom in-cluster RBAC CANNOT be used here, which is worth recording because the
-# AWS docs suggest otherwise. The capability's auto-created access entry has:
-#
-#   kubernetesGroups: []
-#   username: arn:aws:sts::<acct>:assumed-role/<role>/{{SessionName}}
-#
-# There is no group to bind to, and the username is session-templated - at runtime it
-# resolves to a fresh value like aws-go-sdk-1787004054908077004. A ClusterRoleBinding
-# to "eks-access-entry:<principal-arn>", which the Register-target-clusters docs
-# recommend, binds to a group that does not exist and silently grants nothing.
-# Verified by attempting exactly that: the CRD patch stayed forbidden.
-#
-# A separate IAM role does not help either - every capability role gets an identical,
-# equally unbindable access entry. The only lever is which access POLICIES are
-# associated.
-#
-# AmazonEKSKROPolicy grants apiextensions.k8s.io/customresourcedefinitions: * . It is
-# AWS-managed and far narrower than AmazonEKSClusterAdminPolicy. Its incidental
-# grants (kro.run/*, leases, events) are inert here - no kro CRDs are installed.
+# AmazonEKSKROPolicy grants apiextensions.k8s.io/customresourcedefinitions: * and is
+# far narrower than AmazonEKSClusterAdminPolicy. Its incidental grants (kro.run/*,
+# leases, events) are inert - no kro CRDs are installed.
 resource "aws_eks_access_policy_association" "argocd_hub_crd" {
   cluster_name  = aws_eks_cluster.this.name
   principal_arn = local.argocd_capability_role_arn
@@ -272,34 +182,13 @@ resource "aws_eks_access_policy_association" "argocd_hub_crd" {
   }
 }
 
-################################################################################
-# ACK custom resources.
+# ACK custom resources. The AWS-managed policies enumerate standard API groups and do
+# not extend to arbitrary CRDs, so without this Argo CD renders the ~63 ACK CRs it
+# manages but cannot apply them. AmazonEKSACKPolicy is what the ACK capability role
+# itself is granted and is scoped to the *.services.k8s.aws groups.
 #
-# Found by cutting one path over and watching it fail safely:
-#
-#   pullthroughcacherules.ecr.services.k8s.aws "ghcr-fluxcd" is forbidden: User
-#   ".../ack-test-infra-staging-argocd-capability-role/aws-go-sdk-..." cannot patch
-#   resource "pullthroughcacherules" in API group "ecr.services.k8s.aws" in the
-#   namespace "ack-system"
-#
-# AmazonEKSAdminPolicy is already associated for the workload namespaces, but the
-# AWS-managed policies enumerate standard API groups and do not extend to arbitrary
-# CRDs. Argo CD manages 63 ACK custom resources across the *.services.k8s.aws
-# groups, so without this it can render them but never apply them.
-#
-# As established in D14, in-cluster RBAC is not an option: the capability's access
-# entry carries no kubernetesGroups and a session-templated username, so there is no
-# stable subject to bind. Associated access policies are the only lever.
-#
-# AmazonEKSACKPolicy is exactly the right shape - it is what the ACK capability role
-# itself is granted, and it is scoped to the *.services.k8s.aws groups rather than
-# handing out cluster-admin.
-#
-# Cluster scope, matching the ACK capability role's own association: ACK CRs live in
-# ack-system today, but the scope of a policy granting only ACK API groups is already
-# narrow, and namespace scope would silently break if a controller is ever pointed at
-# another namespace.
-################################################################################
+# Cluster scope, matching the ACK capability role: the policy is already narrow, and
+# namespace scope would break silently if a controller is pointed elsewhere.
 resource "aws_eks_access_policy_association" "argocd_hub_ack" {
   cluster_name  = aws_eks_cluster.this.name
   principal_arn = local.argocd_capability_role_arn
@@ -310,70 +199,45 @@ resource "aws_eks_access_policy_association" "argocd_hub_ack" {
   }
 }
 
-################################################################################
-# Cluster-scoped objects in the ack-cluster chart.
-#
-# Found by cutting one path over and reading the per-resource result. The three
-# namespaced ACK CRs synced; all four cluster-scoped objects were refused:
-#
-#   StorageClass  auto-ebs-sc         SyncFailed  cannot patch StorageClass
-#   IngressClass  alb                 SyncFailed  cannot patch IngressClass
-#   NodePool      prow-compute        SyncFailed  cannot patch NodePool
-#   NodePool      prow-control-plane  SyncFailed  cannot patch NodePool
-#
-# NO ACCESS POLICY SOLVES THIS. Recorded so the next attempt does not repeat it:
+# Cluster-scoped objects in the ack-cluster chart - StorageClass, IngressClass and the
+# two NodePools - are handled by the group below plus a narrow ClusterRole in
+# argocd-rbac.tf, NOT by an access policy. Recorded so the next attempt does not
+# repeat it:
 #
 #   AmazonEKSBlockStorageClusterPolicy and AmazonEKSComputeClusterPolicy cannot be
-#   associated at all - "InvalidParameterException: The specified policyArn can only
-#   be associated with service-linked roles". They are reserved for EKS Auto Mode's
-#   own service-linked roles. Declaring either as a resource here makes every apply
-#   fail, which is why neither appears below.
+#   associated at all ("policyArn can only be associated with service-linked roles").
+#   Declaring either makes every apply fail.
 #
-#   AmazonEKSLoadBalancingClusterPolicy associates but grants no IngressClass write.
-#   AmazonEKSAdminPolicy grants nothing extra at either scope: it mirrors the built-in
-#   admin ClusterRole, which is namespace-oriented and excludes cluster-scoped
-#   resources and CRD instances. It also covers no CRD group, so it misses
-#   karpenter.sh regardless. Associating it at CLUSTER scope REPLACES the
-#   namespace-scoped association above of the same policy, silently widening that
-#   grant - verify with list-associated-access-policies after any change.
+#   AmazonEKSLoadBalancingClusterPolicy grants no IngressClass write.
 #
-#   The only associable policy covering all four is AmazonEKSClusterAdminPolicy, i.e.
-#   cluster-admin for Argo CD.
+#   AmazonEKSAdminPolicy adds nothing at either scope - it mirrors the namespace-
+#   oriented admin ClusterRole and covers no CRD group. Associating it at CLUSTER
+#   scope also REPLACES the namespace-scoped association above, silently widening that
+#   grant; verify with list-associated-access-policies after any change.
 #
-# Solved instead by adding a Kubernetes group to the capability role's access entry
-# and binding a narrow ClusterRole to it - see the access entry at the end of this
-# file and argocd-rbac.tf.
-################################################################################
+#   The only associable policy covering all four is AmazonEKSClusterAdminPolicy.
 
-################################################################################
-# A Kubernetes group on the capability role's access entry.
+# A Kubernetes group on the capability role's access entry, which is what avoids
+# granting Argo CD cluster-admin.
 #
-# This is the lever that avoids granting Argo CD cluster-admin. An earlier decision
-# record concluded in-cluster RBAC was impossible here, because the capability's
-# auto-created access entry ships with kubernetesGroups: [] and a session-templated
-# username that cannot serve as an RBAC subject. The first half is true; the
-# conclusion was not. A group can be ADDED to the entry, and a group is bindable.
+# The capability's auto-created entry ships with kubernetesGroups: [] and a
+# session-templated username that resolves to a fresh value per session, so it cannot
+# itself serve as an RBAC subject - binding to "eks-access-entry:<principal-arn>", as
+# the register-target-clusters docs suggest, binds a group that does not exist and
+# grants nothing. A group can however be ADDED to the entry, and a group is bindable.
 #
-# With this set, argocd-rbac.tf binds a ClusterRole granting
-# exactly storage.k8s.io/storageclasses, networking.k8s.io/ingressclasses,
-# karpenter.sh/nodepools and eks.amazonaws.com/nodeclasses - the cluster-scoped
-# objects in the ack-cluster chart. Verified: all four sync, and adding the group
-# leaves the six associated access policies intact.
-#
-# Kept as a separate resource rather than folded into an access entry declaration,
-# because the entry itself is created by the capability, not by Terraform. Terraform
-# only adds the group to it.
-################################################################################
+# Separate resource because the capability creates the entry; Terraform only adds the
+# group.
 resource "aws_eks_access_entry" "argocd_capability_group" {
   cluster_name  = aws_eks_cluster.this.name
   principal_arn = local.argocd_capability_role_arn
 
-  # Must match the subject in argocd-rbac.tf, which consumes this via local.argocd_rbac_group.
+  # Must match the subject in argocd-rbac.tf, via local.argocd_rbac_group.
   kubernetes_groups = ["argocd-cluster-scoped"]
 
   lifecycle {
     # The capability owns the entry and sets type and username; Terraform contributes
-    # only the group. Without this, Terraform and the capability fight over the rest.
+    # only the group.
     ignore_changes = [type, user_name]
   }
 }

--- a/bootstrap/argocd-applications.tf
+++ b/bootstrap/argocd-applications.tf
@@ -1,77 +1,32 @@
 ################################################################################
-# The root Application: one object Terraform owns, rendering every other Application
-# from git.
+# The root Application. The only Application Terraform declares; it renders the
+# rest from argocd/applications/ in git, so adding or changing a path is a commit
+# rather than a `terraform apply`.
 #
-# WHY THE APPLICATIONS ARE NOT HERE ANY MORE. They were, one kubernetes_manifest per
-# path, and the structure they carried - chart path, target namespace, which parameters
-# each chart needs, sync behaviour - is all git-authored. That is the `prow-mirror` rule
-# applied one level above the charts: static git-authored content belongs with the
-# structure, not in Terraform. The consequence that matters day to day is that adding or
-# changing a path is now a commit, not a `terraform apply`.
+# Terraform still supplies the per-environment values, because Argo CD renders
+# off-cluster and cannot read them from the cluster: valuesFrom against a
+# ConfigMap does not exist (argo-cd#12060), Helm's lookup returns empty, and there
+# is no repo-server to attach a plugin to. They travel as ONE helm.values blob,
+# not as parameters: yamlencode quotes every scalar, which is what keeps a
+# 12-digit account id a string. Unquoted, an id with a leading zero parses as a
+# float and renders as %!s(float64=...) - a valid-looking image reference that
+# fails at pull time rather than at render time.
 #
-# WHAT TERRAFORM STILL HAS TO SUPPLY, and why this is not a full handover. The values
-# below are per-environment and Terraform is the only thing that knows them. Argo CD
-# cannot read them from the cluster at render time: it renders off-cluster, valuesFrom
-# against a ConfigMap does not exist (argo-cd#12060), Helm's lookup returns empty, and
-# there is no repo-server here to attach a plugin to. So they travel as ONE helm.values
-# blob on this object, and argocd/applications/ threads them into each child.
+# Sync ordering lives in the chart, as a sync-wave per child.
 #
-# ONE BLOB, NOT PARAMETERS, and the reason is specific rather than stylistic. Parameters
-# are --set, which reads `.` as a path separator and `,` as a list separator. Threading 16
-# values through a root chart into 19 children as parameters multiplies every escaping
-# hazard this migration already hit. yamlencode also QUOTES every scalar, which is what
-# keeps a 12-digit account id a string. Unquoted, Go's YAML parser reads an id with a
-# leading zero - say 012345678901 - as a float, and printf %s then yields
-# %!s(float64=1.2345678901e+10): a valid-looking image reference that fails at pull time
-# rather than at render time. Confirmed by writing the same file unquoted by hand and
-# watching the chart's guard catch it.
+# Terraform keeps four things because none of them can bootstrap themselves: the
+# AppProject and the hub registration Secret (argocd-access.tf), in-cluster RBAC
+# (argocd-rbac.tf), and this object.
 #
-# ORDERING IS IN THE CHART, NOT HERE. Each child carries a sync-wave derived from Flux's
-# dependsOn graph plus three edges Flux omitted; the root applies them wave by wave. Argo
-# CD had no ordering at all before this - no sync-wave on any of the 19 - which the
-# migration never noticed because paths were cut over one at a time into a cluster where
-# the graph was already satisfied. On a fresh bootstrap it is not. See
-# docs/argocd-migration.md for the derivation.
-#
-# WHAT STAYS TERRAFORM'S, and why each one cannot move:
-#
-#   the AppProject (argocd-access.tf) - it authorises the repo and the destinations, and
-#   every child references it. A child cannot create the project that admits it.
-#
-#   the hub registration Secret (argocd-access.tf) - Argo CD can deploy nothing until at
-#   least one cluster is registered. This is the chicken-and-egg seam.
-#
-#   in-cluster RBAC (argocd-rbac.tf) - Argo CD cannot apply the objects that authorise
-#   Argo CD. Moving it here also fixed an ordering problem by construction: the grants
-#   that prow-plugins and secrets need are applied before this object exists at all.
-#
-#   this object - an Application that renders itself is a loop with no seam. The seam is
-#   the point.
-#
-# WHAT IS DELIBERATELY ABSENT FROM THE CHART:
-#
-#   prow-build-cluster-resources, permanently. Its destination is the BUILD CLUSTER, and
-#   D13 puts anything keyed to that cluster out of Terraform's reach - which now includes
-#   anything Terraform renders. It is composed at runtime by the
-#   prow-build-cluster-connection Job, which reads the cluster ARN from the CR status,
-#   writes the spoke registration Secret and appends the AppProject destination. Adding it
-#   to argocd/applications/ would re-introduce exactly what D13 forbids, by a longer route.
-#
-#   prow-build-cluster-kubeconfig, because it does not outlive Flux. The
-#   build-cluster-flux-kubeconfig ConfigMap exists only so kustomize-controller can
-#   remote-apply into the build cluster; it was deleted with Flux and the Access Entry
-#   replaced it. Migrating it would have meant adopting an object in order to delete it. Contrast
-#   the prow-build-cluster-connection chart, which looked similar and DOES survive, because
-#   Prow's own components mount the kubeconfig it writes (D16).
-#
-#   ack-flux is in that same category and is cut over anyway - done before this was
-#   noticed. Its PullThroughCacheRule cached ghcr.io/fluxcd images and was removed with Flux,
-#   along with this entry.
+# prow-build-cluster-resources is deliberately absent from the chart. Anything
+# keyed to the build cluster is owned at runtime, never by Terraform, because its
+# ARN is not knowable until ACK creates the cluster. The
+# prow-build-cluster-connection Job composes that Application instead, reading the
+# ARN from the CR status.
 ################################################################################
 
 locals {
-  # Parameters every chart may draw from, keyed by the chart value name. Sourced from
-  # the same locals as self-managed-vars so the two cannot drift while both exist.
+  # Values any chart may draw from, keyed by chart value name.
   argocd_chart_values = {
     stackName         = local.stack_name
     accountId         = local.account_id
@@ -80,57 +35,33 @@ locals {
     prowDomain        = var.prow_domain
     prowImagesRepoUri = local.prow_images_repo_uri
 
-    # Repo coordinates, needed by prow-build-cluster-connection because the Application it
-    # creates at runtime has to name its own source. Terraform uses these for every
-    # Application's source already (see repoURL / targetRevision below) and for the
-    # AppProject's sourceRepos; passing them as chart values is the same data by the route
-    # a runtime owner can reach. They say nothing about the build cluster.
+    # Needed by prow-build-cluster-connection: the Application it creates at
+    # runtime has to name its own source.
     testInfraOrg    = var.test_infra_org
     testInfraRepo   = var.test_infra_repo
     testInfraBranch = var.test_infra_branch
 
-    # For prow-jobs. The only token on the three generated paths that had no counterpart here
-    # and had to be added; same expression as CONTROLLER_ECR_REGISTRY in self-managed-vars, so
-    # the two cannot drift while both exist.
-    #
-    # It is threaded into the substitutor Job's env and passed to envsubst over jobs.yaml, but
-    # currently has zero occurrences in that file. Kept because dropping it would change the
-    # Job's behaviour on a path being migrated; worth removing from both once confirmed dead.
+    # For prow-jobs. Passed to envsubst over jobs.yaml, where it currently has zero
+    # occurrences - worth removing from both once confirmed dead.
     controllerEcrRegistry = "public.ecr.aws/${local.controller_ecr_alias}"
 
-    # For prow-config. Plain per-environment scalars the HelmRelease used to substitute.
+    # For prow-config.
     stage         = var.stage
     kubernetesOrg = var.kubernetes_org
     redhatOrg     = var.redhat_org
 
-    # Composed here rather than in the chart, because both name resources on the HUB, which
-    # Terraform owns and bootstraps. Contrast buildCluster.clusterName, which names the build
-    # cluster: the chart does not need it (its only consumer is gated on buildCluster.server,
-    # which nothing sets since the connection Job took over that ConfigMap), so nothing has to
-    # compose it and D13 never comes up.
+    # Composed here because both name resources on the hub, which Terraform owns.
     ecrPublicReaderRoleArn = "arn:${local.partition}:iam::${var.publish_account_id}:role/ArtifactReader"
     prowLogsBucketName     = "${local.stack_name}-prow-logs-${local.account_id}"
   }
 }
 
-# The one Application Terraform declares.
+# prune stays false. With prune on, a chart that rendered empty for any reason
+# would delete every child Application at once. Argo CD also has no delete on
+# Applications (see argocd-rbac.tf), so removing a path from the chart orphans its
+# Application rather than removing it - deleting the leftover is a manual step.
 #
-# ServerSideApply is what let this take over the 19 existing Applications without
-# recreating them: they were removed from Terraform state rather than destroyed, so the
-# live objects were untouched, and SSA merges field ownership instead of replacing the
-# object. Verified before the handover with a server-side dry-run apply as
-# argocd-controller against all 19 - zero conflicts, because SSA only conflicts where two
-# managers set DIFFERENT values and the render was byte-identical to live.
-#
-# prune stays false, as everywhere. It matters more here than anywhere else: with prune on,
-# a chart that renders empty for any reason would delete all 19 Application objects at
-# once. Argo CD also cannot delete Applications today - argocd-rbac.tf grants
-# get/create/update/patch and no delete - so removing a path from the chart orphans its
-# Application rather than removing it. That is deliberate and it is the known cost of this
-# pattern; deleting the leftover is a manual step.
-#
-# selfHeal stays false too, for the reason it is off elsewhere: it reverts live changes Argo
-# CD did not make, which during an incident means fighting whoever is diagnosing it.
+# selfHeal stays false so it does not revert live changes during a diagnosis.
 resource "kubernetes_manifest" "argocd_root" {
   manifest = {
     apiVersion = "argoproj.io/v1alpha1"
@@ -151,9 +82,8 @@ resource "kubernetes_manifest" "argocd_root" {
 
         helm = {
           values = yamlencode({
-            # Passed through to every child's source, so all 19 read the same revision this
-            # object does. A child cannot be pinned elsewhere, which is the point: one
-            # branch, one tree.
+            # Passed through to every child's source, so all of them read the same
+            # revision this object does. One branch, one tree.
             project           = kubernetes_manifest.argocd_project.manifest.metadata.name
             repoURL           = "https://github.com/${var.test_infra_org}/${var.test_infra_repo}"
             targetRevision    = var.test_infra_branch
@@ -162,14 +92,8 @@ resource "kubernetes_manifest" "argocd_root" {
 
             chartValues = local.argocd_chart_values
 
-            # prow-build-cluster-connection's helm.values, composed here because the chart
-            # cannot: .Files.Get is chart-rooted, so a chart under argocd/ cannot read
-            # prow/jobs/test_config.yaml. Terraform reads it with file() and passes the
-            # yamlencode output, which is also what keeps the rendered string identical to
-            # what that Application already carries.
-            #
-            # file() at 226 bytes, precedent at images.tf:63. Verified byte-identical to the
-            # live ConfigMap on the build cluster, same single test_config.yaml key.
+            # Composed here because the chart cannot: .Files.Get is chart-rooted, so
+            # a chart under argocd/ cannot read prow/jobs/test_config.yaml.
             testConfigValues = yamlencode({
               testConfig = file("${path.module}/../prow/jobs/test_config.yaml")
             })
@@ -178,14 +102,13 @@ resource "kubernetes_manifest" "argocd_root" {
       }
 
       destination = {
-        # The capability registers clusters by ARN, not URL. A URL does not match the
-        # AppProject destination and the Application is REJECTED rather than failing at
-        # sync, so the symptom appears far from the cause.
+        # The capability registers clusters by ARN, not URL. A URL does not match
+        # the AppProject destination and the Application is REJECTED rather than
+        # failing at sync, so the symptom appears far from the cause.
         server = aws_eks_cluster.this.arn
 
-        # The children are Application objects, so they land in the capability's namespace.
-        # It must be in the AppProject's sourceNamespaces or they cannot reference the
-        # project.
+        # The children are Application objects, so they land in the capability's
+        # namespace, which must be in the AppProject's sourceNamespaces.
         namespace = "argocd"
       }
 
@@ -195,18 +118,15 @@ resource "kubernetes_manifest" "argocd_root" {
           "CreateNamespace=false",
         ]
 
-        # An EMPTY object, not `{prune = false, selfHeal = false}`, and the difference is
-        # only about keeping the plan honest. Absent means false to Argo CD, and the API
-        # server drops both zero values on Terraform's write - so spelling them out leaves
-        # `prune: null -> false` in every future plan, forever, on a field nothing reads.
-        # The children can spell them out because argocd-controller's server-side apply
-        # keeps them; this object cannot. Presence of `automated` is what enables auto-sync.
+        # An EMPTY object, not `{prune = false, selfHeal = false}`. Absent means
+        # false to Argo CD, and the API server drops both zero values on
+        # Terraform's write - so spelling them out would leave `prune: null ->
+        # false` in every future plan. Presence of `automated` enables auto-sync.
         automated = {}
       }
     }
   }
 
-  # The children reference the AppProject by name, and an Application whose project does
-  # not exist is rejected.
+  # A child Application whose project does not exist is rejected.
   depends_on = [kubernetes_manifest.argocd_project]
 }

--- a/bootstrap/argocd-logs.tf
+++ b/bootstrap/argocd-logs.tf
@@ -1,14 +1,13 @@
 ################################################################################
-# Argo CD capability controller log delivery (plan section 3.7)
+# Argo CD capability controller log delivery.
 #
-# The capability's controllers run on AWS-managed infrastructure outside the
-# cluster, so Prometheus cannot scrape them and `kubectl logs` cannot reach them.
-# Log delivery is the compensating control for that observability gap (D7).
+# The capability's controllers run on AWS-managed infrastructure outside the cluster,
+# so Prometheus cannot scrape them and `kubectl logs` cannot reach them. Log delivery
+# is the compensating control for that.
 #
-# Delivery is CloudWatch Vended Logs, configured through the CloudWatch Logs API
-# rather than the EKS capability API: a delivery SOURCE per log type (the capability
-# ARN plus a log type), a delivery DESTINATION (the log group), and a DELIVERY
-# joining them.
+# Configured through the CloudWatch Logs API rather than the EKS capability API: a
+# delivery SOURCE per log type (the capability ARN plus a log type), a delivery
+# DESTINATION (the log group), and a DELIVERY joining them.
 #
 # *** The sources MUST be created serially, WITH a settling delay between them. ***
 #
@@ -18,13 +17,11 @@
 #   ConflictException: Capability argocd cannot be updated as it is currently
 #   being modified by another request
 #
-# A for_each over log types creates them in parallel and most of them fail. Ordering
-# alone is not sufficient either: the capability stays in a modifying state for a
-# short period AFTER PutDeliverySource returns, so a bare depends_on chain still
-# collides. Hence explicit resources chained through time_sleep.
-#
-# This keeps a plain `terraform apply` correct without needing -parallelism=1, which
-# a fresh bootstrap would not know to pass.
+# A for_each over log types creates them in parallel and most fail. Ordering alone is
+# not sufficient either - the capability stays in a modifying state briefly AFTER
+# PutDeliverySource returns, so a bare depends_on chain still collides. Hence explicit
+# resources chained through time_sleep, which keeps a plain `terraform apply` correct
+# without needing -parallelism=1.
 #
 # To add a log type, add a resource and extend the chain. The five available are:
 #   EKS_CAPABILITY_ARGOCD_APPLICATION_LOGS      sync and health decisions
@@ -32,9 +29,6 @@
 #   EKS_CAPABILITY_ARGOCD_REPOSERVER_LOGS       manifest generation
 #   EKS_CAPABILITY_ARGOCD_SERVER_LOGS           API and UI access
 #   EKS_CAPABILITY_ARGOCD_COMMITSERVER_LOGS     git write-back (unused here)
-#
-# The three enabled below are the ones that matter during the migration. SERVER is
-# API/UI access logging and COMMITSERVER covers git write-back, which is not used.
 ################################################################################
 
 variable "argocd_log_retention_days" {

--- a/bootstrap/argocd-rbac.tf
+++ b/bootstrap/argocd-rbac.tf
@@ -1,57 +1,39 @@
 ################################################################################
 # In-cluster RBAC for the Argo CD capability.
 #
-# WHY TERRAFORM OWNS THIS. Argo CD cannot apply the object that authorises Argo CD,
-# so this path could never be an Application. It was reconciled by Flux until Flux was removed,
-# which made it the last thing Flux owned and blocked Flux removal outright. Terraform
-# is the right owner rather than the residual one: the SUBJECT these objects bind is
-# the kubernetesGroup that Terraform adds to the capability role's access entry
-# (aws_eks_access_entry.argocd_capability_group in argocd-access.tf). Both halves of
-# one mechanism now live in one place, and neither can be applied without the other
-# being visible.
+# Terraform owns this because Argo CD cannot apply the object that authorises Argo CD,
+# so it could never be an Application. It belongs here specifically: the SUBJECT these
+# objects bind is the kubernetesGroup Terraform adds to the capability role's access
+# entry (aws_eks_access_entry.argocd_capability_group in argocd-access.tf), so both
+# halves of one mechanism live in one place.
 #
-# Migrated from flux/argocd/{cluster-scoped-rbac,namespaced-rbac}.yaml, adopted by
-# `terraform import` so no object was recreated - a gap in the ClusterRoleBinding is a
-# gap in Argo CD's authorisation, and deleting to recreate would have opened one.
-#
-# WHY IN-CLUSTER RBAC AT ALL, since EKS access policies do the rest of the work here:
+# WHY IN-CLUSTER RBAC AT ALL, when EKS access policies do the rest of the work:
 # Kubernetes escalation prevention refuses to let a principal create a Role granting
-# permissions it does not itself hold, and that check resolves IN-CLUSTER RBAC ONLY.
-# A principal authorised entirely by EKS access policies holds nothing as far as the
-# RBAC authorizer is concerned, so it cannot create a Role granting anything at all:
-#
-#   roles.rbac.authorization.k8s.io "build-cluster-connection-write" is forbidden:
-#   user ".../ack-test-infra-staging-argocd-capability-role/aws-go-sdk-..."
-#   (groups=["argocd-cluster-scoped" "system:authenticated"]) is attempting to grant
-#   RBAC permissions not currently held: {APIGroups:[""], Resources:["configmaps"], ...}
-#
-# Most of what follows therefore adds no access Argo CD lacked. It restates access the
+# permissions it does not itself hold, and that check resolves IN-CLUSTER RBAC ONLY. A
+# principal authorised entirely by EKS access policies holds nothing as far as the RBAC
+# authorizer is concerned, so it cannot create a Role granting anything at all. Most of
+# what follows therefore adds no access Argo CD lacked - it restates access the
 # associated policies already grant, in the form the RBAC authorizer can see. The two
-# exceptions are called out where they appear, because they are real expansions.
+# real expansions are called out where they appear.
 #
 # `kubectl auth can-i --as-group=argocd-cluster-scoped` is the right probe for this and
-# the wrong probe for anything else: it reports what the RBAC authorizer sees, which is
-# exactly the escalation-prevention view, and it reports `no` for everything granted by
-# an access policy, because those are enforced by the EKS authorizer and are invisible
-# to a SubjectAccessReview. Do not read a `no` from it as a gap without checking which
-# authorizer is meant to be answering.
-#
-# Full history, including the options rejected: docs/argocd-migration.md.
+# the wrong probe for anything else: it reports what the RBAC authorizer sees, and
+# reports `no` for everything granted by an access policy, because those are enforced by
+# the EKS authorizer and are invisible to a SubjectAccessReview. Do not read a `no` from
+# it as a gap without checking which authorizer is meant to answer.
 ################################################################################
 
 locals {
-  # The group on the capability role's access entry. Every binding here uses it as the
-  # subject; aws_eks_access_entry.argocd_capability_group puts it on the entry. The
-  # entry's username is session-templated (".../{{SessionName}}") and cannot serve as
-  # an RBAC subject, so a group is the only stable option.
+  # The group on the capability role's access entry. The entry's username is
+  # session-templated (".../{{SessionName}}") and cannot serve as an RBAC subject, so a
+  # group is the only stable option.
   argocd_rbac_group = one(aws_eks_access_entry.argocd_capability_group.kubernetes_groups)
 
-  # One name, used by the four Roles below and by the RoleBindings that reference them.
   argocd_grantor_name = "argocd-rbac-grantor"
 
-  # Namespaces holding a CR type that `admin` does not aggregate. Not the same set as
-  # argocd_hub_namespaces: flux-system needs no grantor Role, and `argocd` gets one
-  # despite being covered by no access policy at all.
+  # Namespaces holding a CR type that `admin` does not aggregate. Deliberately not the
+  # same set as argocd_hub_namespaces: `argocd` gets one despite being covered by no
+  # access policy at all.
   argocd_grantor_namespaces = [
     "ack-system",
     "prow",
@@ -60,132 +42,82 @@ locals {
   ]
 }
 
-################################################################################
-# Cluster-scoped grants.
-#
-# No associable EKS access policy covers these objects, which is why in-cluster RBAC
-# is here at all rather than another access_policy_association:
-#
-#   AmazonEKSBlockStorageClusterPolicy and AmazonEKSComputeClusterPolicy are rejected
-#   outright - "The specified policyArn can only be associated with service-linked
-#   roles". AmazonEKSLoadBalancingClusterPolicy associates but grants no IngressClass
-#   write. AmazonEKSAdminPolicy mirrors the built-in admin ClusterRole, which is
-#   namespace-oriented and excludes cluster-scoped resources and CRD instances; it
-#   makes no difference at either scope, and associating it at CLUSTER scope silently
-#   REPLACES the namespace-scoped association of the same policy in argocd-access.tf,
-#   widening that grant.
-#
-#   The only associable policy that would cover all of these is
-#   AmazonEKSClusterAdminPolicy, i.e. cluster-admin for Argo CD.
-################################################################################
-
+# Cluster-scoped grants. No associable EKS access policy covers these objects - see the
+# block in argocd-access.tf for which were tried and why each fails - so in-cluster RBAC
+# is the mechanism rather than another access_policy_association.
 resource "kubernetes_cluster_role_v1" "argocd_cluster_scoped" {
   metadata {
     name = "argocd-cluster-scoped"
   }
 
-  ##############################################################################
-  # 1-4. The cluster-scoped objects in the ack-cluster chart. If that chart stops
-  # carrying them, these four rules go too.
-  ##############################################################################
-
-  # StorageClass - auto-ebs-sc
+  # The four cluster-scoped objects in the ack-cluster chart: StorageClass auto-ebs-sc,
+  # IngressClass alb, the Karpenter NodePools, and the build cluster's Auto Mode
+  # NodeClass (needed because that cluster runs Auto Mode with no built-in NodePools, so
+  # no managed `default` NodeClass exists). If that chart stops carrying them, these
+  # four rules go too.
   rule {
     api_groups = ["storage.k8s.io"]
     resources  = ["storageclasses"]
     verbs      = ["get", "list", "watch", "create", "update", "patch", "delete"]
   }
 
-  # IngressClass - alb
   rule {
     api_groups = ["networking.k8s.io"]
     resources  = ["ingressclasses"]
     verbs      = ["get", "list", "watch", "create", "update", "patch", "delete"]
   }
 
-  # Karpenter NodePool - prow-compute and prow-control-plane on the hub, and the build
-  # cluster's pool, since that cluster is registered as a spoke.
   rule {
     api_groups = ["karpenter.sh"]
     resources  = ["nodepools"]
     verbs      = ["get", "list", "watch", "create", "update", "patch", "delete"]
   }
 
-  # EKS Auto Mode NodeClass - the build cluster's custom prow-compute class. Required
-  # because that cluster enables Auto Mode with no built-in NodePools, so no managed
-  # `default` NodeClass exists.
   rule {
     api_groups = ["eks.amazonaws.com"]
     resources  = ["nodeclasses"]
     verbs      = ["get", "list", "watch", "create", "update", "patch", "delete"]
   }
 
-  ##############################################################################
-  # For prow/namespaces: the prow and test-pods Namespaces, plus the ServiceAccounts every
-  # PodIdentityAssociation binds to. Those seven objects were applied by Flux directly and
-  # by nothing else - the ack-pod-identities CHART excludes them on purpose, since a chart
-  # that owns a Namespace can delete one - so they had no owner that survives Flux, and a
-  # fresh bootstrap would never have created them.
+  # For prow/namespaces: the prow and test-pods Namespaces. A real grant rather than a
+  # restatement, since Namespaces are cluster-scoped and AmazonEKSAdminPolicy is
+  # associated per namespace, so it cannot grant creating one.
   #
-  # Namespaces are cluster-scoped, so no namespace-scoped access policy reaches them:
-  # AmazonEKSAdminPolicy is associated per namespace and cannot grant creating one. This is
-  # therefore a real grant rather than a restatement, and it is the smallest one that makes
-  # the path work.
+  # NO DELETE, and that omission is the point: deleting a Namespace cascades to
+  # everything inside it, which for `prow` is the whole control plane and for
+  # `test-pods` every running job. Argo CD needs to create these and reconcile their
+  # labels, never to remove one.
   #
-  # NO DELETE, and that omission is the point. Deleting a Namespace cascades to everything
-  # inside it, which for `prow` is the entire control plane and for `test-pods` is every
-  # running job. Argo CD needs to CREATE these and reconcile their labels; it never needs to
-  # remove one. `prune` is false on the path as well, so the only way to lose a namespace is
-  # by hand.
-  #
-  # The ServiceAccounts need no rule here: they are namespaced, and the admin RoleBindings
-  # below already cover serviceaccounts in prow and test-pods.
-  ##############################################################################
+  # The ServiceAccounts on that path need no rule - they are namespaced, and the admin
+  # RoleBindings below cover serviceaccounts in prow and test-pods.
   rule {
     api_groups = [""]
     resources  = ["namespaces"]
     verbs      = ["get", "list", "watch", "create", "update", "patch"]
   }
 
-  ##############################################################################
-  # 5-8. For prow-plugins. THIS IS A DELIBERATE PRIVILEGE EXPANSION, decided rather
-  # than drifted into, and one of the two grants here that is NOT merely a
-  # restatement of access Argo CD already holds.
+  # For prow-plugins. A DELIBERATE PRIVILEGE EXPANSION, and one of the two grants here
+  # that is not merely a restatement.
   #
   # prow/plugins/deployments/agent-plugin/rbac.yaml carries a ClusterRole and
-  # ClusterRoleBinding. Applying them needs two separate permissions: the ability to
-  # create ClusterRoles at all, and holding everything the created ClusterRole grants,
-  # or escalation prevention refuses it. Measured before deciding, with
-  # `kubectl auth can-i --as-group=argocd-cluster-scoped`:
+  # ClusterRoleBinding. Applying them needs both the ability to create ClusterRoles and
+  # holding everything the created ClusterRole grants, or escalation prevention refuses.
+  # Cluster-wide prowjobs write and pod read is WIDER than the namespace-scoped admin
+  # Argo CD already holds, so the "restatement" argument does not apply here.
   #
-  #   create clusterroles         no    create prowjobs (all ns)   no
-  #   create clusterrolebindings  no    patch  prowjobs (all ns)   no
-  #                                     list   pods     (all ns)   no
-  #                                     get    pods/log (all ns)   no
+  # The exit condition is narrowing the plugin's own ClusterRole to namespaced Roles,
+  # which the evidence supports - its Deployment pins PROW_JOB_NAMESPACE to prow and all
+  # live ProwJobs are in prow. Not done here because it changes generated RBAC and the
+  # plugin's effective permissions, which belongs to whoever owns agent-plugin. If it
+  # lands, shrink these rules to match; they only need to remain a superset of what that
+  # ClusterRole grants.
   #
-  # Every other grantor rule in this file is honestly describable as access Argo CD
-  # already had, only expressed where escalation prevention can see it -
-  # AmazonEKSAdminPolicy grants it namespace-scoped admin over the four namespaces in
-  # argocd_hub_namespaces. Cluster-wide prowjobs write and pod read is WIDER than that,
-  # so that description does not apply here.
-  #
-  # The alternative was narrowing the plugin's own ClusterRole to namespaced Roles,
-  # which the evidence supports - its Deployment pins PROW_JOB_NAMESPACE to prow and
-  # all live ProwJobs are in prow, so the ClusterRole is wider than the workload needs.
-  # Not taken here: it changes generated RBAC and the plugin's effective permissions,
-  # which belongs to whoever owns agent-plugin. If it lands, shrink these rules to
-  # match - they only need to remain a superset of what that ClusterRole grants.
-  #
-  # What bounded the expansion when it was made: kustomize-controller held strictly more than
-  # this and has since been removed with Flux, so the number of broadly-privileged principals
-  # went down rather than up.
-  # No `delete` on any of it, and no `escalate` - which would let Argo CD create a Role
+  # No `delete` on any of it, and no `escalate`, which would let Argo CD create a Role
   # conferring anything at all.
-  ##############################################################################
 
-  # Create the objects themselves. Without this the failure is a plain "cannot create
-  # resource clusterroles at the cluster scope", not an escalation error, which is easy
-  # to mistake for one.
+  # Create the objects. Without this the failure is a plain "cannot create resource
+  # clusterroles at the cluster scope", not an escalation error, which is easy to
+  # mistake for one.
   rule {
     api_groups = ["rbac.authorization.k8s.io"]
     resources  = ["clusterroles", "clusterrolebindings"]
@@ -193,8 +125,8 @@ resource "kubernetes_cluster_role_v1" "argocd_cluster_scoped" {
   }
 
   # Hold what the agent-plugin ClusterRole grants, so escalation prevention passes.
-  # These mirror it exactly; if that file gains a verb or resource, these need it too
-  # or the sync fails.
+  # These mirror it exactly; if that file gains a verb or resource, these need it too or
+  # the sync fails.
   rule {
     api_groups = ["prow.k8s.io"]
     resources  = ["prowjobs"]
@@ -213,35 +145,30 @@ resource "kubernetes_cluster_role_v1" "argocd_cluster_scoped" {
     verbs      = ["get"]
   }
 
-  ##############################################################################
-  # 9. For the `secrets` path. THIS IS THE WIDEST GRANT IN THE MIGRATION, and it was
-  # authorised explicitly after being priced, not inferred from a convention.
+  # For the `secrets` path. THE WIDEST GRANT HERE, authorised explicitly rather than
+  # inferred.
   #
-  # flux/secrets/secrets-store-rbac.yaml declares a ClusterRole granting the CSI
-  # driver `secrets` create/delete/get/list/patch/update/watch cluster-wide.
-  # Escalation prevention requires the applier to hold EVERY rule in a ClusterRole it
-  # creates, so Argo CD must hold all seven verbs on every Secret in the cluster for
-  # that object to apply. Measured before asking: all seven were `no`.
+  # flux/secrets/secrets-store-rbac.yaml declares a ClusterRole granting the CSI driver
+  # all seven verbs on `secrets` cluster-wide. Escalation prevention requires the
+  # applier to hold every rule in a ClusterRole it creates, so Argo CD must hold all
+  # seven on every Secret in the cluster for that object to apply.
   #
-  # BE CLEAR ABOUT WHAT THIS IS. It is not read access for health assessment. It is
-  # read, write and delete on every Secret in the cluster, including credentials this
-  # repo does not own, reachable by anything that can act as the Argo CD capability
-  # role. There is no narrower version that still applies the object: a subset fails
-  # the escalation check, and the only alternative mechanism is the `escalate` verb,
-  # which is broader still.
+  # BE CLEAR ABOUT WHAT THIS IS: read, write and delete on every Secret in the cluster,
+  # including credentials this repo does not own, reachable by anything that can act as
+  # the Argo CD capability role. There is no narrower version that still applies the
+  # object - a subset fails the escalation check, and the only alternative is the
+  # `escalate` verb, which is broader.
   #
-  # THE EXIT CONDITION, which is cheaper than it looks and should be taken. Narrow the
-  # CSI driver's own ClusterRole to namespaced Roles and this rule can be deleted
-  # outright - Argo CD would then need only namespaced secrets write, which
-  # AmazonEKSAdminPolicy already grants. The measurements say that is viable: the
-  # ClusterRoleBinding's only subject is the single secrets-store-csi-driver
-  # ServiceAccount in aws-secrets-manager, and the only SecretProviderClasses in the
-  # cluster are prow/prow-secrets and test-pods/prow-secrets, so the driver writes
-  # Secrets in two namespaces rather than all of them.
+  # THE EXIT CONDITION, cheaper than it looks and worth taking: narrow the CSI driver's
+  # own ClusterRole to namespaced Roles and this rule can be deleted outright, leaving
+  # Argo CD needing only namespaced secrets write, which AmazonEKSAdminPolicy already
+  # grants. That is viable today - the ClusterRoleBinding's only subject is the single
+  # secrets-store-csi-driver ServiceAccount, and the only SecretProviderClasses are
+  # prow/prow-secrets and test-pods/prow-secrets, so the driver writes Secrets in two
+  # namespaces rather than all of them.
   #
   # Mirrors that ClusterRole exactly, including delete. If its verbs change, this must
-  # change with them or the sync fails.
-  ##############################################################################
+  # change with them.
   rule {
     api_groups = [""]
     resources  = ["secrets"]
@@ -268,40 +195,24 @@ resource "kubernetes_cluster_role_binding_v1" "argocd_cluster_scoped" {
   }
 }
 
-################################################################################
 # Namespaced grants: one RoleBinding to the built-in `admin` ClusterRole per namespace.
 #
-# WHY THIS SHAPE, and why it is not a privilege increase. The first four paths were
-# unblocked one rule at a time, each discovered by a failed sync. That does not
-# converge: every chart that adds a Role adds another round trip. Measured across the
-# remaining paths, 13 more triples were missing across two namespaces - and 12 of the
-# 13 fall inside the built-in aggregated `admin` ClusterRole.
+# NOT a privilege increase. AmazonEKSAdminPolicy is already associated to this principal
+# scoped to exactly these namespaces (argocd_hub_namespaces, in argocd-access.tf), so a
+# RoleBinding to `admin` in them mirrors an access policy the EKS authorizer already
+# honours into the authorizer that escalation prevention consults. It replaces an
+# open-ended rule list that never converged - each chart adding a Role meant another
+# failed sync and another round trip - and any future namespaced Role in those
+# namespaces now just works.
 #
-# AmazonEKSAdminPolicy is already associated to this principal scoped to exactly these
-# namespaces (argocd_hub_namespaces, in argocd-access.tf). So a RoleBinding to `admin`
-# in them grants NO NEW EFFECTIVE PRIVILEGE - it mirrors the access policy the EKS
-# authorizer already honours into the authorizer that escalation prevention consults.
-# One binding per namespace replaces the open-ended rule list, and any future
-# namespaced Role in those namespaces just works.
+# for_each over argocd_hub_namespaces rather than a literal list, because equality with
+# that list IS the privilege-neutral argument. A namespace added to or removed from the
+# access policy changes its binding in the same apply, so the two cannot drift apart and
+# quietly falsify the claim above.
 #
-# The coupling works in both directions, which is the point of the for_each: when
-# flux-system came off argocd_hub_namespaces - prow-build-cluster-connection having moved to
-# ack-system, leaving no Application targeting it - this binding went with it in the same
-# apply. Had the list been written out literally here, the binding would have outlived the
-# access policy it claims to mirror, and the privilege-neutral argument above would have
-# quietly stopped being true.
-#
-# WHAT IS DELIBERATELY NOT DONE: binding cluster-admin. That would be a genuine
-# expansion, and after this change the remaining whack-a-mole is small - only
-# cluster-scoped grants and custom resource types need explicit rules, and both are
-# rare enough that explicitness is worth more than brevity.
-#
-# for_each over argocd_hub_namespaces rather than a literal list, because the equality
-# with that list is the whole argument for this being privilege-neutral. Adding a
-# namespace to the access policy now adds its binding in the same change, and the two
-# cannot drift apart silently.
-################################################################################
-
+# Deliberately not done: binding cluster-admin. Only cluster-scoped grants and custom
+# resource types still need explicit rules, and both are rare enough that explicitness
+# is worth more than brevity.
 resource "kubernetes_role_binding_v1" "argocd_namespace_admin" {
   for_each = toset(local.argocd_hub_namespaces)
 
@@ -324,12 +235,10 @@ resource "kubernetes_role_binding_v1" "argocd_namespace_admin" {
   }
 }
 
-################################################################################
 # Custom resource types, which the aggregated `admin` ClusterRole does not cover. One
-# Role per namespace, holding only CR types - kept as four explicit resources rather
-# than a for_each with dynamic rules, because the rules differ per namespace and the
-# point of them is to be read.
-################################################################################
+# Role per namespace, kept as four explicit resources rather than a for_each with
+# dynamic rules, because the rules differ per namespace and the point of them is to be
+# read.
 
 # ack-system: the connection Job's chart reads the build-cluster Cluster CR status.
 resource "kubernetes_role_v1" "argocd_grantor_ack_system" {
@@ -346,9 +255,9 @@ resource "kubernetes_role_v1" "argocd_grantor_ack_system" {
 }
 
 # prow: the secrets path declares a SecretProviderClass here, and prow-config's Roles
-# grant prowjobs including `delete`, which the cluster-scoped rule deliberately omits -
-# sinker deletes ProwJobs, so the permission is real, but it is granted here rather
-# than cluster-wide.
+# grant prowjobs including `delete`, which the cluster-scoped rule deliberately omits.
+# sinker deletes ProwJobs, so the permission is real, but it is granted here rather than
+# cluster-wide.
 resource "kubernetes_role_v1" "argocd_grantor_prow" {
   metadata {
     name      = local.argocd_grantor_name
@@ -368,7 +277,7 @@ resource "kubernetes_role_v1" "argocd_grantor_prow" {
   }
 }
 
-# test-pods: the second SecretProviderClass. Job pods mount it via the CSI driver.
+# test-pods: the second SecretProviderClass, mounted by job pods via the CSI driver.
 resource "kubernetes_role_v1" "argocd_grantor_test_pods" {
   metadata {
     name      = local.argocd_grantor_name
@@ -383,21 +292,13 @@ resource "kubernetes_role_v1" "argocd_grantor_test_pods" {
 }
 
 # argocd: the one namespace no access policy covers, so nothing here comes for free.
+# AmazonEKSAdminPolicy is scoped to argocd_hub_namespaces and excludes it, and
+# AmazonEKSArgoCDPolicy covers it but is the capability's own-operation grant. So it
+# gets no admin binding, and both halves are spelled out: the ability to create roles
+# and rolebindings at all, and holding whatever the created Role grants so escalation
+# prevention passes.
 #
-# AmazonEKSAdminPolicy is scoped to argocd_hub_namespaces and excludes this one;
-# AmazonEKSArgoCDPolicy covers it but is the capability's own-operation grant, which
-# reads cluster registration Secrets rather than managing RBAC. So this namespace gets
-# no admin binding and needs both halves spelled out:
-#
-#   1. the ability to create roles and rolebindings at all. Elsewhere the admin binding
-#      provides it. Without it the failure is a plain "cannot create resource roles in
-#      API group rbac.authorization.k8s.io in the namespace argocd" - not an escalation
-#      error, and easy to mistake for one.
-#   2. holding whatever the created Role grants, so escalation prevention passes: the
-#      secrets, appprojects and applications rules, matching
-#      build-cluster-connection-registrar.
-#
-# Granting roles/rolebindings write here does not let Argo CD widen its own access:
+# Granting roles/rolebindings write here does not let Argo CD widen its own access -
 # escalation prevention still caps any Role it creates at what it already holds.
 resource "kubernetes_role_v1" "argocd_grantor_argocd" {
   metadata {
@@ -417,12 +318,11 @@ resource "kubernetes_role_v1" "argocd_grantor_argocd" {
     verbs      = ["get", "create", "update", "patch"]
   }
 
-  # The connection Job appends the build cluster to the AppProject's destinations, and
-  # applies the prow-build-cluster-resources Application. Both are runtime work because
-  # they name a cluster ACK owns and Terraform must hold nothing keyed to it (D13).
-  # appprojects is get and patch only - the AppProject is Terraform-owned and the Job
-  # amends one field - while applications needs create, because the Job owns that object
-  # outright. No delete on either.
+  # The connection Job amends the AppProject's destinations and applies the
+  # prow-build-cluster-resources Application, both runtime work because they name a
+  # cluster ACK owns. appprojects is get and patch only, since the AppProject is
+  # Terraform-owned and the Job amends one field; applications needs create, because the
+  # Job owns that object outright. No delete on either.
   rule {
     api_groups = ["argoproj.io"]
     resources  = ["appprojects"]
@@ -437,8 +337,8 @@ resource "kubernetes_role_v1" "argocd_grantor_argocd" {
 }
 
 # One binding per grantor Role. All four Roles share a name, so role_ref is the same
-# symbol in each; depends_on is implicit through local.argocd_grantor_name only, so the
-# Roles are listed explicitly to keep the binding from being created first.
+# symbol in each and the dependency is not inferred - hence the explicit depends_on,
+# which keeps a binding from being created before its Role.
 resource "kubernetes_role_binding_v1" "argocd_grantor" {
   for_each = toset(local.argocd_grantor_namespaces)
 

--- a/bootstrap/identity/main.tf
+++ b/bootstrap/identity/main.tf
@@ -11,9 +11,8 @@
 # aws_ssoadmin_instances and aws_identitystore_group data sources, not through a
 # cross-state reference.
 #
-# Teardown is explicit and only for account decommissioning - see the Teardown note in
-# docs/argocd-migration.md. No prevent_destroy is set, because that would make
-# deliberate teardown impossible.
+# Teardown is explicit and only for account decommissioning. No prevent_destroy is set,
+# because that would make deliberate teardown impossible.
 
 provider "aws" {
   region = var.region

--- a/flux/ack/README.md
+++ b/flux/ack/README.md
@@ -146,4 +146,4 @@ as parameters.
 
 Historically these manifests used `${VAR}` placeholders substituted by Flux from a
 `self-managed-vars` ConfigMap. Argo CD renders off-cluster and has no substitution step, so that
-mechanism and the ConfigMap are gone; see `docs/argocd-migration.md`.
+mechanism and the ConfigMap are gone; values now arrive as Helm parameters from Terraform.

--- a/flux/ack/charts/ack-build-infra/templates/access-entries.yaml
+++ b/flux/ack/charts/ack-build-infra/templates/access-entries.yaml
@@ -1,16 +1,13 @@
 {{- $accountId := required "accountId is required" .Values.accountId }}
 {{- $stackName := required "stackName is required" .Values.stackName }}
-# Build cluster EKS Access Entries, reconciled by the control-plane ACK EKS
-# controller. They grant Kubernetes API access to the build cluster: a
-# break-glass admin role, the account's Admin/ReadOnly roles for humans, the
-# Prow components' role and the EC2 node
-# role (Auto Mode nodes — required because we run a custom NodeClass with no
-# built-in pools, so EKS doesn't auto-create the node entry).
+# Build cluster EKS Access Entries, reconciled by the control-plane ACK EKS controller.
+# They grant Kubernetes API access to the build cluster: a break-glass admin role, the
+# account's Admin and ReadOnly roles for humans, the Prow components' role, the EC2 node
+# role, and the Argo CD capability role.
 #
-# The Flux entry uses an access policy rather than a kubernetesGroups mapping so
-# its authorization exists on the first reconcile — otherwise the RBAC authorizing
-# Argo CD would itself be an object Argo CD must apply. Mirrors the pattern used on
-# the control plane.
+# Each uses an access policy rather than a kubernetesGroups mapping so authorization
+# exists on the first reconcile - otherwise the RBAC authorizing Argo CD would itself be
+# an object Argo CD must apply.
 ---
 # Dedicated build-cluster admin role (assumable by account root for break-glass)
 apiVersion: eks.services.k8s.aws/v1alpha1
@@ -98,11 +95,10 @@ spec:
 # []), we must supply it. Type EC2 + AmazonEKSAutoNodePolicy is the required
 # combination for Auto Mode node roles (custom NodeClass docs: create-node-class).
 #
-# adopt-or-create: a fresh Design-B cluster never ran a built-in pool, so EKS
-# never made this entry → ACK creates it. But a cluster that previously ran
-# general-purpose (e.g. before the switch to nodePools: []) already has an
-# EKS-created EC2 entry for this same principal → ACK adopts it instead of
-# failing terminal on "resource already exists".
+# adopt-or-create: a cluster that never ran a built-in pool has no such entry, so ACK
+# creates it. One that previously ran general-purpose already has an EKS-created EC2
+# entry for the same principal, so ACK adopts it rather than failing terminal on
+# "resource already exists".
 #
 # No adoption-fields annotation needed: adopt-or-create reads the find/create
 # identifiers (principalARN + the clusterRef-resolved clusterName) from the spec.
@@ -127,40 +123,26 @@ spec:
     accessScope:
       type: cluster
 ---
-# Argo CD capability role — the successor to the Flux entry above.
+# Argo CD capability role. Without this the build cluster cannot be registered as an Argo
+# CD destination at all - registering the spoke would produce a cluster Argo CD cannot
+# authenticate to, which is worse than not registering it. The
+# prow-build-cluster-resources chart applies thirteen in-cluster objects here, which ACK
+# cannot own because they are Kubernetes objects in a remote cluster rather than AWS
+# resources.
 #
-# prow-build-cluster-resources applies thirteen in-cluster objects INTO this cluster: a
-# Namespace, a ServiceAccount, four Roles and four RoleBindings, the test-config
-# ConfigMap, a NodeClass and a NodePool. ACK cannot own those - they are Kubernetes
-# objects in a remote cluster, not AWS resources - so something must remote-apply them,
-# and after Flux that is Argo CD. This entry is what makes the build cluster registerable
-# as an Argo CD destination at all; without it, registering the spoke would produce a
-# cluster Argo CD cannot authenticate to, which is worse than not registering it.
+# WHY ClusterAdminPolicy, when the hub deliberately avoids it. On the hub, cluster-scoped
+# access comes from a kubernetesGroups entry bound to a narrow ClusterRole
+# (bootstrap/argocd-rbac.tf). That cannot work here: the ClusterRole would have to live
+# inside THIS cluster, and the only thing able to apply it is Argo CD - the very thing it
+# authorises. On the hub that circularity is escaped because Terraform owns those objects
+# and reaches the cluster directly; on a remote cluster there is no such applier, and
+# nothing keyed to a cluster ACK owns may be Terraform's. The narrow role would also have
+# to enumerate every permission in those four Roles, or escalation prevention refuses
+# them.
 #
-# WHY ClusterAdminPolicy, when the hub deliberately avoids it.
-#
-# On the hub, cluster-scoped access is granted by adding a kubernetesGroups entry to the
-# access entry and binding a narrow ClusterRole (bootstrap/argocd-rbac.tf), specifically
-# to avoid handing Argo CD cluster-admin. That approach cannot work here.
-# The ClusterRole would have to live inside THIS cluster, and once Flux is gone the only
-# thing able to apply it is Argo CD - the very thing it authorises. On the hub that
-# circularity is escaped because Terraform owns those objects and reaches the cluster
-# directly; on a remote cluster there is no such applier - and Terraform must hold nothing
-# keyed to a cluster ACK owns (D13), so it cannot be the applier here. The narrow role would also have to
-# enumerate every permission in those four Roles, or Kubernetes escalation prevention
-# refuses them: a principal may not create a Role granting permissions it lacks.
-#
-# This is also not an increase in privilege. It is the same grant
-# flux-build-cluster-access held until it was removed with Flux,
-# so the number of cluster-admin principals on this cluster stays at one. The build
-# cluster is a CI execution environment rather than the control plane, which is why the
-# trade lands differently here than on the hub.
-#
-# Like the Flux entry, this uses an access policy rather than a kubernetesGroups mapping
-# so the authorization exists on the first reconcile.
-#
-# If prow-build-cluster-resources is ever retired, or the build cluster stops carrying
-# in-cluster objects, this entry should go with it.
+# The build cluster is a CI execution environment rather than a control plane, which is
+# why the trade lands differently here. If prow-build-cluster-resources is ever retired,
+# this entry should go with it.
 apiVersion: eks.services.k8s.aws/v1alpha1
 kind: AccessEntry
 metadata:

--- a/flux/prow/charts/prow-build-cluster-connection/templates/application.yaml
+++ b/flux/prow/charts/prow-build-cluster-connection/templates/application.yaml
@@ -3,37 +3,31 @@
 {{- $testInfraBranch := required "testInfraBranch is required" .Values.testInfraBranch }}
 {{- $stackName := required "stackName is required" .Values.stackName }}
 {{- $testConfig := required "testConfig is required" .Values.testConfig }}
-# The prow-build-cluster-resources Application, carried as a manifest inside a ConfigMap
-# for the Job to apply.
+# The prow-build-cluster-resources Application, carried as a manifest inside a ConfigMap for
+# the Job to apply.
 #
-# WHY THIS IS NOT IN TERRAFORM. Its destination is the build cluster, and D13 puts anything
-# keyed to that cluster out of Terraform's reach: the cluster is an ACK Cluster CR, so a
-# Terraform-declared Application naming it would be created before the cluster exists on a
-# fresh bootstrap and removed while its objects still depended on it on destroy. The same
-# rule already sends the spoke registration Secret and the AppProject destination through
-# this Job. This is the third object in that set, and the Job already holds the one input
-# Terraform cannot supply - the cluster ARN from the CR status.
+# Not declared by Terraform because its destination is the build cluster, an ACK Cluster CR:
+# a Terraform-declared Application naming it would be created before the cluster exists on a
+# fresh bootstrap, and removed while its objects still depended on it on destroy. The Job
+# holds the one input Terraform cannot supply - the ARN from the CR status.
 #
 # WHY A CONFIGMAP RATHER THAN A HEREDOC IN THE JOB. Two reasons.
 #
-# The manifest nests a YAML document (the Application) containing a YAML string
-# (helm.values) containing a YAML file (test_config.yaml). Composed here, Helm's `indent`
-# gets all three levels right at render time and the result is reviewable as YAML. Composed
-# in the Job it would be a bash heredoc inside a YAML block scalar, where the same
-# indentation is invisible and one space breaks the mount.
+# The manifest nests a YAML document (the Application) containing a YAML string (helm.values)
+# containing a YAML file (test_config.yaml). Composed here, Helm's `indent` gets all three
+# levels right and the result is reviewable as YAML. In the Job it would be a bash heredoc
+# inside a YAML block scalar, where the indentation is invisible and one space breaks the
+# mount.
 #
-# It also gives this chart a TRACKED object that carries the Application's desired state.
-# The Job is a Helm hook, and a hook is excluded from Argo CD's comparison, so a chart of
-# nothing but hooks can never drift and never syncs. With the spec in a tracked ConfigMap,
-# editing the Application - enabling automated at cutover, moving the branch - is drift,
-# which syncs, which re-runs the hook that applies it. Same mechanism prow-mirror uses to
-# make its version bumps a trigger.
+# It also gives this chart a TRACKED object carrying the Application's desired state. The Job
+# is a Helm hook, and hooks are excluded from Argo CD's comparison, so a chart of nothing but
+# hooks can never drift and never syncs. With the spec in a tracked ConfigMap, editing the
+# Application here is drift, which syncs, which re-runs the hook that applies it.
 #
-# __BUILD_CLUSTER_ARN__ is substituted by the Job. It is deliberately not a chart value:
-# nothing that renders this chart knows the ARN, and constructing it from stackName here
-# would put a build-cluster reference back into render-time input, which is what D13
-# forbids. The Job reads it from the CR status, where the read doubles as proof the cluster
-# exists and is reconciled.
+# __BUILD_CLUSTER_ARN__ is substituted by the Job. Deliberately not a chart value: nothing
+# that renders this chart knows the ARN, and constructing it from stackName would put a
+# build-cluster reference back into render-time input. The Job reads it from the CR status,
+# where the read doubles as proof the cluster exists and is reconciled.
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -78,20 +72,9 @@ data:
         # namespaces itself, here or on the hub.
         - CreateNamespace=false
 
-        # CUT OVER. The prow-build-cluster-resources Kustomization is suspended in git, so
-        # kustomize-controller no longer remote-applies the 13 objects and this Application owns
-        # them alone.
-        #
-        # Note how this change reaches the Application: editing it here is drift on the
-        # build-cluster-resources-application ConfigMap, which is a TRACKED object of this chart, so
-        # Argo CD syncs it, which re-runs the PostSync Job, which applies the updated Application.
-        # That is exactly why the manifest lives in a tracked ConfigMap rather than in the Job's
-        # shell - a chart of nothing but hooks could not have delivered this.
-        #
-        # prune and selfHeal stay false, as everywhere else. prune because Argo CD deleting whatever
-        # its rendered set does not contain is the failure this migration was shaped to avoid, and
-        # selfHeal because these 13 objects have no AWS resource behind them but do sit on a remote
-        # cluster, where reasserting desired state during a diagnosis is unhelpful.
+        # prune false because Argo CD deleting whatever its rendered set does not contain is
+        # the failure mode this whole layout avoids. selfHeal false because these objects sit
+        # on a remote cluster, where reasserting desired state mid-diagnosis is unhelpful.
         automated:
           prune: false
           selfHeal: false

--- a/flux/prow/charts/prow-build-cluster-connection/templates/job.yaml
+++ b/flux/prow/charts/prow-build-cluster-connection/templates/job.yaml
@@ -1,13 +1,13 @@
 {{- $prowImagesRepoUri := required "prowImagesRepoUri is required" .Values.prowImagesRepoUri }}
 {{- $stackName := required "stackName is required" .Values.stackName }}
-# Reads the build cluster's endpoint, CA and ARN from the build-cluster Cluster CR's
-# status, then assembles the kubeconfig Prow mounts, registers the cluster as an Argo CD
-# spoke, authorises it in the AppProject and applies its Application.
+# Reads the build cluster's endpoint, CA and ARN from the build-cluster Cluster CR's status,
+# then assembles the kubeconfig Prow mounts, registers the cluster as an Argo CD spoke,
+# authorises it in the AppProject and applies its Application.
 #
-# Why a Job (not static manifests): the build cluster is created by ACK, not Terraform, so
-# none of these values are in self-managed-vars at bootstrap. Reading the CR status means a
-# cluster re-creation - the only event that changes them - is picked up automatically.
-# Runs on every reconcile as a Helm hook.
+# A Job rather than static manifests because the build cluster is created by ACK, so none of
+# these values are knowable at bootstrap. Reading the CR status means a cluster re-creation -
+# the only event that changes them - is picked up automatically. Runs on every reconcile as a
+# Helm hook.
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -16,14 +16,13 @@ metadata:
   annotations:
     # Run as a Helm hook, not as a tracked release object.
     #
-    # A Job's spec.template is immutable, and upgrade.force does NOT get around
-    # that: Helm's force performs a replace (PUT), which the API server still
-    # rejects with "field is immutable". Flux's Kustomization force: true worked
-    # because kustomize-controller deletes and recreates on that error. Only
-    # delete-then-create works, which is exactly what before-hook-creation does.
+    # A Job's spec.template is immutable, and upgrade.force does NOT get around that:
+    # Helm's force performs a replace (PUT), which the API server still rejects with
+    # "field is immutable". Only delete-then-create works, which is what
+    # before-hook-creation does.
     #
-    # post-install and post-upgrade so the ServiceAccount and RBAC in this chart
-    # are applied before the Job runs.
+    # post-install and post-upgrade so this chart's ServiceAccount and RBAC are applied
+    # before the Job runs.
     helm.sh/hook: post-install,post-upgrade
     helm.sh/hook-delete-policy: before-hook-creation
 spec:
@@ -35,8 +34,8 @@ spec:
       restartPolicy: Never
       containers:
       - name: surface-connection
-        # Not in the generator's output set, so `make prow-gen` will never bump
-        # this. Keep in sync with `kubectl` in prow/jobs/images_config.yaml.
+        # Not in the generator's output set, so `make prow-gen` will never bump this. Keep
+        # in sync with `kubectl` in prow/jobs/images_config.yaml.
         image: "{{ $prowImagesRepoUri }}:prow-kubectl-0.0.3"
         command:
         - /bin/bash
@@ -61,19 +60,15 @@ spec:
           echo "  endpoint: $EP"
           echo "  ca: ${CA:0:40}...(truncated)"
 
-          # Assemble the kubeconfig the four components mount, here rather than in
-          # the prow chart.
+          # Assemble the kubeconfig the four components mount, here rather than in the prow
+          # chart. Both values are discovered at RUNTIME from the Cluster CR, and Argo CD
+          # renders off-cluster with no API access - valuesFrom a ConfigMap does not exist
+          # (argo-cd#12060) and Helm's lookup returns empty there. Writing the finished
+          # ConfigMap from the Job that already holds the values removes the render-time
+          # dependency entirely.
           #
-          # Both values are discovered at RUNTIME from the Cluster CR, but the chart
-          # consumed them at RENDER time via Flux postBuild substitution. Argo CD
-          # renders off-cluster with no API access, so it has no equivalent:
-          # valuesFrom a ConfigMap does not exist (argo-cd#12060) and Helm's lookup
-          # returns empty there. Writing the finished ConfigMap from the Job that
-          # already holds the values removes the render-time dependency and behaves
-          # identically under either reconciler.
-          #
-          # Written with a heredoc into a file rather than inline YAML so the
-          # kubeconfig's own indentation is not sensitive to this script's.
+          # Heredoc into a file rather than inline YAML so the kubeconfig's own indentation
+          # is not sensitive to this script's.
           BUILD_CTX="build"
           BUILD_CLUSTER_NAME="{{ $stackName }}-build-cluster"
 
@@ -103,9 +98,9 @@ spec:
                 - ${BUILD_CLUSTER_NAME}
           KCFG
 
-          # resource-policy: keep so that when the chart stops rendering this object
-          # Helm treats it as removed-from-manifest without deleting it. The four
-          # components mount it as a volume and will not start without it.
+          # resource-policy: keep so that if the chart stops rendering this object it is
+          # treated as removed-from-manifest without being deleted. The four components
+          # mount it as a volume and will not start without it.
           kubectl create configmap build-cluster-kubeconfig -n prow \
             --from-file=config=/tmp/kubeconfig \
             --dry-run=client -o yaml \
@@ -117,27 +112,23 @@ spec:
 
           echo "build-cluster-kubeconfig ConfigMap updated."
 
-          # Register the build cluster as an Argo CD spoke.
-          #
-          # Argo CD discovers target clusters from labelled Secrets in its own namespace.
-          # This one is written at runtime, not by Terraform: the build cluster is an ACK
-          # Cluster CR, so a Terraform-owned registration keyed to it would be created
-          # before the cluster exists on a fresh bootstrap, and removed while Applications
-          # still reference it on destroy (D13).
+          # Register the build cluster as an Argo CD spoke, which Argo CD discovers from
+          # labelled Secrets in its own namespace. Written at runtime because a
+          # Terraform-owned registration keyed to an ACK-created cluster would be created
+          # before the cluster exists and removed while Applications still reference it.
           #
           # server MUST be the cluster ARN. API server URLs are not accepted by the managed
-          # capability, and a URL would also fail to match the AppProject destination -
-          # which rejects the Application outright rather than failing at sync.
+          # capability, and a URL would also fail to match the AppProject destination, which
+          # rejects the Application outright rather than failing at sync.
           #
-          # Read from the CR status rather than built from stackName, even though the ARN
-          # is deterministic: reading it proves the cluster exists and is reconciled before
-          # anything is registered. Registering a spoke Argo CD cannot reach is worse than
-          # not registering one.
+          # Read from the CR status rather than built from stackName, even though the ARN is
+          # deterministic: reading it proves the cluster exists and is reconciled first.
+          # Registering a spoke Argo CD cannot reach is worse than not registering one.
           #
-          # No credentials are stored. The capability authenticates as its own role, which
-          # holds a cluster-admin access entry on the build cluster
-          # (argocd-build-cluster-access, in the ack-build-infra chart). Without that entry
-          # this Secret would register an unreachable cluster.
+          # No credentials stored. The capability authenticates as its own role, which holds
+          # a cluster-admin access entry on the build cluster (argocd-build-cluster-access,
+          # in the ack-build-infra chart). Without that entry this registers an unreachable
+          # cluster.
           ARN=$(kubectl -n "$CR_NS" get cluster.eks.services.k8s.aws "$CR" \
                   -o jsonpath='{.status.ackResourceMetadata.arn}')
           if [ -z "$ARN" ]; then
@@ -155,19 +146,16 @@ spec:
             | kubectl apply -f -
           echo "build cluster registered as an Argo CD spoke."
 
-          # Authorise the spoke in the AppProject.
+          # Authorise the spoke in the AppProject. Registration alone is not enough: an
+          # Application whose destination.server is not listed in its project's destinations
+          # is REJECTED outright rather than failing at sync.
           #
-          # Registration alone is not enough: an Application whose destination.server is
-          # not listed in its project's destinations is REJECTED outright, rather than
-          # failing at sync, which is a confusing way to discover the omission.
+          # Runtime for the same reason as the registration. Terraform declares only the hub
+          # destination and marks spec.destinations in computed_fields so it does not
+          # reconcile this away - see bootstrap/argocd-access.tf.
           #
-          # Runtime, like the registration and for the same reason - a destination naming
-          # the build cluster is keyed to a cluster ACK owns, so Terraform must not hold
-          # it (D13). Terraform declares the hub destination and carries
-          # ignore_changes on the list so it does not revert this.
-          #
-          # Idempotent because this hook runs on every sync: the destination is appended
-          # only when absent. A blind `add` would grow the list without bound.
+          # Idempotent because this hook runs on every sync: the destination is appended only
+          # when absent. A blind `add` would grow the list without bound.
           PROJECT="test-infra"
           if kubectl -n argocd get appproject "$PROJECT" \
                -o jsonpath='{.spec.destinations[*].server}' | grep -qF "$ARN"; then
@@ -179,21 +167,13 @@ spec:
             echo "AppProject $PROJECT updated."
           fi
 
-          # Apply the prow-build-cluster-resources Application.
+          # Apply the prow-build-cluster-resources Application. The manifest is composed by
+          # the chart and mounted from the build-cluster-resources-application ConfigMap; only
+          # the ARN placeholder is filled in here.
           #
-          # Third and last of the build-cluster-keyed objects this Job owns, for the same
-          # reason as the other two: its destination names a cluster ACK creates, so
-          # Terraform must not declare it (D13). Terraform supplies the values; the ARN,
-          # the one thing it cannot know, is substituted here.
-          #
-          # The manifest itself is composed by the chart and mounted from the
-          # build-cluster-resources-application ConfigMap - see templates/application.yaml
-          # for why it is not a heredoc here. Only the ARN placeholder is filled in.
-          #
-          # Ordering matters and is why this is last: an Application whose
-          # destination.server is absent from its project's destinations is rejected
-          # outright, so the registration and the AppProject patch above must both have
-          # happened first.
+          # Last on purpose: an Application whose destination.server is absent from its
+          # project's destinations is rejected outright, so the registration and the
+          # AppProject patch above must both have happened first.
           echo "Applying the prow-build-cluster-resources Application..."
           sed "s|__BUILD_CLUSTER_ARN__|${ARN}|" /etc/application/application.yaml \
             | kubectl apply -f -
@@ -204,27 +184,23 @@ spec:
             memory: "128Mi"
           limits:
             cpu: "200m"
-            # 128Mi was not enough and the failure mode was opaque: the pod was OOMKilled three
-            # times in a row, which Argo CD surfaces only as a PostSync hook stuck in Running.
-            #
-            # This script's steps are kubectl PIPELINES - `kubectl create ... | kubectl label
-            # --local | kubectl apply -f -` runs three Go binaries concurrently, each tens of MB,
-            # and the script has four such steps. Peak is concurrent, not
-            # sequential, so the ceiling has to clear several kubectl processes at once.
+            # 128Mi was not enough, and the failure mode was opaque: the pod was OOMKilled
+            # three times in a row, which Argo CD surfaces only as a PostSync hook stuck in
+            # Running. The steps above are kubectl PIPELINES, each running several Go
+            # binaries concurrently, so peak is concurrent rather than sequential.
             memory: "512Mi"
         volumeMounts:
         - name: application
           mountPath: /etc/application
           readOnly: true
       volumes:
-      # The composed Application manifest. A mount rather than a `kubectl get -o jsonpath`
-      # read, so the manifest reaches the container exactly as the chart rendered it with
-      # no shell quoting in the path.
+      # The composed Application manifest, mounted rather than read with `kubectl get -o
+      # jsonpath` so it reaches the container exactly as the chart rendered it, with no shell
+      # quoting in the path.
       #
-      # This ConfigMap is a normal tracked object of the chart, not a hook, so both
-      # reconcilers have it in place before the hook runs: Helm applies release resources
-      # before post-install/post-upgrade hooks, and Argo CD applies the sync wave before
-      # PostSync.
+      # This ConfigMap is a normal tracked object rather than a hook, so both reconcilers have
+      # it in place before the hook runs: Helm applies release resources before
+      # post-install/post-upgrade hooks, and Argo CD applies the sync wave before PostSync.
       - name: application
         configMap:
           name: build-cluster-resources-application

--- a/flux/prow/charts/prow-build-cluster-connection/templates/rbac.yaml
+++ b/flux/prow/charts/prow-build-cluster-connection/templates/rbac.yaml
@@ -1,32 +1,17 @@
 # RBAC for the build-cluster-connection Job (job.yaml).
 #
-# The Job reads the build cluster's endpoint, CA and ARN from the ACK Cluster CR's status
-# and does three things with them: assembles the build-cluster-kubeconfig ConfigMap in
-# `prow` that the four components mount, registers the cluster as an Argo CD spoke, and
-# applies the prow-build-cluster-resources Application.
+# The Job reads the build cluster's endpoint, CA and ARN from the ACK Cluster CR's status and
+# does three things: assembles the build-cluster-kubeconfig ConfigMap in `prow` that four
+# Prow components mount, registers the cluster as an Argo CD spoke, and applies the
+# prow-build-cluster-resources Application.
 #
-# NOTHING HERE IS FLUX WIRING, which is worth stating because the chart began life in
-# flux-system and that is easy to misread. Flux's own route to the build cluster was
-# kustomize-controller remote-applying through build-cluster-flux-kubeconfig, a different
-# ConfigMap from a different chart (prow-build-cluster-kubeconfig), and it went with Flux.
-# Of the three things above, two exist only BECAUSE of Argo CD, and the kubeconfig is a
-# Prow requirement under either reconciler.
+# The home namespace is .Release.Namespace, not a literal - Argo CD places this in
+# ack-system, next to the Cluster CR the Job reads. The ack-system, prow and argocd
+# references below stay literal, because those are where the TARGET objects live.
 #
-# The chart previously also wrote a build-cluster-connection ConfigMap in its own
-# namespace, for prow-charts to substitute BUILD_CLUSTER_ENDPOINT / BUILD_CLUSTER_CA from
-# at render time. Argo CD cannot substitute, so the Job assembles the finished kubeconfig
-# instead and that ConfigMap has no reader - `flux/prow.yaml` records the substitution being
-# removed. It and its Role are gone.
-#
-# The home namespace is .Release.Namespace, not a literal: Argo CD places this in
-# ack-system, next to the Cluster CR the Job reads, while environments still on Flux get
-# flux-system from their HelmRelease's targetNamespace. The ack-system, prow and argocd
-# references below stay literal - those are where the TARGET objects live, not where this
-# chart is installed.
-#
-# Least privilege: read the one Cluster CR in ack-system, write one ConfigMap in prow, and
-# in argocd write the registration Secret, patch the AppProject and apply one Application.
-# No AWS/IAM credentials - the values live in the CR status.
+# Least privilege: read the one Cluster CR in ack-system, write one ConfigMap in prow, and in
+# argocd write the registration Secret, patch the AppProject and apply one Application. No
+# AWS credentials - the values come from the CR status.
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -85,20 +70,14 @@ subjects:
   name: build-cluster-connection
   namespace: {{ .Release.Namespace }}
 ---
-# Register the build cluster as an Argo CD spoke by writing a labelled cluster Secret in
-# the argocd namespace. Scoped to secrets in argocd only.
+# Register the build cluster as an Argo CD spoke by writing a labelled cluster Secret in the
+# argocd namespace. Scoped to secrets in argocd only. Runtime work rather than Terraform's,
+# because a registration keyed to an ACK-owned cluster would be created before the cluster
+# existed and removed while Applications still referenced it.
 #
-# This has to happen at runtime rather than in Terraform. The build cluster is an ACK
-# Cluster CR, so Terraform owning a registration keyed to it recreates the coupling D13
-# had to unpick: on a fresh bootstrap Terraform would register a destination before the
-# cluster existed, and on destroy it would remove the registration while Applications
-# still referenced it. The Job already reads that CR, so it is the natural place.
-#
-# Argo CD can only apply this Role because bootstrap/argocd-rbac.tf grants the
-# capability the same permission in this namespace. argocd is the one namespace the
-# associated access policies leave uncovered - AmazonEKSAdminPolicy excludes it, and
-# AmazonEKSArgoCDPolicy is the capability's own-operation grant. Without that grantor rule
-# escalation prevention refuses this object.
+# Argo CD can only apply this Role because bootstrap/argocd-rbac.tf grants the capability the
+# same permission here. argocd is the one namespace the associated access policies leave
+# uncovered, so without that grantor rule escalation prevention refuses this object.
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
@@ -108,23 +87,19 @@ rules:
 - apiGroups: [""]
   resources: ["secrets"]
   verbs: ["get", "create", "update", "patch"]
-# Append the spoke to the AppProject's destinations. get and patch only: Terraform creates
-# and owns the AppProject, and the Job amends one field. Without the destination an
-# Application targeting the build cluster is rejected outright rather than failing at sync.
+# Append the spoke to the AppProject's destinations. get and patch only: Terraform owns the
+# AppProject and the Job amends one field. Without the destination an Application targeting
+# the build cluster is rejected outright rather than failing at sync.
 - apiGroups: ["argoproj.io"]
   resources: ["appprojects"]
   verbs: ["get", "patch"]
-# Apply the prow-build-cluster-resources Application, whose destination is the build cluster
-# and which Terraform therefore must not declare (D13). Unlike appprojects this needs
-# create: the Job owns the object outright rather than amending one Terraform owns.
+# Apply the prow-build-cluster-resources Application. Needs create, unlike appprojects,
+# because the Job owns that object outright. update as well as patch because `kubectl apply`
+# sends a PATCH to an existing object but falls back to a PUT when it must replace one, and a
+# hook that failed halfway should not need a different verb to recover.
 #
-# update as well as patch because `kubectl apply` sends a PATCH to an existing object but
-# falls back to a PUT when it has to replace one, and a hook that failed halfway should not
-# need a different verb to recover. Matches the get,create,update,patch the secrets and
-# configmaps rules use.
-#
-# Scoped to applications in this namespace only - not applicationsets, not delete. Nothing
-# here can remove an Application, so a misfiring hook cannot take one out.
+# Scoped to applications in this namespace only - not applicationsets, and no delete, so a
+# misfiring hook cannot remove an Application.
 - apiGroups: ["argoproj.io"]
   resources: ["applications"]
   verbs: ["get", "create", "update", "patch"]

--- a/flux/prow/charts/prow-build-cluster-connection/values.yaml
+++ b/flux/prow/charts/prow-build-cluster-connection/values.yaml
@@ -1,26 +1,17 @@
-# Supplied by the Argo CD Application as helm parameters, from Terraform. Left empty rather than
-# defaulted so a missing value fails at render time via `required`.
+# Supplied by the Argo CD Application as helm parameters, from Terraform. Left empty rather
+# than defaulted so a missing value fails at render time via `required`.
 prowImagesRepoUri: ""
 # Used to build the aws-iam-authenticator cluster id in the assembled kubeconfig.
 stackName: ""
 
-# The rest exist so this chart can compose the prow-build-cluster-resources Application
-# (templates/application.yaml). That Application's destination is the build cluster, so
-# Terraform must not declare it (D13) - but everything about it except the cluster ARN is
-# static or Terraform-known, and the ARN is what the Job reads from the CR status.
-#
-# Repo coordinates for the composed Application's source. Terraform already uses the same
-# three for every Application it declares and for the AppProject's sourceRepos; these are
-# the same values arriving by the route a runtime owner can reach.
+# Repo coordinates for the prow-build-cluster-resources Application this chart composes
+# (templates/application.yaml). Everything about that Application except the cluster ARN is
+# static or Terraform-known; the ARN is what the Job reads from the CR status.
 testInfraOrg: ""
 testInfraRepo: ""
 testInfraBranch: ""
 
-# The CONTENT of prow/jobs/test_config.yaml, passed through to the composed Application as
-# a Helm value so the build cluster's test-config ConfigMap is rendered from the same file
-# the hub's is generated from.
-#
-# It has to travel as content rather than a path because the consuming chart cannot read
-# the file: the directory it replaces used a `../../../` configMapGenerator reference,
-# which only kustomize-controller permits, and Helm's .Files.Get is chart-rooted.
+# The CONTENT of prow/jobs/test_config.yaml, so the build cluster's test-config ConfigMap is
+# rendered from the same file the hub's is. Content rather than a path because the consuming
+# chart cannot read the file - Helm's .Files.Get is chart-rooted.
 testConfig: ""


### PR DESCRIPTION
Removes every reference to `docs/argocd-migration.md`, which is not in this repo, and trims the comments that grew during the Flux to Argo CD migration.

## Why

The repo referenced that document **32 times** — 8 by path, and 24 more by the decision IDs it defined (`D13` alone appeared 19 times). None resolved, because the migration docs were never merged. Removing only the paths would have left 24 bare `D13` citations pointing at nothing, so both are gone: each rule is now stated where it is relied on.

The comments were also carrying migration narrative that has outlived its usefulness — how each problem was discovered, which alternatives were rejected, tool output captured at the time. Four files were over 55% comments.

## What was kept

The operative facts, compressed. Anything that stops someone reintroducing a bug stays, in particular:

- **`argocd-access.tf`** — that `aws_eks_access_policy_association` is keyed by (cluster, principal, policy) with no namespace component, so a `for_each` over namespaces silently leaves most ungranted; that `AmazonEKSBlockStorageClusterPolicy` and `AmazonEKSComputeClusterPolicy` cannot be associated at all and declaring either breaks every apply; that associating `AmazonEKSAdminPolicy` at cluster scope silently replaces the namespace-scoped association; and why `ignore_changes` does not work on `spec.destinations` where `computed_fields` does.
- **`argocd-rbac.tf`** — that escalation prevention resolves in-cluster RBAC only, which is the entire reason the file exists; that `kubectl auth can-i --as-group=` reports `no` for anything granted by an access policy and must not be read as a gap; the two deliberate privilege expansions and **both exit conditions** for narrowing them.
- **`argocd-logs.tf`** — that delivery sources must be created serially with a settling delay, because `PutDeliverySource` modifies the capability and a `for_each` mostly fails with `ConflictException`.
- **`applications/values.yaml`** — that `chartValues` entries must be strings; that the ProwJob CRD's apply mode is pinned on the manifest because it is 667 KB and client-side apply exceeds the annotation limit; why `selfHeal` is load-bearing on `prow-jobs` and the connection chart.
- **the connection chart** — why the Application manifest lives in a tracked ConfigMap rather than a heredoc, why a Job's `spec.template` immutability means only delete-then-create works, and why the spoke ARN is read from the CR status rather than composed.

## Stale comments corrected

Trimming surfaced comments that had become wrong rather than merely verbose:

- `job.yaml` stated that Terraform "carries `ignore_changes` on the list" for the AppProject destinations. That mechanism was replaced by `computed_fields`, and the comment now describes what the code actually does.
- References to `self-managed-vars`, the `ack-flux` Application entry, the `prow-build-cluster-kubeconfig` chart, `flux/prow/version/`, and "environments still on Flux" — all removed with Flux.
- `access-entries.yaml` described a Flux access entry that no longer exists, and cited `flux/prow/build-cluster-resources`, a path replaced by a chart.
- `values.yaml` credited `ack-pod-identities` with creating the prow and test-pods namespaces, which the `prow-namespaces` path now owns.

## Verification

- **No functional line changed.** Verified per file by stripping comments and blank lines from both sides and diffing: identical for all 11 code files. The only three non-comment edits are intentional and visible in the diff — one `fail` message and two lines of README prose.
- **Rendered output is unchanged.** The Helm templates emit their `#` comments, so raw output differs; with comments stripped, the connection chart (9 objects) and `ack-build-infra` (21 objects) render byte-identically, and their kind/namespace/name sets match. The app-of-apps output is byte-identical even before stripping.
- `terraform fmt -check -recursive` clean; `terraform validate` passes for `bootstrap/` and `bootstrap/identity/`.
- Zero remaining references to the doc, its decision IDs, or "the migration doc" as prose.

Net: 3020 lines to 2530, and 1318 comment lines to 836 — 36% of the comments removed.
