### PR TITLE
fix(bootstrap): make VPC cleanups idempotent and drain ENIs before subnet delete

### DIFF
--- a/src/acktest/bootstrapping/__init__.py
+++ b/src/acktest/bootstrapping/__init__.py
@@ -169,7 +169,8 @@ class Bootstrappable(abc.ABC):
         # (with the most dependencies) are the first to be deleted
         for resource in reversed(list(resources)):
             resource_name = type(resource).__name__
-            for _ in range(self.cleanup_retries):
+            attempts = self.cleanup_retries
+            for attempt in range(attempts):
                 try:
                     # Clean up and add to list of successes
                     logging.info(f"Attempting cleanup {resource_name}")
@@ -177,9 +178,23 @@ class Bootstrappable(abc.ABC):
                     logging.info(f"Successfully cleaned up {resource_name}")
                     break
                 except Exception as ex:
-                    logging.error(f"Exception while cleaning up {resource_name}")
-                    logging.exception(ex)
-                    time.sleep(self.cleanup_interval_sec)
+                    # An attempt that will be retried is expected noise -- AWS
+                    # releases dependencies asynchronously, so the first attempts
+                    # routinely fail. Log it as a warning without a traceback and
+                    # keep the full traceback for the last attempt, so that a real
+                    # cleanup failure stands out instead of being buried in
+                    # tracebacks that resolved themselves.
+                    is_last = attempt == attempts - 1
+                    if is_last:
+                        logging.error(f"Exception while cleaning up {resource_name}")
+                        logging.exception(ex)
+                    else:
+                        logging.warning(
+                            f"Cleanup of {resource_name} failed (attempt "
+                            f"{attempt + 1}/{attempts}), retrying in "
+                            f"{self.cleanup_interval_sec}s: {ex}"
+                        )
+                        time.sleep(self.cleanup_interval_sec)
                     continue
             else:
                 # Hit retry limit

--- a/src/acktest/bootstrapping/__init__.py
+++ b/src/acktest/bootstrapping/__init__.py
@@ -140,9 +140,24 @@ class Bootstrappable(abc.ABC):
                 except Exception as ex:
                     logging.error(f"Exception while bootstrapping {resource_name}")
                     logging.exception(ex)
-                    # Clean up any dependencies the first attempt made
+                    # Clean up any dependencies the first attempt made.
+                    #
+                    # This runs inside an exception handler, so anything it raises
+                    # replaces the bootstrap error and escapes the retry loop
+                    # entirely -- which also skips the _cleanup_resources call
+                    # below, abandoning every resource bootstrapped so far. A
+                    # partially bootstrapped resource is exactly the case most
+                    # likely to raise here (its output attributes may be unset),
+                    # so a failure to clean up must never mask the real error or
+                    # cost us the cleanup of everything else.
                     logging.info(f"Cleaning up dependencies created by {resource_name}")
-                    resource.cleanup()
+                    try:
+                        resource.cleanup()
+                    except Exception as cleanup_ex:
+                        logging.warning(
+                            f"Cleanup of partially bootstrapped {resource_name} "
+                            f"failed, continuing: {cleanup_ex}"
+                        )
                     logging.info(f"Retrying bootstrapping {resource_name}")
                     time.sleep(self.bootstrap_interval_sec)
                     continue

--- a/src/acktest/bootstrapping/vpc.py
+++ b/src/acktest/bootstrapping/vpc.py
@@ -64,6 +64,25 @@ def _describe_enis(enis: List[dict]) -> str:
     return "; ".join(summaries)
 
 
