### PR TITLE
Enable images-generate-config-path flag in build-prow-images.sh

### DIFF
--- a/prow/jobs/images_config.yaml
+++ b/prow/jobs/images_config.yaml
@@ -1,18 +1,18 @@
 image_repo: ${PROW_IMAGES_REPO_URI}
 images:
-    auto-generate-controllers: prow-auto-generate-controllers-0.0.44
-    auto-update-controllers: prow-auto-update-controllers-0.0.35
+    auto-generate-controllers: prow-auto-generate-controllers-0.0.45
+    auto-update-controllers: prow-auto-update-controllers-0.0.36
     build-prow-images: prow-build-prow-images-0.0.73
-    controller-release-tag: prow-controller-release-tag-0.0.35
-    deploy: prow-deploy-0.0.46
-    deploy-docs: prow-deploy-docs-0.0.15
-    docs: prow-docs-0.0.40
-    integration-test: prow-integration-0.0.58
-    kubectl: prow-kubectl-0.0.3
-    olm-bundle-pr: prow-olm-bundle-pr-0.0.36
-    olm-test: prow-olm-test-0.0.35
-    scan-controllers-cve: prow-scan-controllers-cve-0.0.29
-    soak-test: prow-soak-0.0.34
-    unit-test: prow-unit-0.0.39
-    upgrade-go-version: prow-upgrade-go-version-0.0.37
-    verify-attribution: prow-verify-attribution-0.0.34
+    controller-release-tag: prow-controller-release-tag-0.0.36
+    deploy: prow-deploy-0.0.47
+    deploy-docs: prow-deploy-docs-0.0.16
+    docs: prow-docs-0.0.41
+    integration-test: prow-integration-0.0.59
+    kubectl: prow-kubectl-0.0.4
+    olm-bundle-pr: prow-olm-bundle-pr-0.0.37
+    olm-test: prow-olm-test-0.0.36
+    scan-controllers-cve: prow-scan-controllers-cve-0.0.30
+    soak-test: prow-soak-0.0.35
+    unit-test: prow-unit-0.0.40
+    upgrade-go-version: prow-upgrade-go-version-0.0.38
+    verify-attribution: prow-verify-attribution-0.0.35

--- a/prow/jobs/tools/cmd/build-prow-images.sh
+++ b/prow/jobs/tools/cmd/build-prow-images.sh
@@ -22,8 +22,13 @@ envsubst < ./prow/plugins/images_config.yaml > /tmp/plugins_images_config.yaml
 envsubst < ./prow/agent-workflows/images_config.yaml > /tmp/agent_workflows_images_config.yaml
 
 # Build Prow Jobs
+# --images-config-path is the RESOLVED config (real ECR URI) used for building
+# and pushing images. --images-generate-config-path is the RAW config so the
+# generated jobs.yaml / job-config-job.yaml keep ${PROW_IMAGES_REPO_URI},
+# matching what `make prow-gen` produces (avoids churn).
 BUILT_JOB_TAGS=$(ack-build-tools build-prow-images \
   --images-config-path /tmp/images_config.yaml \
+  --images-generate-config-path ./prow/jobs/images_config.yaml \
   --jobs-config-path ./prow/jobs/jobs_config.yaml \
   --jobs-templates-path ./prow/jobs/templates/ \
   --jobs-output-path ./prow/jobs/jobs.yaml \
@@ -35,8 +40,10 @@ if [ $? -ne 0 ]; then
 fi
 
 # Build Prow Agent Workflows
+# Resolved config for build/push, raw config for generation (keeps the variable).
 BUILT_AGENT_WORKFLOW_TAGS=$(ack-build-tools build-prow-agent-workflow-images \
   --images-config-path /tmp/agent_workflows_images_config.yaml \
+  --images-generate-config-path ./prow/agent-workflows/images_config.yaml \
   --prow-ecr-repository "$PROW_ECR_REPO_NAME" \
   --agent-workflows-templates-path ./prow/agent-workflows/templates \
   --agent-workflows-output-path ./prow/agent-workflows/agent-workflows.yaml)


### PR DESCRIPTION
Issue #, if available:

Description of changes:
PR enables `--images-generate-config-path` flag for build-prow-images.sh and re-triggers image build for ProwJobs

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
