### PR TITLE
Remove cli flags that require updated build-prow-images Docker image

### DIFF
--- a/prow/jobs/tools/cmd/build-prow-images.sh
+++ b/prow/jobs/tools/cmd/build-prow-images.sh
@@ -22,13 +22,8 @@ envsubst < ./prow/plugins/images_config.yaml > /tmp/plugins_images_config.yaml
 envsubst < ./prow/agent-workflows/images_config.yaml > /tmp/agent_workflows_images_config.yaml
 
 # Build Prow Jobs
-# --images-config-path is the RESOLVED config (real ECR URI) used for building
-# and pushing images. --images-generate-config-path is the RAW config so the
-# generated jobs.yaml / job-config-job.yaml keep ${PROW_IMAGES_REPO_URI},
-# matching what `make prow-gen` produces (avoids churn).
 BUILT_JOB_TAGS=$(ack-build-tools build-prow-images \
   --images-config-path /tmp/images_config.yaml \
-  --images-generate-config-path ./prow/jobs/images_config.yaml \
   --jobs-config-path ./prow/jobs/jobs_config.yaml \
   --jobs-templates-path ./prow/jobs/templates/ \
   --jobs-output-path ./prow/jobs/jobs.yaml \
@@ -40,10 +35,8 @@ if [ $? -ne 0 ]; then
 fi
 
 # Build Prow Agent Workflows
-# Resolved config for build/push, raw config for generation (keeps the variable).
 BUILT_AGENT_WORKFLOW_TAGS=$(ack-build-tools build-prow-agent-workflow-images \
   --images-config-path /tmp/agent_workflows_images_config.yaml \
-  --images-generate-config-path ./prow/agent-workflows/images_config.yaml \
   --prow-ecr-repository "$PROW_ECR_REPO_NAME" \
   --agent-workflows-templates-path ./prow/agent-workflows/templates \
   --agent-workflows-output-path ./prow/agent-workflows/agent-workflows.yaml)


### PR DESCRIPTION
Issue #, if available:

Description of changes:
#1017 added new cli flags for the build-prow-image go tool. However, before the cli flag can be used in the `build-prow-images` ProwJob it needs to build itself. This PR removes the flag to unblock that process as the CLI flags are unrecognized by the current version. Once the new version has been built the flags can be added back.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