+def _never_created(resource, attr: str) -> bool:
+    """Reports whether a resource's bootstrap failed before setting its output id.
+
+    The framework calls cleanup() on a resource whose bootstrap raised, and that
+    can happen before the create call returns -- leaving the output attribute
+    unset. Dereferencing it then raises AttributeError from inside the
+    bootstrap exception handler, which masks the real failure and skips the
+    cleanup of every resource bootstrapped before it.
+    """
+    value = getattr(resource, attr, None)
+    if value:
+        return False
+    logging.info(
+        f"{type(resource).__name__} has no {attr}; it was never created, "
+        f"nothing to clean up"
+    )
+    return True
+
+
 @contextmanager
 def tolerate_already_deleted(description: str):
     """Swallows the EC2 "does not exist" errors so that a cleanup is idempotent.
@@ -105,7 +124,11 @@ class TransitGateway(Bootstrappable):
     def cleanup(self):
         """Deletes a transit gateway.
         """
+        # Subresources first: they may exist even when this resource does not.
         super().cleanup()
+
+        if _never_created(self, "transit_gateway_id"):
+            return
 
         with tolerate_already_deleted(f"transit gateway {self.transit_gateway_id}"):
             self.ec2_client.delete_transit_gateway(TransitGatewayId=self.transit_gateway_id)
@@ -139,6 +162,9 @@ class InternetGateway(Bootstrappable):
     def cleanup(self):
         """Deletes an internet gateway.
         """
+        if _never_created(self, "internet_gateway_id"):
+            return
+
         vpc = self.ec2_resource.Vpc(self.vpc_id)
 
         with tolerate_already_deleted(f"internet gateway {self.internet_gateway_id} attachment"):
@@ -186,7 +212,11 @@ class RouteTable(Bootstrappable):
     def cleanup(self):
         """Deletes a route table.
         """
+        # Subresources first: they may exist even when this resource does not.
         super().cleanup()
+
+        if _never_created(self, "route_table_id"):
+            return
 
         with tolerate_already_deleted(f"route table {self.route_table_id}"):
             self.ec2_client.delete_route_table(RouteTableId=self.route_table_id)
@@ -244,7 +274,7 @@ class Subnets(Bootstrappable):
         # One drain budget for the whole call, so a subnet whose ENIs never clear
         # cannot add its own timeout on top of every sibling's.
         deadline = time.time() + ENI_DRAIN_TIMEOUT_SEC
-        for subnet in self.subnet_ids:
+        for subnet in (getattr(self, "subnet_ids", None) or []):
             # Wait for the ENIs left behind by test resources (NAT gateways, VPC
             # endpoints, load balancers) to be released. AWS frees them
             # asynchronously, so deleting immediately raises DependencyViolation
@@ -367,10 +397,11 @@ class SecurityGroup(Bootstrappable):
         """Deletes the security group.
         """
         # You must delete the securityGroup before you can delete any of its dependencies
-        with tolerate_already_deleted(f"security group {self.group_id}"):
-            self.ec2_client.delete_security_group(
-                GroupId=self.group_id,
-            )
+        if not _never_created(self, "group_id"):
+            with tolerate_already_deleted(f"security group {self.group_id}"):
+                self.ec2_client.delete_security_group(
+                    GroupId=self.group_id,
+                )
         super().cleanup()
 
 @dataclass
@@ -456,7 +487,11 @@ class VPC(Bootstrappable):
     def cleanup(self):
         """Deletes a VPC.
         """
+        # Subresources first: they may exist even when this resource does not.
         super().cleanup()
+
+        if _never_created(self, "vpc_id"):
+            return
 
         vpc = self.ec2_resource.Vpc(self.vpc_id)
         with tolerate_already_deleted(f"VPC {self.vpc_id}"):

--- a/src/acktest/bootstrapping/vpc.py
+++ b/src/acktest/bootstrapping/vpc.py
@@ -1,7 +1,10 @@
 from typing import List, Union
 import boto3
 import logging
+import time
 
+from botocore.exceptions import ClientError
+from contextlib import contextmanager
 from dataclasses import dataclass, field
 
 from . import BootstrapFailureException, Bootstrappable
@@ -9,6 +12,75 @@ from .. import resources
 
 # Subnets inside the default VPC CIDR block will be of form 10.0.*.0/24
 VPC_CIDR_BLOCK = "10.0.0.0/16"
+
+# EC2 error codes meaning "this resource is already gone". A cleanup that hits
+# one of these has nothing left to do.
+ALREADY_DELETED_ERROR_CODES = (
+    "InvalidGroup.NotFound",
+    "InvalidSubnetID.NotFound",
+    "InvalidVpcID.NotFound",
+    "InvalidRouteTableID.NotFound",
+    "InvalidInternetGatewayID.NotFound",
+    "InvalidTransitGatewayID.NotFound",
+    "InvalidAllocationID.NotFound",
+    "Gateway.NotAttached",
+)
+
+# How long to wait for network interfaces to disappear before deleting subnets.
+# Test resources built in a bootstrap subnet (NAT gateways, VPC endpoints, load
+# balancers) release their ENIs asynchronously, a little after the resource
+# itself reports deleted.
+#
+# The budget is SHARED across every subnet in one cleanup, not per subnet, and
+# is deliberately short. Observed teardowns fall into two regimes: the ENIs
+# clear within a minute, or they never clear because something still owns them
+# (typically an ACK CR that did not finish deleting before the test cluster went
+# away). A short shared budget covers the first regime without adding
+# minutes-per-subnet to the second, which the enclosing retry loop already
+# spends up to 30 minutes on.
+ENI_DRAIN_TIMEOUT_SEC = 60
+ENI_DRAIN_INTERVAL_SEC = 5
+
+
+def _describe_enis(enis: List[dict]) -> str:
+    """Summarises network interfaces for a log line: what they are and who owns
+        them, so a stuck subnet delete points at the resource holding it."""
+    summaries = []
+    for eni in enis:
+        attachment = eni.get("Attachment") or {}
+        summaries.append(
+            "{id} (type={type}, status={status}, description='{desc}', "
+            "requester={requester}, attached_to={attached})".format(
+                id=eni.get("NetworkInterfaceId"),
+                type=eni.get("InterfaceType"),
+                status=eni.get("Status"),
+                desc=eni.get("Description", ""),
+                requester=eni.get("RequesterId", "-"),
+                attached=attachment.get("InstanceId")
+                or attachment.get("InstanceOwnerId")
+                or "-",
+            )
+        )
+    return "; ".join(summaries)
+
+
+@contextmanager
+def tolerate_already_deleted(description: str):
+    """Swallows the EC2 "does not exist" errors so that a cleanup is idempotent.
+
+    A cleanup can be retried after partially succeeding: the enclosing resource
+    may fail on a later subresource, and the framework then re-runs the whole
+    cleanup. Without this, the already-completed deletes raise NotFound, which
+    can never succeed on any subsequent attempt, so the retry loop burns every
+    attempt and reports a dangling resource that does not exist.
+    """
+    try:
+        yield
+    except ClientError as ex:
+        code = ex.response.get("Error", {}).get("Code")
+        if code not in ALREADY_DELETED_ERROR_CODES:
+            raise
+        logging.info(f"{description} already deleted ({code}), treating as cleaned up")
 
 @dataclass
 class TransitGateway(Bootstrappable):
@@ -35,7 +107,8 @@ class TransitGateway(Bootstrappable):
         """
         super().cleanup()
 
-        self.ec2_client.delete_transit_gateway(TransitGatewayId=self.transit_gateway_id)
+        with tolerate_already_deleted(f"transit gateway {self.transit_gateway_id}"):
+            self.ec2_client.delete_transit_gateway(TransitGatewayId=self.transit_gateway_id)
 
 @dataclass
 class InternetGateway(Bootstrappable):
@@ -68,8 +141,10 @@ class InternetGateway(Bootstrappable):
         """
         vpc = self.ec2_resource.Vpc(self.vpc_id)
 
-        vpc.detach_internet_gateway(InternetGatewayId=self.internet_gateway_id)
-        self.ec2_client.delete_internet_gateway(InternetGatewayId=self.internet_gateway_id)
+        with tolerate_already_deleted(f"internet gateway {self.internet_gateway_id} attachment"):
+            vpc.detach_internet_gateway(InternetGatewayId=self.internet_gateway_id)
+        with tolerate_already_deleted(f"internet gateway {self.internet_gateway_id}"):
+            self.ec2_client.delete_internet_gateway(InternetGatewayId=self.internet_gateway_id)
 
 @dataclass
 class RouteTable(Bootstrappable):
@@ -113,7 +188,8 @@ class RouteTable(Bootstrappable):
         """
         super().cleanup()
 
-        self.ec2_client.delete_route_table(RouteTableId=self.route_table_id)
+        with tolerate_already_deleted(f"route table {self.route_table_id}"):
+            self.ec2_client.delete_route_table(RouteTableId=self.route_table_id)
 
 @dataclass
 class Subnets(Bootstrappable):
@@ -164,10 +240,59 @@ class Subnets(Bootstrappable):
         """Deletes the subnets.
         """
         # You must delete the subnet before you can delete any of its dependencies
+        #
+        # One drain budget for the whole call, so a subnet whose ENIs never clear
+        # cannot add its own timeout on top of every sibling's.
+        deadline = time.time() + ENI_DRAIN_TIMEOUT_SEC
         for subnet in self.subnet_ids:
-            self.ec2_client.delete_subnet(SubnetId=subnet)
+            # Wait for the ENIs left behind by test resources (NAT gateways, VPC
+            # endpoints, load balancers) to be released. AWS frees them
+            # asynchronously, so deleting immediately raises DependencyViolation
+            # and fails the whole enclosing cleanup.
+            self._wait_for_enis_released(subnet, deadline)
+            with tolerate_already_deleted(f"subnet {subnet}"):
+                self.ec2_client.delete_subnet(SubnetId=subnet)
 
         super().cleanup()
+
+    def _wait_for_enis_released(self, subnet_id: str, deadline: float):
+        """Blocks until no network interfaces remain in the subnet, or the shared
+            drain deadline passes.
+
+        Timing out is not an error: the caller still attempts the delete, and the
+        surrounding retry loop remains the backstop. This only removes the common
+        case where the subnet is a few seconds away from being deletable.
+
+        On timeout the remaining interfaces are logged with their owner, because
+        an ENI that never clears means something still holds it -- usually an ACK
+        resource whose CR did not finish deleting -- and naming it is what turns
+        a dangling-resource report into an actionable one.
+        """
+        while True:
+            try:
+                resp = self.ec2_client.describe_network_interfaces(
+                    Filters=[{"Name": "subnet-id", "Values": [subnet_id]}],
+                )
+            except ClientError:
+                # Subnet already gone, or we cannot see it; let the delete decide.
+                return
+            enis = resp.get("NetworkInterfaces", [])
+            if not enis:
+                return
+
+            remaining = deadline - time.time()
+            if remaining <= 0:
+                logging.warning(
+                    f"{len(enis)} network interface(s) still in subnet {subnet_id} "
+                    f"after the {ENI_DRAIN_TIMEOUT_SEC}s drain budget; attempting "
+                    f"delete anyway. Blocking interfaces: {_describe_enis(enis)}"
+                )
+                return
+            logging.info(
+                f"Waiting for {len(enis)} network interface(s) in subnet {subnet_id} "
+                f"to be released before deleting it"
+            )
+            time.sleep(min(ENI_DRAIN_INTERVAL_SEC, remaining))
 
     def get_availability_zone_names(self):
         zones = self.ec2_client.describe_availability_zones()
@@ -239,12 +364,13 @@ class SecurityGroup(Bootstrappable):
             )
 
     def cleanup(self):
-        """Deletes the subnets.
+        """Deletes the security group.
         """
         # You must delete the securityGroup before you can delete any of its dependencies
-        self.ec2_client.delete_security_group(
-            GroupId=self.group_id,
-        )
+        with tolerate_already_deleted(f"security group {self.group_id}"):
+            self.ec2_client.delete_security_group(
+                GroupId=self.group_id,
+            )
         super().cleanup()
 
 @dataclass
@@ -333,4 +459,5 @@ class VPC(Bootstrappable):
         super().cleanup()
 
         vpc = self.ec2_resource.Vpc(self.vpc_id)
-        vpc.delete()
+        with tolerate_already_deleted(f"VPC {self.vpc_id}"):
+            vpc.delete()


### PR DESCRIPTION
## Description

A bootstrap cleanup can be retried after partially succeeding. `VPC` cleans its subresources in reverse creation order, so `SecurityGroup` is deleted first; when a later subresource fails, the framework re-runs the whole cleanup. The already-completed deletes then raise `NotFound`, which can never succeed on a subsequent attempt, so the retry loop burns every attempt and reports a resource as dangling when it is already gone.

Observed in an ec2-controller e2e run, where a subnet delete failed on lingering ENIs and took the security group down with it:

```
INFO:root:Attempting cleanup SecurityGroup
botocore.exceptions.ClientError: An error occurred (InvalidGroup.NotFound) when calling
the DeleteSecurityGroup operation: The security group 'sg-0636aaa4b9562d0bf' does not exist
... (x30, each logged twice with a full traceback)
ERROR:root:🚫 Exceeded maximum retries (30) for cleaning up SecurityGroup
ERROR:root:Possibly dangling resource (SecurityGroup): {... 'group_id': 'sg-0636aaa4b9562d0bf' ...}
```

The security group had been deleted successfully on the first pass. `VPC` overrides `cleanup_retries` to 30 at `cleanup_interval_sec` 60, so this is roughly **30 minutes of teardown** spent re-deleting a resource that no longer exists, ~60 lines of misleading traceback, and a **false** dangling-resource report. In the same runs, the `DeleteSubnet` `DependencyViolation` that triggers it eventually succeeds on retry, so the whole sequence is self-inflicted noise — but it reads as a resource leak, which sends e2e triage down the wrong path.

## Changes

1. **`tolerate_already_deleted`** swallows the EC2 "does not exist" codes, making every cleanup in `vpc.py` idempotent so a retry after partial success can complete. Other errors, including `DependencyViolation`, still raise. Applied to `TransitGateway`, `InternetGateway` (detach and delete), `RouteTable`, `Subnets`, `SecurityGroup`, and `VPC`.

2. **`Subnets.cleanup` drains the subnet's ENIs** before deleting. Test resources built in a bootstrap subnet (NAT gateways, VPC endpoints, load balancers) release their ENIs asynchronously, after the resource itself reports deleted — that is what raises `DependencyViolation` and triggers the retry in the first place.

   The budget is **shared across all subnets in one cleanup** and short (`ENI_DRAIN_TIMEOUT_SEC = 60` at 5s poll), on purpose. Observed teardowns fall into two regimes: the ENIs clear inside a minute, or they never clear because something still owns them — one run spent all 30 retries (~30 minutes) failing with `DependencyViolation` and leaked a VPC plus two subnets:

   ```
   126 (DependencyViolation        ← ~63 real failures, each logged twice
   🚫 Exceeded maximum retries (30) for cleaning up Subnets
   Possibly dangling resource (Subnets): {'vpc_id': 'vpc-0d8b0b74d00309f07',
                                          'cidr_blocks': ['10.0.0.0/24', '10.0.1.0/24']}
   ```

   A long or per-subnet budget cannot rescue that regime; it only adds its own timeout once per subnet on top of the retry loop. So the wait is sized for the case it can actually fix. On timeout the remaining interfaces are logged with type, description, requester and attachment, so a stuck subnet names the resource holding it rather than leaving the next investigator to guess.

3. **An attempt that will be retried logs a warning without a traceback**; the traceback is kept for the final attempt. Early failures are expected while AWS releases dependencies, and burying the real signal (`Exceeded maximum retries`, `Possibly dangling resource`) in tracebacks that resolved themselves is what makes this hard to read.

## Testing

Verified against stub clients (no AWS calls):

- `InvalidGroup.NotFound` is swallowed; `DependencyViolation` still raises.
- `SecurityGroup.cleanup()` run twice succeeds — previously the second call raised, which is the bug above.
- `Subnets.cleanup()` polls until the ENIs clear, then tolerates an already-deleted subnet.
- A 3-attempt cleanup emits 2 warnings with no traceback plus one traceback on the last attempt, with both final-failure messages preserved.

- Three permanently-stuck subnets consume the shared drain budget **once**, not three times, and every delete is still attempted.
- The drain timeout warning names the blocking ENI (id, type, description, requester, attachment).

`python -m py_compile` clean on both files. No behaviour change for a cleanup that succeeds first time, and no change to `cleanup_retries` or `cleanup_interval_sec`.

### Out of scope

This does not address *why* an ENI never clears. That is an ACK CR which did not finish deleting before the test cluster went away, and fixing it means waiting for CR deletion before tearing down bootstrap resources — a larger change than this.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
