### PR TITLE
Upgrade Prow to v20260908-104d452f4 and bump patch revision

### DIFF
--- a/flux/prow/charts/prow-mirror/values.yaml
+++ b/flux/prow/charts/prow-mirror/values.yaml
@@ -14,6 +14,6 @@ region: ""
 #
 # PROW_PATCH_REVISION is a monotonic counter appended to mirrored image tags and must
 # never be reset. PROW_VERSION and TOOLS_VERSION move independently but share it.
-prowVersion: "v20260702-fff8399c7"
-toolsVersion: "v20260515-778139c32d"
-prowPatchRevision: "1"
+prowVersion: "v20260908-104d452f4"
+toolsVersion: "v20260729-f66136c16c"
+prowPatchRevision: "2"

--- a/flux/prow/crds/prowjob_customresourcedefinition.yaml
+++ b/flux/prow/crds/prowjob_customresourcedefinition.yaml
@@ -4,12 +4,12 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     api-approved.kubernetes.io: https://github.com/kubernetes/test-infra/pull/8669
-    controller-gen.kubebuilder.io/version: v0.17.3
+    controller-gen.kubebuilder.io/version: v0.22.0
     # THE ONLY LOCAL EDIT TO THIS UPSTREAM FILE. scripts/upgrade-prow.sh regenerates it from
     # kubernetes/test-infra, so this line has to be re-added after an upgrade or Argo CD stops
     # being able to apply the CRD at all.
     #
-    # This manifest is 667 KB. Client-side apply stores the whole thing in
+    # This manifest is 704 KB. Client-side apply stores the whole thing in
     # kubectl.kubernetes.io/last-applied-configuration, which the API server rejects:
     #   metadata.annotations: Too long: may not be more than 262144 bytes
     # Reproduced outside Argo CD - `kubectl apply --dry-run=server` fails with exactly that,
@@ -339,7 +339,7 @@ spec:
                             description: |-
                               Claims lists the names of resources, defined in spec.resourceClaims,
                               that are used by this container.
-                              This is an alpha field and requires enabling the
+                              This field depends on the
                               DynamicResourceAllocation feature gate.
                               This field is immutable. It can only be set for containers.
                             items:
@@ -397,7 +397,7 @@ spec:
                             description: |-
                               Claims lists the names of resources, defined in spec.resourceClaims,
                               that are used by this container.
-                              This is an alpha field and requires enabling the
+                              This field depends on the
                               DynamicResourceAllocation feature gate.
                               This field is immutable. It can only be set for containers.
                             items:
@@ -455,7 +455,7 @@ spec:
                             description: |-
                               Claims lists the names of resources, defined in spec.resourceClaims,
                               that are used by this container.
-                              This is an alpha field and requires enabling the
+                              This field depends on the
                               DynamicResourceAllocation feature gate.
                               This field is immutable. It can only be set for containers.
                             items:
@@ -513,7 +513,7 @@ spec:
                             description: |-
                               Claims lists the names of resources, defined in spec.resourceClaims,
                               that are used by this container.
-                              This is an alpha field and requires enabling the
+                              This field depends on the
                               DynamicResourceAllocation feature gate.
                               This field is immutable. It can only be set for containers.
                             items:
@@ -1168,8 +1168,8 @@ spec:
                                   most preferred is the one with the greatest sum of weights, i.e.
                                   for each node that meets all of the scheduling requirements (resource
                                   request, requiredDuringScheduling anti-affinity expressions, etc.),
-                                  compute a sum by iterating through the elements of this field and adding
-                                  "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the
+                                  compute a sum by iterating through the elements of this field and subtracting
+                                  "weight" from the sum if the node has pods which matches the corresponding podAffinityTerm; the
                                   node(s) with the highest sum are the most preferred.
                                 items:
                                   description: The weights of all of the matched WeightedPodAffinityTerm
@@ -1538,9 +1538,10 @@ spec:
                             operator:
                               description: |-
                                 Operator represents a key's relationship to the value.
-                                Valid operators are Exists and Equal. Defaults to Equal.
+                                Valid operators are Exists, Equal, Lt, and Gt. Defaults to Equal.
                                 Exists is equivalent to wildcard for value, so that a pod can
                                 tolerate all taints of a particular category.
+                                Lt and Gt perform numeric comparisons (requires feature gate TaintTolerationComparisonOperators).
                               type: string
                             tolerationSeconds:
                               description: |-
@@ -2401,8 +2402,8 @@ spec:
                               most preferred is the one with the greatest sum of weights, i.e.
                               for each node that meets all of the scheduling requirements (resource
                               request, requiredDuringScheduling anti-affinity expressions, etc.),
-                              compute a sum by iterating through the elements of this field and adding
-                              "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the
+                              compute a sum by iterating through the elements of this field and subtracting
+                              "weight" from the sum if the node has pods which matches the corresponding podAffinityTerm; the
                               node(s) with the highest sum are the most preferred.
                             items:
                               description: The weights of all of the matched WeightedPodAffinityTerm
@@ -2798,8 +2799,9 @@ spec:
                               present in a Container.
                             properties:
                               name:
-                                description: Name of the environment variable. Must
-                                  be a C_IDENTIFIER.
+                                description: |-
+                                  Name of the environment variable.
+                                  May consist of any printable ASCII characters except '='.
                                 type: string
                               value:
                                 description: |-
@@ -2821,7 +2823,9 @@ spec:
                                     description: Selects a key of a ConfigMap.
                                     properties:
                                       key:
-                                        description: The key to select.
+                                        description: |-
+                                          The key to select from the ConfigMap's Data field.
+                                          Keys in the BinaryData field are not currently propagated to container env vars.
                                         type: string
                                       name:
                                         default: ""
@@ -2855,6 +2859,42 @@ spec:
                                         type: string
                                     required:
                                     - fieldPath
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  fileKeyRef:
+                                    description: |-
+                                      FileKeyRef selects a key of the env file.
+                                      Requires the EnvFiles feature gate to be enabled.
+                                    properties:
+                                      key:
+                                        description: |-
+                                          The key within the env file. An invalid key will prevent the pod from starting.
+                                          The keys defined within a source may consist of any printable ASCII characters except '='.
+                                          During Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.
+                                        type: string
+                                      optional:
+                                        default: false
+                                        description: |-
+                                          Specify whether the file or its key must be defined. If the file or key
+                                          does not exist, then the env var is not published.
+                                          If optional is set to true and the specified key does not exist,
+                                          the environment variable will not be set in the Pod's containers.
+                                          If optional is set to false and the specified key does not exist,
+                                          an error will be returned during Pod creation.
+                                        type: boolean
+                                      path:
+                                        description: |-
+                                          The path within the volume from which to select the file.
+                                          Must be relative and may not contain the '..' path or start with '..'.
+                                        type: string
+                                      volumeName:
+                                        description: The name of the volume mount
+                                          containing the env file.
+                                        type: string
+                                    required:
+                                    - key
+                                    - path
+                                    - volumeName
                                     type: object
                                     x-kubernetes-map-type: atomic
                                   resourceFieldRef:
@@ -2917,8 +2957,8 @@ spec:
                         envFrom:
                           description: |-
                             List of sources to populate environment variables in the container.
-                            The keys defined within a source must be a C_IDENTIFIER. All invalid keys
-                            will be reported as an event when the container is starting. When a key exists in multiple
+                            The keys defined within a source may consist of any printable ASCII characters except '='.
+                            When a key exists in multiple
                             sources, the value associated with the last source will take precedence.
                             Values defined by an Env with a duplicate key will take precedence.
                             Cannot be updated.
@@ -2945,8 +2985,9 @@ spec:
                                 type: object
                                 x-kubernetes-map-type: atomic
                               prefix:
-                                description: Optional text to prepend to the name
-                                  of each environment variable. Must be a C_IDENTIFIER.
+                                description: |-
+                                  Optional text to prepend to the name of each environment variable.
+                                  May consist of any printable ASCII characters except '='.
                                 type: string
                               secretRef:
                                 description: The Secret to select from
@@ -3054,6 +3095,11 @@ spec:
                                         Number must be in the range 1 to 65535.
                                         Name must be an IANA_SVC_NAME.
                                       x-kubernetes-int-or-string: true
+                                    protocol:
+                                      description: |-
+                                        Protocol selects the wire protocol for the probe connection.
+                                        Nil defaults to HTTP/1.1.
+                                      type: string
                                     scheme:
                                       description: |-
                                         Scheme to use for connecting to the host.
@@ -3167,6 +3213,11 @@ spec:
                                         Number must be in the range 1 to 65535.
                                         Name must be an IANA_SVC_NAME.
                                       x-kubernetes-int-or-string: true
+                                    protocol:
+                                      description: |-
+                                        Protocol selects the wire protocol for the probe connection.
+                                        Nil defaults to HTTP/1.1.
+                                      type: string
                                     scheme:
                                       description: |-
                                         Scheme to use for connecting to the host.
@@ -3249,6 +3300,13 @@ spec:
                             grpc:
                               description: GRPC specifies a GRPC HealthCheckRequest.
                               properties:
+                                mode:
+                                  description: |-
+                                    mode specifies the connection mode for the gRPC health probe.
+                                    Set to "TLS" to use TLS without certificate verification.
+                                    Set to "Plaintext" to use a plaintext (insecure) connection explicitly.
+                                    If not specified, the probe uses a plaintext (insecure) connection.
+                                  type: string
                                 port:
                                   description: Port number of the gRPC service. Number
                                     must be in the range 1 to 65535.
@@ -3306,6 +3364,11 @@ spec:
                                     Number must be in the range 1 to 65535.
                                     Name must be an IANA_SVC_NAME.
                                   x-kubernetes-int-or-string: true
+                                protocol:
+                                  description: |-
+                                    Protocol selects the wire protocol for the probe connection.
+                                    Nil defaults to HTTP/1.1.
+                                  type: string
                                 scheme:
                                   description: |-
                                     Scheme to use for connecting to the host.
@@ -3463,6 +3526,13 @@ spec:
                             grpc:
                               description: GRPC specifies a GRPC HealthCheckRequest.
                               properties:
+                                mode:
+                                  description: |-
+                                    mode specifies the connection mode for the gRPC health probe.
+                                    Set to "TLS" to use TLS without certificate verification.
+                                    Set to "Plaintext" to use a plaintext (insecure) connection explicitly.
+                                    If not specified, the probe uses a plaintext (insecure) connection.
+                                  type: string
                                 port:
                                   description: Port number of the gRPC service. Number
                                     must be in the range 1 to 65535.
@@ -3520,6 +3590,11 @@ spec:
                                     Number must be in the range 1 to 65535.
                                     Name must be an IANA_SVC_NAME.
                                   x-kubernetes-int-or-string: true
+                                protocol:
+                                  description: |-
+                                    Protocol selects the wire protocol for the probe connection.
+                                    Nil defaults to HTTP/1.1.
+                                  type: string
                                 scheme:
                                   description: |-
                                     Scheme to use for connecting to the host.
@@ -3589,7 +3664,9 @@ spec:
                               type: integer
                           type: object
                         resizePolicy:
-                          description: Resources resize policy for the container.
+                          description: |-
+                            Resources resize policy for the container.
+                            This field cannot be set on ephemeral containers.
                           items:
                             description: ContainerResizePolicy represents resource
                               resize policy for the container.
@@ -3620,7 +3697,7 @@ spec:
                               description: |-
                                 Claims lists the names of resources, defined in spec.resourceClaims,
                                 that are used by this container.
-                                This is an alpha field and requires enabling the
+                                This field depends on the
                                 DynamicResourceAllocation feature gate.
                                 This field is immutable. It can only be set for containers.
                               items:
@@ -3674,10 +3751,10 @@ spec:
                         restartPolicy:
                           description: |-
                             RestartPolicy defines the restart behavior of individual containers in a pod.
-                            This field may only be set for init containers, and the only allowed value is "Always".
-                            For non-init containers or when this field is not specified,
+                            This overrides the pod-level restart policy. When this field is not specified,
                             the restart behavior is defined by the Pod's restart policy and the container type.
-                            Setting the RestartPolicy as "Always" for the init container will have the following effect:
+                            Additionally, setting the RestartPolicy as "Always" for the init container will
+                            have the following effect:
                             this init container will be continually restarted on
                             exit until all regular containers have terminated. Once all regular
                             containers have completed, all init containers with restartPolicy "Always"
@@ -3689,6 +3766,59 @@ spec:
                             init container is started, or after any startupProbe has successfully
                             completed.
                           type: string
+                        restartPolicyRules:
+                          description: |-
+                            Represents a list of rules to be checked to determine if the
+                            container should be restarted on exit. The rules are evaluated in
+                            order. Once a rule matches a container exit condition, the remaining
+                            rules are ignored. If no rule matches the container exit condition,
+                            the Container-level restart policy determines the whether the container
+                            is restarted or not. Constraints on the rules:
+                            - At most 20 rules are allowed.
+                            - Rules can have the same action.
+                            - Identical rules are not forbidden in validations.
+                            When rules are specified, container MUST set RestartPolicy explicitly
+                            even it if matches the Pod's RestartPolicy.
+                          items:
+                            description: ContainerRestartRule describes how a container
+                              exit is handled.
+                            properties:
+                              action:
+                                description: |-
+                                  Specifies the action taken on a container exit if the requirements
+                                  are satisfied. The only possible value is "Restart" to restart the
+                                  container.
+                                type: string
+                              exitCodes:
+                                description: Represents the exit codes to check on
+                                  container exits.
+                                properties:
+                                  operator:
+                                    description: |-
+                                      Represents the relationship between the container exit code(s) and the
+                                      specified values. Possible values are:
+                                      - In: the requirement is satisfied if the container exit code is in the
+                                        set of specified values.
+                                      - NotIn: the requirement is satisfied if the container exit code is
+                                        not in the set of specified values.
+                                    type: string
+                                  values:
+                                    description: |-
+                                      Specifies the set of values to check for container exit codes.
+                                      At most 255 elements are allowed.
+                                    items:
+                                      format: int32
+                                      type: integer
+                                    type: array
+                                    x-kubernetes-list-type: set
+                                required:
+                                - operator
+                                type: object
+                            required:
+                            - action
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
                         securityContext:
                           description: |-
                             SecurityContext defines the security options the container should be run with.
@@ -3764,7 +3894,6 @@ spec:
                                 procMount denotes the type of proc mount to use for the containers.
                                 The default value is Default which uses the container runtime defaults for
                                 readonly paths and masked paths.
-                                This requires the ProcMountType feature flag to be enabled.
                                 Note that this field cannot be set when spec.os.name is windows.
                               type: string
                             readOnlyRootFilesystem:
@@ -3918,6 +4047,13 @@ spec:
                             grpc:
                               description: GRPC specifies a GRPC HealthCheckRequest.
                               properties:
+                                mode:
+                                  description: |-
+                                    mode specifies the connection mode for the gRPC health probe.
+                                    Set to "TLS" to use TLS without certificate verification.
+                                    Set to "Plaintext" to use a plaintext (insecure) connection explicitly.
+                                    If not specified, the probe uses a plaintext (insecure) connection.
+                                  type: string
                                 port:
                                   description: Port number of the gRPC service. Number
                                     must be in the range 1 to 65535.
@@ -3975,6 +4111,11 @@ spec:
                                     Number must be in the range 1 to 65535.
                                     Name must be an IANA_SVC_NAME.
                                   x-kubernetes-int-or-string: true
+                                protocol:
+                                  description: |-
+                                    Protocol selects the wire protocol for the probe connection.
+                                    Nil defaults to HTTP/1.1.
+                                  type: string
                                 scheme:
                                   description: |-
                                     Scheme to use for connecting to the host.
@@ -4115,10 +4256,21 @@ spec:
                             description: VolumeMount describes a mounting of a Volume
                               within a container.
                             properties:
-                              mountPath:
+                              bindMountOptions:
                                 description: |-
-                                  Path within the container at which the volume should be mounted.  Must
-                                  not contain ':'.
+                                  bindMountOptions is the list of additional bind mount options to apply when
+                                  mounting this volume into the container. Allowed values are noexec,
+                                  nodev, and nosuid. These are Linux mount options and have no effect on
+                                  Windows nodes.
+                                  This field is not supported with image volumes.
+                                  This is an alpha field and requires enabling the VolumeBindMountOptions feature gate.
+                                items:
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: set
+                              mountPath:
+                                description: Path within the container at which the
+                                  volume should be mounted.
                                 type: string
                               mountPropagation:
                                 description: |-
@@ -4300,8 +4452,9 @@ spec:
                               present in a Container.
                             properties:
                               name:
-                                description: Name of the environment variable. Must
-                                  be a C_IDENTIFIER.
+                                description: |-
+                                  Name of the environment variable.
+                                  May consist of any printable ASCII characters except '='.
                                 type: string
                               value:
                                 description: |-
@@ -4323,7 +4476,9 @@ spec:
                                     description: Selects a key of a ConfigMap.
                                     properties:
                                       key:
-                                        description: The key to select.
+                                        description: |-
+                                          The key to select from the ConfigMap's Data field.
+                                          Keys in the BinaryData field are not currently propagated to container env vars.
                                         type: string
                                       name:
                                         default: ""
@@ -4357,6 +4512,42 @@ spec:
                                         type: string
                                     required:
                                     - fieldPath
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  fileKeyRef:
+                                    description: |-
+                                      FileKeyRef selects a key of the env file.
+                                      Requires the EnvFiles feature gate to be enabled.
+                                    properties:
+                                      key:
+                                        description: |-
+                                          The key within the env file. An invalid key will prevent the pod from starting.
+                                          The keys defined within a source may consist of any printable ASCII characters except '='.
+                                          During Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.
+                                        type: string
+                                      optional:
+                                        default: false
+                                        description: |-
+                                          Specify whether the file or its key must be defined. If the file or key
+                                          does not exist, then the env var is not published.
+                                          If optional is set to true and the specified key does not exist,
+                                          the environment variable will not be set in the Pod's containers.
+                                          If optional is set to false and the specified key does not exist,
+                                          an error will be returned during Pod creation.
+                                        type: boolean
+                                      path:
+                                        description: |-
+                                          The path within the volume from which to select the file.
+                                          Must be relative and may not contain the '..' path or start with '..'.
+                                        type: string
+                                      volumeName:
+                                        description: The name of the volume mount
+                                          containing the env file.
+                                        type: string
+                                    required:
+                                    - key
+                                    - path
+                                    - volumeName
                                     type: object
                                     x-kubernetes-map-type: atomic
                                   resourceFieldRef:
@@ -4419,8 +4610,8 @@ spec:
                         envFrom:
                           description: |-
                             List of sources to populate environment variables in the container.
-                            The keys defined within a source must be a C_IDENTIFIER. All invalid keys
-                            will be reported as an event when the container is starting. When a key exists in multiple
+                            The keys defined within a source may consist of any printable ASCII characters except '='.
+                            When a key exists in multiple
                             sources, the value associated with the last source will take precedence.
                             Values defined by an Env with a duplicate key will take precedence.
                             Cannot be updated.
@@ -4447,8 +4638,9 @@ spec:
                                 type: object
                                 x-kubernetes-map-type: atomic
                               prefix:
-                                description: Optional text to prepend to the name
-                                  of each environment variable. Must be a C_IDENTIFIER.
+                                description: |-
+                                  Optional text to prepend to the name of each environment variable.
+                                  May consist of any printable ASCII characters except '='.
                                 type: string
                               secretRef:
                                 description: The Secret to select from
@@ -4552,6 +4744,11 @@ spec:
                                         Number must be in the range 1 to 65535.
                                         Name must be an IANA_SVC_NAME.
                                       x-kubernetes-int-or-string: true
+                                    protocol:
+                                      description: |-
+                                        Protocol selects the wire protocol for the probe connection.
+                                        Nil defaults to HTTP/1.1.
+                                      type: string
                                     scheme:
                                       description: |-
                                         Scheme to use for connecting to the host.
@@ -4665,6 +4862,11 @@ spec:
                                         Number must be in the range 1 to 65535.
                                         Name must be an IANA_SVC_NAME.
                                       x-kubernetes-int-or-string: true
+                                    protocol:
+                                      description: |-
+                                        Protocol selects the wire protocol for the probe connection.
+                                        Nil defaults to HTTP/1.1.
+                                      type: string
                                     scheme:
                                       description: |-
                                         Scheme to use for connecting to the host.
@@ -4743,6 +4945,13 @@ spec:
                             grpc:
                               description: GRPC specifies a GRPC HealthCheckRequest.
                               properties:
+                                mode:
+                                  description: |-
+                                    mode specifies the connection mode for the gRPC health probe.
+                                    Set to "TLS" to use TLS without certificate verification.
+                                    Set to "Plaintext" to use a plaintext (insecure) connection explicitly.
+                                    If not specified, the probe uses a plaintext (insecure) connection.
+                                  type: string
                                 port:
                                   description: Port number of the gRPC service. Number
                                     must be in the range 1 to 65535.
@@ -4800,6 +5009,11 @@ spec:
                                     Number must be in the range 1 to 65535.
                                     Name must be an IANA_SVC_NAME.
                                   x-kubernetes-int-or-string: true
+                                protocol:
+                                  description: |-
+                                    Protocol selects the wire protocol for the probe connection.
+                                    Nil defaults to HTTP/1.1.
+                                  type: string
                                 scheme:
                                   description: |-
                                     Scheme to use for connecting to the host.
@@ -4945,6 +5159,13 @@ spec:
                             grpc:
                               description: GRPC specifies a GRPC HealthCheckRequest.
                               properties:
+                                mode:
+                                  description: |-
+                                    mode specifies the connection mode for the gRPC health probe.
+                                    Set to "TLS" to use TLS without certificate verification.
+                                    Set to "Plaintext" to use a plaintext (insecure) connection explicitly.
+                                    If not specified, the probe uses a plaintext (insecure) connection.
+                                  type: string
                                 port:
                                   description: Port number of the gRPC service. Number
                                     must be in the range 1 to 65535.
@@ -5002,6 +5223,11 @@ spec:
                                     Number must be in the range 1 to 65535.
                                     Name must be an IANA_SVC_NAME.
                                   x-kubernetes-int-or-string: true
+                                protocol:
+                                  description: |-
+                                    Protocol selects the wire protocol for the probe connection.
+                                    Nil defaults to HTTP/1.1.
+                                  type: string
                                 scheme:
                                   description: |-
                                     Scheme to use for connecting to the host.
@@ -5101,7 +5327,7 @@ spec:
                               description: |-
                                 Claims lists the names of resources, defined in spec.resourceClaims,
                                 that are used by this container.
-                                This is an alpha field and requires enabling the
+                                This field depends on the
                                 DynamicResourceAllocation feature gate.
                                 This field is immutable. It can only be set for containers.
                               items:
@@ -5156,9 +5382,53 @@ spec:
                           description: |-
                             Restart policy for the container to manage the restart behavior of each
                             container within a pod.
-                            This may only be set for init containers. You cannot set this field on
-                            ephemeral containers.
+                            You cannot set this field on ephemeral containers.
                           type: string
+                        restartPolicyRules:
+                          description: |-
+                            Represents a list of rules to be checked to determine if the
+                            container should be restarted on exit. You cannot set this field on
+                            ephemeral containers.
+                          items:
+                            description: ContainerRestartRule describes how a container
+                              exit is handled.
+                            properties:
+                              action:
+                                description: |-
+                                  Specifies the action taken on a container exit if the requirements
+                                  are satisfied. The only possible value is "Restart" to restart the
+                                  container.
+                                type: string
+                              exitCodes:
+                                description: Represents the exit codes to check on
+                                  container exits.
+                                properties:
+                                  operator:
+                                    description: |-
+                                      Represents the relationship between the container exit code(s) and the
+                                      specified values. Possible values are:
+                                      - In: the requirement is satisfied if the container exit code is in the
+                                        set of specified values.
+                                      - NotIn: the requirement is satisfied if the container exit code is
+                                        not in the set of specified values.
+                                    type: string
+                                  values:
+                                    description: |-
+                                      Specifies the set of values to check for container exit codes.
+                                      At most 255 elements are allowed.
+                                    items:
+                                      format: int32
+                                      type: integer
+                                    type: array
+                                    x-kubernetes-list-type: set
+                                required:
+                                - operator
+                                type: object
+                            required:
+                            - action
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
                         securityContext:
                           description: |-
                             Optional: SecurityContext defines the security options the ephemeral container should be run with.
@@ -5233,7 +5503,6 @@ spec:
                                 procMount denotes the type of proc mount to use for the containers.
                                 The default value is Default which uses the container runtime defaults for
                                 readonly paths and masked paths.
-                                This requires the ProcMountType feature flag to be enabled.
                                 Note that this field cannot be set when spec.os.name is windows.
                               type: string
                             readOnlyRootFilesystem:
@@ -5380,6 +5649,13 @@ spec:
                             grpc:
                               description: GRPC specifies a GRPC HealthCheckRequest.
                               properties:
+                                mode:
+                                  description: |-
+                                    mode specifies the connection mode for the gRPC health probe.
+                                    Set to "TLS" to use TLS without certificate verification.
+                                    Set to "Plaintext" to use a plaintext (insecure) connection explicitly.
+                                    If not specified, the probe uses a plaintext (insecure) connection.
+                                  type: string
                                 port:
                                   description: Port number of the gRPC service. Number
                                     must be in the range 1 to 65535.
@@ -5437,6 +5713,11 @@ spec:
                                     Number must be in the range 1 to 65535.
                                     Name must be an IANA_SVC_NAME.
                                   x-kubernetes-int-or-string: true
+                                protocol:
+                                  description: |-
+                                    Protocol selects the wire protocol for the probe connection.
+                                    Nil defaults to HTTP/1.1.
+                                  type: string
                                 scheme:
                                   description: |-
                                     Scheme to use for connecting to the host.
@@ -5585,10 +5866,21 @@ spec:
                             description: VolumeMount describes a mounting of a Volume
                               within a container.
                             properties:
-                              mountPath:
+                              bindMountOptions:
                                 description: |-
-                                  Path within the container at which the volume should be mounted.  Must
-                                  not contain ':'.
+                                  bindMountOptions is the list of additional bind mount options to apply when
+                                  mounting this volume into the container. Allowed values are noexec,
+                                  nodev, and nosuid. These are Linux mount options and have no effect on
+                                  Windows nodes.
+                                  This field is not supported with image volumes.
+                                  This is an alpha field and requires enabling the VolumeBindMountOptions feature gate.
+                                items:
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: set
+                              mountPath:
+                                description: Path within the container at which the
+                                  volume should be mounted.
                                 type: string
                               mountPropagation:
                                 description: |-
@@ -5656,6 +5948,58 @@ spec:
                     x-kubernetes-list-map-keys:
                     - name
                     x-kubernetes-list-type: map
+                  evictionResponders:
+                    description: |-
+                      evictionResponders reference responders that react to Evictions based on EvictionRequests.
+                      Responders should observe and communicate through the Eviction Resource API to help with
+                      the graceful termination of a pod. The responders are selected sequentially, according to
+                      their specified priority.
+                      Responders should periodically report on an eviction progress by updating the
+                      .status.responders[].heartbeatTime field of the Eviction object. If this field is not updated
+                      within the heartbeat deadline defined by the Eviction API (currently 20 minutes), the eviction
+                      is passed over to the next responder with a lower priority. If there is no other responder,
+                      the last default imperative-eviction.k8s.io/evictor responder with a priority of 100 will
+                      evict the pod using the imperative Eviction API (pods/<name>/eviction subresource).
+                      The maximum length of the responders list is 10.
+                      Responders are not supported when the pod is part of a PodGroup (.spec.schedulingGroup is set).
+                      This field can only be set on creation and is immutable afterwards.
+                    items:
+                      description: |-
+                        EvictionResponder allows you to specify the responder reacting to an Eviction.
+                        Responders should observe and communicate through the Eviction Resource API to help with
+                        the graceful eviction of a target (e.g. termination of a pod).
+                      properties:
+                        name:
+                          description: |-
+                            name allows you to identify the responder responding to the Eviction.
+                            It must be a valid domain-prefixed key (such as "acme.io/foo").
+                            Domain names *.k8s.io and *.kubernetes.io are reserved.
+                            This field must be unique for each responder.
+                            This field is required.
+                          type: string
+                        priority:
+                          description: |-
+                            priority for this responder. Higher priorities are selected first by the evictionrequest-controller.
+                            If there are responders with the same priority, the responder whose domain name comes first in the
+                            alphabetical higher domain order, will be picked. This means that the top domain labels are compared
+                            alphabetically first, followed by the lower domain labels. The key is compared last.
+                            The responder that is the managing controller of the pod should set the value of
+                            this field to 10000 to allow both for preemption or fallback registration by other
+                            responders.
+                            The minimum value is 0 and the maximum value is 100000.
+                            The interval 0-999 is reserved for responders with *.k8s.io suffix.
+                            This field is required.
+                          format: int32
+                          type: integer
+                      required:
+                      - name
+                      - priority
+                      type: object
+                      x-kubernetes-map-type: atomic
+                    type: array
+                    x-kubernetes-list-map-keys:
+                    - name
+                    x-kubernetes-list-type: map
                   hostAliases:
                     description: |-
                       HostAliases is an optional list of hosts and IPs that will be injected into the pod's hosts
@@ -5689,7 +6033,9 @@ spec:
                   hostNetwork:
                     description: |-
                       Host networking requested for this pod. Use the host's network namespace.
-                      If this option is set, the ports that will be used must be specified.
+                      When using HostNetwork you should specify ports so the scheduler is aware.
+                      When `hostNetwork` is true, specified `hostPort` fields in port definitions must match `containerPort`,
+                      and unspecified `hostPort` fields in port definitions are defaulted to match `containerPort`.
                       Default to false.
                     type: boolean
                   hostPID:
@@ -5707,12 +6053,22 @@ spec:
                       When set to false, a new userns is created for the pod. Setting false is useful for
                       mitigating container breakout vulnerabilities even allowing users to run their
                       containers as root without actually having root privileges on the host.
-                      This field is alpha-level and is only honored by servers that enable the UserNamespacesSupport feature.
                     type: boolean
                   hostname:
                     description: |-
                       Specifies the hostname of the Pod
                       If not specified, the pod's hostname will be set to a system-defined value.
+                    type: string
+                  hostnameOverride:
+                    description: |-
+                      HostnameOverride specifies an explicit override for the pod's hostname as perceived by the pod.
+                      This field only specifies the pod's hostname and does not affect its DNS records.
+                      When this field is set to a non-empty string:
+                      - It takes precedence over the values set in `hostname` and `subdomain`.
+                      - The Pod's hostname will be set to this value.
+                      - `setHostnameAsFQDN` must be nil or set to false.
+                      - `hostNetwork` must be set to false.
+                      This field must be a valid DNS subdomain as defined in RFC 1123 and contain at most 64 characters.
                     type: string
                   imagePullSecrets:
                     description: |-
@@ -5795,8 +6151,9 @@ spec:
                               present in a Container.
                             properties:
                               name:
-                                description: Name of the environment variable. Must
-                                  be a C_IDENTIFIER.
+                                description: |-
+                                  Name of the environment variable.
+                                  May consist of any printable ASCII characters except '='.
                                 type: string
                               value:
                                 description: |-
@@ -5818,7 +6175,9 @@ spec:
                                     description: Selects a key of a ConfigMap.
                                     properties:
                                       key:
-                                        description: The key to select.
+                                        description: |-
+                                          The key to select from the ConfigMap's Data field.
+                                          Keys in the BinaryData field are not currently propagated to container env vars.
                                         type: string
                                       name:
                                         default: ""
@@ -5852,6 +6211,42 @@ spec:
                                         type: string
                                     required:
                                     - fieldPath
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  fileKeyRef:
+                                    description: |-
+                                      FileKeyRef selects a key of the env file.
+                                      Requires the EnvFiles feature gate to be enabled.
+                                    properties:
+                                      key:
+                                        description: |-
+                                          The key within the env file. An invalid key will prevent the pod from starting.
+                                          The keys defined within a source may consist of any printable ASCII characters except '='.
+                                          During Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.
+                                        type: string
+                                      optional:
+                                        default: false
+                                        description: |-
+                                          Specify whether the file or its key must be defined. If the file or key
+                                          does not exist, then the env var is not published.
+                                          If optional is set to true and the specified key does not exist,
+                                          the environment variable will not be set in the Pod's containers.
+                                          If optional is set to false and the specified key does not exist,
+                                          an error will be returned during Pod creation.
+                                        type: boolean
+                                      path:
+                                        description: |-
+                                          The path within the volume from which to select the file.
+                                          Must be relative and may not contain the '..' path or start with '..'.
+                                        type: string
+                                      volumeName:
+                                        description: The name of the volume mount
+                                          containing the env file.
+                                        type: string
+                                    required:
+                                    - key
+                                    - path
+                                    - volumeName
                                     type: object
                                     x-kubernetes-map-type: atomic
                                   resourceFieldRef:
@@ -5914,8 +6309,8 @@ spec:
                         envFrom:
                           description: |-
                             List of sources to populate environment variables in the container.
-                            The keys defined within a source must be a C_IDENTIFIER. All invalid keys
-                            will be reported as an event when the container is starting. When a key exists in multiple
+                            The keys defined within a source may consist of any printable ASCII characters except '='.
+                            When a key exists in multiple
                             sources, the value associated with the last source will take precedence.
                             Values defined by an Env with a duplicate key will take precedence.
                             Cannot be updated.
@@ -5942,8 +6337,9 @@ spec:
                                 type: object
                                 x-kubernetes-map-type: atomic
                               prefix:
-                                description: Optional text to prepend to the name
-                                  of each environment variable. Must be a C_IDENTIFIER.
+                                description: |-
+                                  Optional text to prepend to the name of each environment variable.
+                                  May consist of any printable ASCII characters except '='.
                                 type: string
                               secretRef:
                                 description: The Secret to select from
@@ -6051,6 +6447,11 @@ spec:
                                         Number must be in the range 1 to 65535.
                                         Name must be an IANA_SVC_NAME.
                                       x-kubernetes-int-or-string: true
+                                    protocol:
+                                      description: |-
+                                        Protocol selects the wire protocol for the probe connection.
+                                        Nil defaults to HTTP/1.1.
+                                      type: string
                                     scheme:
                                       description: |-
                                         Scheme to use for connecting to the host.
@@ -6164,6 +6565,11 @@ spec:
                                         Number must be in the range 1 to 65535.
                                         Name must be an IANA_SVC_NAME.
                                       x-kubernetes-int-or-string: true
+                                    protocol:
+                                      description: |-
+                                        Protocol selects the wire protocol for the probe connection.
+                                        Nil defaults to HTTP/1.1.
+                                      type: string
                                     scheme:
                                       description: |-
                                         Scheme to use for connecting to the host.
@@ -6246,6 +6652,13 @@ spec:
                             grpc:
                               description: GRPC specifies a GRPC HealthCheckRequest.
                               properties:
+                                mode:
+                                  description: |-
+                                    mode specifies the connection mode for the gRPC health probe.
+                                    Set to "TLS" to use TLS without certificate verification.
+                                    Set to "Plaintext" to use a plaintext (insecure) connection explicitly.
+                                    If not specified, the probe uses a plaintext (insecure) connection.
+                                  type: string
                                 port:
                                   description: Port number of the gRPC service. Number
                                     must be in the range 1 to 65535.
@@ -6303,6 +6716,11 @@ spec:
                                     Number must be in the range 1 to 65535.
                                     Name must be an IANA_SVC_NAME.
                                   x-kubernetes-int-or-string: true
+                                protocol:
+                                  description: |-
+                                    Protocol selects the wire protocol for the probe connection.
+                                    Nil defaults to HTTP/1.1.
+                                  type: string
                                 scheme:
                                   description: |-
                                     Scheme to use for connecting to the host.
@@ -6460,6 +6878,13 @@ spec:
                             grpc:
                               description: GRPC specifies a GRPC HealthCheckRequest.
                               properties:
+                                mode:
+                                  description: |-
+                                    mode specifies the connection mode for the gRPC health probe.
+                                    Set to "TLS" to use TLS without certificate verification.
+                                    Set to "Plaintext" to use a plaintext (insecure) connection explicitly.
+                                    If not specified, the probe uses a plaintext (insecure) connection.
+                                  type: string
                                 port:
                                   description: Port number of the gRPC service. Number
                                     must be in the range 1 to 65535.
@@ -6517,6 +6942,11 @@ spec:
                                     Number must be in the range 1 to 65535.
                                     Name must be an IANA_SVC_NAME.
                                   x-kubernetes-int-or-string: true
+                                protocol:
+                                  description: |-
+                                    Protocol selects the wire protocol for the probe connection.
+                                    Nil defaults to HTTP/1.1.
+                                  type: string
                                 scheme:
                                   description: |-
                                     Scheme to use for connecting to the host.
@@ -6586,7 +7016,9 @@ spec:
                               type: integer
                           type: object
                         resizePolicy:
-                          description: Resources resize policy for the container.
+                          description: |-
+                            Resources resize policy for the container.
+                            This field cannot be set on ephemeral containers.
                           items:
                             description: ContainerResizePolicy represents resource
                               resize policy for the container.
@@ -6617,7 +7049,7 @@ spec:
                               description: |-
                                 Claims lists the names of resources, defined in spec.resourceClaims,
                                 that are used by this container.
-                                This is an alpha field and requires enabling the
+                                This field depends on the
                                 DynamicResourceAllocation feature gate.
                                 This field is immutable. It can only be set for containers.
                               items:
@@ -6671,10 +7103,10 @@ spec:
                         restartPolicy:
                           description: |-
                             RestartPolicy defines the restart behavior of individual containers in a pod.
-                            This field may only be set for init containers, and the only allowed value is "Always".
-                            For non-init containers or when this field is not specified,
+                            This overrides the pod-level restart policy. When this field is not specified,
                             the restart behavior is defined by the Pod's restart policy and the container type.
-                            Setting the RestartPolicy as "Always" for the init container will have the following effect:
+                            Additionally, setting the RestartPolicy as "Always" for the init container will
+                            have the following effect:
                             this init container will be continually restarted on
                             exit until all regular containers have terminated. Once all regular
                             containers have completed, all init containers with restartPolicy "Always"
@@ -6686,6 +7118,59 @@ spec:
                             init container is started, or after any startupProbe has successfully
                             completed.
                           type: string
+                        restartPolicyRules:
+                          description: |-
+                            Represents a list of rules to be checked to determine if the
+                            container should be restarted on exit. The rules are evaluated in
+                            order. Once a rule matches a container exit condition, the remaining
+                            rules are ignored. If no rule matches the container exit condition,
+                            the Container-level restart policy determines the whether the container
+                            is restarted or not. Constraints on the rules:
+                            - At most 20 rules are allowed.
+                            - Rules can have the same action.
+                            - Identical rules are not forbidden in validations.
+                            When rules are specified, container MUST set RestartPolicy explicitly
+                            even it if matches the Pod's RestartPolicy.
+                          items:
+                            description: ContainerRestartRule describes how a container
+                              exit is handled.
+                            properties:
+                              action:
+                                description: |-
+                                  Specifies the action taken on a container exit if the requirements
+                                  are satisfied. The only possible value is "Restart" to restart the
+                                  container.
+                                type: string
+                              exitCodes:
+                                description: Represents the exit codes to check on
+                                  container exits.
+                                properties:
+                                  operator:
+                                    description: |-
+                                      Represents the relationship between the container exit code(s) and the
+                                      specified values. Possible values are:
+                                      - In: the requirement is satisfied if the container exit code is in the
+                                        set of specified values.
+                                      - NotIn: the requirement is satisfied if the container exit code is
+                                        not in the set of specified values.
+                                    type: string
+                                  values:
+                                    description: |-
+                                      Specifies the set of values to check for container exit codes.
+                                      At most 255 elements are allowed.
+                                    items:
+                                      format: int32
+                                      type: integer
+                                    type: array
+                                    x-kubernetes-list-type: set
+                                required:
+                                - operator
+                                type: object
+                            required:
+                            - action
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
                         securityContext:
                           description: |-
                             SecurityContext defines the security options the container should be run with.
@@ -6761,7 +7246,6 @@ spec:
                                 procMount denotes the type of proc mount to use for the containers.
                                 The default value is Default which uses the container runtime defaults for
                                 readonly paths and masked paths.
-                                This requires the ProcMountType feature flag to be enabled.
                                 Note that this field cannot be set when spec.os.name is windows.
                               type: string
                             readOnlyRootFilesystem:
@@ -6915,6 +7399,13 @@ spec:
                             grpc:
                               description: GRPC specifies a GRPC HealthCheckRequest.
                               properties:
+                                mode:
+                                  description: |-
+                                    mode specifies the connection mode for the gRPC health probe.
+                                    Set to "TLS" to use TLS without certificate verification.
+                                    Set to "Plaintext" to use a plaintext (insecure) connection explicitly.
+                                    If not specified, the probe uses a plaintext (insecure) connection.
+                                  type: string
                                 port:
                                   description: Port number of the gRPC service. Number
                                     must be in the range 1 to 65535.
@@ -6972,6 +7463,11 @@ spec:
                                     Number must be in the range 1 to 65535.
                                     Name must be an IANA_SVC_NAME.
                                   x-kubernetes-int-or-string: true
+                                protocol:
+                                  description: |-
+                                    Protocol selects the wire protocol for the probe connection.
+                                    Nil defaults to HTTP/1.1.
+                                  type: string
                                 scheme:
                                   description: |-
                                     Scheme to use for connecting to the host.
@@ -7112,10 +7608,21 @@ spec:
                             description: VolumeMount describes a mounting of a Volume
                               within a container.
                             properties:
-                              mountPath:
+                              bindMountOptions:
                                 description: |-
-                                  Path within the container at which the volume should be mounted.  Must
-                                  not contain ':'.
+                                  bindMountOptions is the list of additional bind mount options to apply when
+                                  mounting this volume into the container. Allowed values are noexec,
+                                  nodev, and nosuid. These are Linux mount options and have no effect on
+                                  Windows nodes.
+                                  This field is not supported with image volumes.
+                                  This is an alpha field and requires enabling the VolumeBindMountOptions feature gate.
+                                items:
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: set
+                              mountPath:
+                                description: Path within the container at which the
+                                  volume should be mounted.
                                 type: string
                               mountPropagation:
                                 description: |-
@@ -7210,6 +7717,7 @@ spec:
                       - spec.hostPID
                       - spec.hostIPC
                       - spec.hostUsers
+                      - spec.resources
                       - spec.securityContext.appArmorProfile
                       - spec.securityContext.seLinuxOptions
                       - spec.securityContext.seccompProfile
@@ -7262,6 +7770,8 @@ spec:
                     description: |-
                       PreemptionPolicy is the Policy for preempting pods with lower priority.
                       One of Never, PreemptLowerPriority.
+                      When Priority Admission Controller is enabled, it prevents users from setting
+                      this field. The admission controller populates this field from PriorityClassName.
                       Defaults to PreemptLowerPriority if unset.
                     type: string
                   priority:
@@ -7307,8 +7817,8 @@ spec:
                       and reserved before the Pod is allowed to start. The resources
                       will be made available to those containers which consume them
                       by name.
-                      This is an alpha field and requires enabling the
-                      DynamicResourceAllocation feature gate.
+                      This is a stable field but requires that the
+                      DynamicResourceAllocation feature gate is enabled.
                       This field is immutable.
                     items:
                       description: |-
@@ -7317,6 +7827,13 @@ spec:
                         for the pod.
                         It adds a name to it that uniquely identifies the ResourceClaim inside the Pod.
                         Containers that need access to the ResourceClaim reference it with this name.
+                        When the DRAWorkloadResourceClaims feature gate is enabled and this Pod
+                        belongs to a PodGroup, a PodResourceClaim is matched to a
+                        PodGroupResourceClaim if all of their fields are equal (Name,
+                        ResourceClaimName, and ResourceClaimTemplateName). A matched claim references
+                        a single ResourceClaim shared across all Pods in the PodGroup, reserved for
+                        the PodGroup in ResourceClaimStatus.ReservedFor rather than for individual
+                        Pods.
                       properties:
                         name:
                           description: |-
@@ -7339,6 +7856,15 @@ spec:
                             will also be deleted. The pod name and resource name, along with a
                             generated component, will be used to form a unique name for the
                             ResourceClaim, which will be recorded in pod.status.resourceClaimStatuses.
+                            When the DRAWorkloadResourceClaims feature gate is enabled and the pod
+                            belongs to a PodGroup that defines a PodGroupResourceClaim with the same
+                            Name and ResourceClaimTemplateName, this PodResourceClaim resolves to the
+                            ResourceClaim generated for the PodGroup. All pods in the group that
+                            define an equivalent PodResourceClaim matching the
+                            PodGroupResourceClaim's Name and ResourceClaimTemplateName share the same
+                            generated ResourceClaim. ResourceClaims generated for a PodGroup are
+                            owned by the PodGroup and their lifecycles are tied to the PodGroup
+                            instead of any individual pod.
                             This field is immutable and no changes will be made to the
                             corresponding ResourceClaim by the control plane after creating the
                             ResourceClaim.
@@ -7356,7 +7882,7 @@ spec:
                     description: |-
                       Resources is the total amount of CPU and Memory resources required by all
                       containers in the pod. It supports specifying Requests and Limits for
-                      "cpu" and "memory" resource names only. ResourceClaims are not supported.
+                      "cpu", "memory" and "hugepages-" resource names only. ResourceClaims are not supported.
                       This field enables fine-grained control over resource allocation for the
                       entire pod, allowing resource sharing among containers in a pod.
                       This is an alpha field and requires enabling the PodLevelResources feature
@@ -7366,7 +7892,7 @@ spec:
                         description: |-
                           Claims lists the names of resources, defined in spec.resourceClaims,
                           that are used by this container.
-                          This is an alpha field and requires enabling the
+                          This field depends on the
                           DynamicResourceAllocation feature gate.
                           This field is immutable. It can only be set for containers.
                         items:
@@ -7458,6 +7984,28 @@ spec:
                     x-kubernetes-list-map-keys:
                     - name
                     x-kubernetes-list-type: map
+                  schedulingGroup:
+                    description: |-
+                      SchedulingGroup provides a reference to the immediate scheduling runtime
+                      grouping object that this Pod belongs to.
+                      This field is used by the scheduler to identify the group and apply the
+                      correct group scheduling policies. The association with a group also
+                      impacts other lifecycle aspects of a Pod that are relevant in a wider context
+                      of scheduling like preemption, resource attachment, etc. If not specified,
+                      the Pod is treated as a single unit in all of these aspects.
+                      The group object referenced by this field may not exist at the time the
+                      Pod is created.
+                      This field is immutable, but a group object with the same name may be
+                      recreated with different policies. Doing this during pod scheduling
+                      may result in the placement not conforming to the expected policies.
+                    properties:
+                      podGroupName:
+                        description: |-
+                          PodGroupName specifies the name of the standalone PodGroup object
+                          that represents the runtime instance of this group.
+                          Must be a DNS subdomain.
+                        type: string
+                    type: object
                   securityContext:
                     description: |-
                       SecurityContext holds pod-level security attributes and common container settings.
@@ -7550,10 +8098,7 @@ spec:
                           Eligible volumes are in-tree FibreChannel and iSCSI volumes, and all CSI volumes
                           whose CSI driver announces SELinux support by setting spec.seLinuxMount: true in their
                           CSIDriver instance. Other volumes are always re-labelled recursively.
-                          "MountOption" value is allowed only when SELinuxMount feature gate is enabled.
-                          If not specified and SELinuxMount feature gate is enabled, "MountOption" is used.
-                          If not specified and SELinuxMount feature gate is disabled, "MountOption" is used for ReadWriteOncePod volumes
-                          and "Recursive" for all other volumes.
+                          If not specified, "MountOption" is used.
                           This field affects only Pods that have SELinux label set, either in PodSecurityContext or in SecurityContext of all containers.
                           All Pods that use the same volume should use the same seLinuxChangePolicy, otherwise some pods can get stuck in ContainerCreating state.
                           Note that this field cannot be set when spec.os.name is windows.
@@ -7747,9 +8292,10 @@ spec:
                         operator:
                           description: |-
                             Operator represents a key's relationship to the value.
-                            Valid operators are Exists and Equal. Defaults to Equal.
+                            Valid operators are Exists, Equal, Lt, and Gt. Defaults to Equal.
                             Exists is equivalent to wildcard for value, so that a pod can
                             tolerate all taints of a particular category.
+                            Lt and Gt perform numeric comparisons (requires feature gate TaintTolerationComparisonOperators).
                           type: string
                         tolerationSeconds:
                           description: |-
@@ -8163,6 +8709,13 @@ spec:
                                 mode, like fsGroup, and the result can be other mode bits set.
                               format: int32
                               type: integer
+                            defaultUser:
+                              description: |-
+                                defaultUser is Optional: The owner UID of the created files by default.
+                                The defaultUser field is only used as a fallback when the item-level user field is unset.
+                                (Alpha) This field requires the AtomicWriteVolumeUserFields feature gate to be enabled.
+                              format: int64
+                              type: integer
                             items:
                               description: |-
                                 items if unspecified, each key-value pair in the Data field of the referenced
@@ -8196,6 +8749,13 @@ spec:
                                       May not contain the path element '..'.
                                       May not start with the string '..'.
                                     type: string
+                                  user:
+                                    description: |-
+                                      user is Optional: The owner UID of the created file.
+                                      If specified, the item-level user field takes precedence over defaultUser.
+                                      (Alpha) This field requires the AtomicWriteVolumeUserFields feature gate to be enabled.
+                                    format: int64
+                                    type: integer
                                 required:
                                 - key
                                 - path
@@ -8283,6 +8843,13 @@ spec:
                                 mode, like fsGroup, and the result can be other mode bits set.
                               format: int32
                               type: integer
+                            defaultUser:
+                              description: |-
+                                defaultUser is Optional: The owner UID of the created files by default.
+                                The defaultUser field is only used as a fallback when the item-level user field is unset.
+                                (Alpha) This field requires the AtomicWriteVolumeUserFields feature gate to be enabled.
+                              format: int64
+                              type: integer
                             items:
                               description: Items is a list of downward API volume
                                 file
@@ -8348,6 +8915,13 @@ spec:
                                     - resource
                                     type: object
                                     x-kubernetes-map-type: atomic
+                                  user:
+                                    description: |-
+                                      user is Optional: The owner UID of the created file.
+                                      If specified, the item-level user field takes precedence over defaultUser.
+                                      (Alpha) This field requires the AtomicWriteVolumeUserFields feature gate to be enabled.
+                                    format: int64
+                                    type: integer
                                 required:
                                 - path
                                 type: object
@@ -8366,6 +8940,18 @@ spec:
                                 Must be an empty string (default) or Memory.
                                 More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir
                               type: string
+                            mode:
+                              description: |-
+                                mode specifies the permission bits for the emptyDir directory, in numeric
+                                notation (e.g., 0755, 01777). Must be a value between 0000 and 01777.
+                                If not specified, defaults to 0777.
+                                This might be in conflict with other options that affect the file
+                                mode, like fsGroup. If fsGroup is specified, the fsGroup permissions
+                                will override the mode specified here.
+                                This field has no effect on Windows.
+                                This field is alpha and requires EmptyDirVolumeMode featuregate to be enabled.
+                              format: int32
+                              type: integer
                             sizeLimit:
                               anyOf:
                               - type: integer
@@ -8452,8 +9038,8 @@ spec:
                                         * An existing PVC (PersistentVolumeClaim)
                                         If the provisioner or an external controller can support the specified data source,
                                         it will create a new volume based on the contents of the specified data source.
-                                        When the AnyVolumeDataSource feature gate is enabled, dataSource contents will be copied to dataSourceRef,
-                                        and dataSourceRef contents will be copied to dataSource when dataSourceRef.namespace is not specified.
+                                        dataSource contents will be copied to dataSourceRef, and dataSourceRef contents will be
+                                        copied to dataSource when dataSourceRef.namespace is not specified.
                                         If the namespace is specified, then dataSourceRef will not be copied to dataSource.
                                       properties:
                                         apiGroup:
@@ -8498,7 +9084,6 @@ spec:
                                           specified.
                                         * While dataSource only allows local objects, dataSourceRef allows objects
                                           in any namespaces.
-                                        (Beta) Using this field requires the AnyVolumeDataSource feature gate to be enabled.
                                         (Alpha) Using the namespace field of dataSourceRef requires the CrossNamespaceVolumeDataSource feature gate to be enabled.
                                       properties:
                                         apiGroup:
@@ -8528,7 +9113,7 @@ spec:
                                     resources:
                                       description: |-
                                         resources represents the minimum resources the volume should have.
-                                        If RecoverVolumeExpansionFailure feature is enabled users are allowed to specify resource requirements
+                                        Users are allowed to specify resource requirements
                                         that are lower than previous value but must still be higher than capacity recorded in the
                                         status field of the claim.
                                         More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources
@@ -8616,15 +9201,13 @@ spec:
                                         volumeAttributesClassName may be used to set the VolumeAttributesClass used by this claim.
                                         If specified, the CSI driver will create or update the volume with the attributes defined
                                         in the corresponding VolumeAttributesClass. This has a different purpose than storageClassName,
-                                        it can be changed after the claim is created. An empty string value means that no VolumeAttributesClass
-                                        will be applied to the claim but it's not allowed to reset this field to empty string once it is set.
-                                        If unspecified and the PersistentVolumeClaim is unbound, the default VolumeAttributesClass
-                                        will be set by the persistentvolume controller if it exists.
+                                        it can be changed after the claim is created. An empty string or nil value indicates that no
+                                        VolumeAttributesClass will be applied to the claim. If the claim enters an Infeasible error state,
+                                        this field can be reset to its previous value (including nil) to cancel the modification.
                                         If the resource referred to by volumeAttributesClass does not exist, this PersistentVolumeClaim will be
                                         set to a Pending state, as reflected by the modifyVolumeStatus field, until such as a resource
                                         exists.
                                         More info: https://kubernetes.io/docs/concepts/storage/volume-attributes-classes/
-                                        (Beta) Using this field requires the VolumeAttributesClass feature gate to be enabled (off by default).
                                       type: string
                                     volumeMode:
                                       description: |-
@@ -8806,12 +9389,10 @@ spec:
                           description: |-
                             glusterfs represents a Glusterfs mount on the host that shares a pod's lifetime.
                             Deprecated: Glusterfs is deprecated and the in-tree glusterfs type is no longer supported.
-                            More info: https://examples.k8s.io/volumes/glusterfs/README.md
                           properties:
                             endpoints:
-                              description: |-
-                                endpoints is the endpoint name that details Glusterfs topology.
-                                More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
+                              description: endpoints is the endpoint name that details
+                                Glusterfs topology.
                               type: string
                             path:
                               description: |-
@@ -8862,7 +9443,7 @@ spec:
                             A failure to resolve or pull the image during pod startup will block containers from starting and may add significant latency. Failures will be retried using normal volume backoff and will be reported on the pod reason and message.
                             The types of objects that may be mounted by this volume are defined by the container runtime implementation on a host machine and at minimum must include all valid types supported by the container image field.
                             The OCI object gets mounted in a single directory (spec.containers[*].volumeMounts.mountPath) by merging the manifest layers in the same way as for container images.
-                            The volume will be mounted read-only (ro) and non-executable files (noexec).
+                            The volume will be mounted read-only (ro).
                             Sub path mounts for containers are not supported (spec.containers[*].volumeMounts.subpath) before 1.33.
                             The field spec.securityContext.fsGroupChangePolicy has no effect on this volume type.
                           properties:
@@ -8888,7 +9469,7 @@ spec:
                           description: |-
                             iscsi represents an ISCSI Disk resource that is attached to a
                             kubelet's host machine and then exposed to the pod.
-                            More info: https://examples.k8s.io/volumes/iscsi/README.md
+                            More info: https://kubernetes.io/docs/concepts/storage/volumes/#iscsi
                           properties:
                             chapAuthDiscovery:
                               description: chapAuthDiscovery defines whether support
@@ -9034,8 +9615,7 @@ spec:
                           description: |-
                             portworxVolume represents a portworx volume attached and mounted on kubelets host machine.
                             Deprecated: PortworxVolume is deprecated. All operations for the in-tree portworxVolume type
-                            are redirected to the pxd.portworx.com CSI driver when the CSIMigrationPortworx feature-gate
-                            is on.
+                            are redirected to the pxd.portworx.com CSI driver.
                           properties:
                             fsType:
                               description: |-
@@ -9068,6 +9648,13 @@ spec:
                                 This might be in conflict with other options that affect the file
                                 mode, like fsGroup, and the result can be other mode bits set.
                               format: int32
+                              type: integer
+                            defaultUser:
+                              description: |-
+                                defaultUser is Optional: The owner UID of the created files by default.
+                                The defaultUser field is only used as a fallback when the item-level user field is unset.
+                                (Alpha) This field requires the AtomicWriteVolumeUserFields feature gate to be enabled.
+                              format: int64
                               type: integer
                             sources:
                               description: |-
@@ -9165,6 +9752,13 @@ spec:
                                           Mutually-exclusive with name.  The contents of all selected
                                           ClusterTrustBundles will be unified and deduplicated.
                                         type: string
+                                      user:
+                                        description: |-
+                                          user is Optional: The owner UID of the created file.
+                                          If specified, the item-level user field takes precedence over defaultUser.
+                                          (Alpha) This field requires the AtomicWriteVolumeUserFields feature gate to be enabled.
+                                        format: int64
+                                        type: integer
                                     required:
                                     - path
                                     type: object
@@ -9205,6 +9799,13 @@ spec:
                                                 May not contain the path element '..'.
                                                 May not start with the string '..'.
                                               type: string
+                                            user:
+                                              description: |-
+                                                user is Optional: The owner UID of the created file.
+                                                If specified, the item-level user field takes precedence over defaultUser.
+                                                (Alpha) This field requires the AtomicWriteVolumeUserFields feature gate to be enabled.
+                                              format: int64
+                                              type: integer
                                           required:
                                           - key
                                           - path
@@ -9301,11 +9902,130 @@ spec:
                                               - resource
                                               type: object
                                               x-kubernetes-map-type: atomic
+                                            user:
+                                              description: |-
+                                                user is Optional: The owner UID of the created file.
+                                                If specified, the item-level user field takes precedence over defaultUser.
+                                                (Alpha) This field requires the AtomicWriteVolumeUserFields feature gate to be enabled.
+                                              format: int64
+                                              type: integer
                                           required:
                                           - path
                                           type: object
                                         type: array
                                         x-kubernetes-list-type: atomic
+                                    type: object
+                                  podCertificate:
+                                    description: |-
+                                      Projects an auto-rotating credential bundle (private key and certificate
+                                      chain) that the pod can use either as a TLS client or server.
+                                      Kubelet generates a private key and uses it to send a
+                                      PodCertificateRequest to the named signer.  Once the signer approves the
+                                      request and issues a certificate chain, Kubelet writes the key and
+                                      certificate chain to the pod filesystem.  The pod does not start until
+                                      certificates have been issued for each podCertificate projected volume
+                                      source in its spec.
+                                      Kubelet will begin trying to rotate the certificate at the time indicated
+                                      by the signer using the PodCertificateRequest.Status.BeginRefreshAt
+                                      timestamp.
+                                      Kubelet can write a single file, indicated by the credentialBundlePath
+                                      field, or separate files, indicated by the keyPath and
+                                      certificateChainPath fields.
+                                      The credential bundle is a single file in PEM format.  The first PEM
+                                      entry is the private key (in PKCS#8 format), and the remaining PEM
+                                      entries are the certificate chain issued by the signer (typically,
+                                      signers will return their certificate chain in leaf-to-root order).
+                                      Prefer using the credential bundle format, since your application code
+                                      can read it atomically.  If you use keyPath and certificateChainPath,
+                                      your application must make two separate file reads. If these coincide
+                                      with a certificate rotation, it is possible that the private key and leaf
+                                      certificate you read may not correspond to each other.  Your application
+                                      will need to check for this condition, and re-read until they are
+                                      consistent.
+                                      The named signer controls chooses the format of the certificate it
+                                      issues; consult the signer implementation's documentation to learn how to
+                                      use the certificates it issues.
+                                    properties:
+                                      certificateChainPath:
+                                        description: |-
+                                          Write the certificate chain at this path in the projected volume.
+                                          Most applications should use credentialBundlePath.  When using keyPath
+                                          and certificateChainPath, your application needs to check that the key
+                                          and leaf certificate are consistent, because it is possible to read the
+                                          files mid-rotation.
+                                        type: string
+                                      credentialBundlePath:
+                                        description: |-
+                                          Write the credential bundle at this path in the projected volume.
+                                          The credential bundle is a single file that contains multiple PEM blocks.
+                                          The first PEM block is a PRIVATE KEY block, containing a PKCS#8 private
+                                          key.
+                                          The remaining blocks are CERTIFICATE blocks, containing the issued
+                                          certificate chain from the signer (leaf and any intermediates).
+                                          Using credentialBundlePath lets your Pod's application code make a single
+                                          atomic read that retrieves a consistent key and certificate chain.  If you
+                                          project them to separate files, your application code will need to
+                                          additionally check that the leaf certificate was issued to the key.
+                                        type: string
+                                      keyPath:
+                                        description: |-
+                                          Write the key at this path in the projected volume.
+                                          Most applications should use credentialBundlePath.  When using keyPath
+                                          and certificateChainPath, your application needs to check that the key
+                                          and leaf certificate are consistent, because it is possible to read the
+                                          files mid-rotation.
+                                        type: string
+                                      keyType:
+                                        description: |-
+                                          The type of keypair Kubelet will generate for the pod.
+                                          Valid values are "RSA3072", "RSA4096", "ECDSAP256", "ECDSAP384",
+                                          "ECDSAP521", and "ED25519".
+                                        type: string
+                                      maxExpirationSeconds:
+                                        description: |-
+                                          maxExpirationSeconds is the maximum lifetime permitted for the
+                                          certificate.
+                                          Kubelet copies this value verbatim into the PodCertificateRequests it
+                                          generates for this projection.
+                                          If omitted, kube-apiserver will set it to 86400(24 hours). kube-apiserver
+                                          will reject values shorter than 3600 (1 hour).  The maximum allowable
+                                          value is 7862400 (91 days).
+                                          The signer implementation is then free to issue a certificate with any
+                                          lifetime *shorter* than MaxExpirationSeconds, but no shorter than 3600
+                                          seconds (1 hour).  This constraint is enforced by kube-apiserver.
+                                          `kubernetes.io` signers will never issue certificates with a lifetime
+                                          longer than 24 hours.
+                                        format: int32
+                                        type: integer
+                                      signerName:
+                                        description: Kubelet's generated CSRs will
+                                          be addressed to this signer.
+                                        type: string
+                                      user:
+                                        description: |-
+                                          user is Optional: The owner UID of the created file.
+                                          If specified, the item-level user field takes precedence over defaultUser.
+                                          (Alpha) This field requires the AtomicWriteVolumeUserFields feature gate to be enabled.
+                                        format: int64
+                                        type: integer
+                                      userAnnotations:
+                                        additionalProperties:
+                                          type: string
+                                        description: |-
+                                          userAnnotations allow pod authors to pass additional information to
+                                          the signer implementation.  Kubernetes does not restrict or validate this
+                                          metadata in any way.
+                                          These values are copied verbatim into the `spec.unverifiedUserAnnotations` field of
+                                          the PodCertificateRequest objects that Kubelet creates.
+                                          Entries are subject to the same validation as object metadata annotations,
+                                          with the addition that all keys must be domain-prefixed. No restrictions
+                                          are placed on values, except an overall size limitation on the entire field.
+                                          Signers should document the keys and values they support. Signers should
+                                          deny requests that contain keys they do not recognize.
+                                        type: object
+                                    required:
+                                    - keyType
+                                    - signerName
                                     type: object
                                   secret:
                                     description: secret information about the secret
@@ -9344,6 +10064,13 @@ spec:
                                                 May not contain the path element '..'.
                                                 May not start with the string '..'.
                                               type: string
+                                            user:
+                                              description: |-
+                                                user is Optional: The owner UID of the created file.
+                                                If specified, the item-level user field takes precedence over defaultUser.
+                                                (Alpha) This field requires the AtomicWriteVolumeUserFields feature gate to be enabled.
+                                              format: int64
+                                              type: integer
                                           required:
                                           - key
                                           - path
@@ -9391,6 +10118,13 @@ spec:
                                           path is the path relative to the mount point of the file to project the
                                           token into.
                                         type: string
+                                      user:
+                                        description: |-
+                                          user is Optional: The owner UID of the created file.
+                                          If specified, the item-level user field takes precedence over defaultUser.
+                                          (Alpha) This field requires the AtomicWriteVolumeUserFields feature gate to be enabled.
+                                        format: int64
+                                        type: integer
                                     required:
                                     - path
                                     type: object
@@ -9441,7 +10175,6 @@ spec:
                           description: |-
                             rbd represents a Rados Block Device mount on the host that shares a pod's lifetime.
                             Deprecated: RBD is deprecated and the in-tree rbd type is no longer supported.
-                            More info: https://examples.k8s.io/volumes/rbd/README.md
                           properties:
                             fsType:
                               description: |-
@@ -9598,6 +10331,13 @@ spec:
                                 mode, like fsGroup, and the result can be other mode bits set.
                               format: int32
                               type: integer
+                            defaultUser:
+                              description: |-
+                                defaultUser is Optional: The owner UID of the created files by default.
+                                The defaultUser field is only used as a fallback when the item-level user field is unset.
+                                (Alpha) This field requires the AtomicWriteVolumeUserFields feature gate to be enabled.
+                              format: int64
+                              type: integer
                             items:
                               description: |-
                                 items If unspecified, each key-value pair in the Data field of the referenced
@@ -9631,6 +10371,13 @@ spec:
                                       May not contain the path element '..'.
                                       May not start with the string '..'.
                                     type: string
+                                  user:
+                                    description: |-
+                                      user is Optional: The owner UID of the created file.
+                                      If specified, the item-level user field takes precedence over defaultUser.
+                                      (Alpha) This field requires the AtomicWriteVolumeUserFields feature gate to be enabled.
+                                    format: int64
+                                    type: integer
                                 required:
                                 - key
                                 - path

--- a/prow/config/Chart.yaml
+++ b/prow/config/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: prow-config
 description: Configuration for the ACK Prow cluster
 type: application
-version: 0.4.24
+version: 0.4.25
 appVersion: "1.16.0"

--- a/prow/config/values.yaml
+++ b/prow/config/values.yaml
@@ -88,8 +88,8 @@ imageMirror:
   # render time rather than producing a reference to account "".
   accountId: ""
   region: ""
-  prowVersion: "v20260702-fff8399c7"
-  prowPatchRevision: "1"
+  prowVersion: "v20260908-104d452f4"
+  prowPatchRevision: "2"
 
 # Prow component images. EMPTY MEANS COMPOSED from imageMirror above; set one to override it
 # outright, which is what the Flux HelmRelease does for every component.

--- a/prow/jobs/values.yaml
+++ b/prow/jobs/values.yaml
@@ -24,6 +24,6 @@ controllerEcrRegistry: ""
 # prowPatchRevision is a monotonic counter appended to mirrored image tags and must never be
 # reset. It is consumed here as the whole `-ack.<n>` suffix rather than the bare number,
 # because a bare number reaches env[].value as a YAML int and the API server rejects it.
-prowVersion: "v20260702-fff8399c7"
-toolsVersion: "v20260515-778139c32d"
-prowPatchRevision: "1"
+prowVersion: "v20260908-104d452f4"
+toolsVersion: "v20260729-f66136c16c"
+prowPatchRevision: "2"


### PR DESCRIPTION
## Description

Upgrades the Prow control plane to `v20260908-104d452f4` (from `v20260702-fff8399c7`) and tools to `v20260729-f66136c16c` (from `v20260515-778139c32d`), keeping us current with upstream. Bumps `prowPatchRevision` to `2`.

Motivated by outdated OS packages in the currently deployed control-plane images. Vulnerability scanning flagged `curl`, `expat` and `openssl` across every component running at `v20260702-fff8399c7-ack.1` — `crier`, `deck`, `ghproxy`, `hook`, `horologium`, `prow-controller-manager`, `sidecar`, `sinker`, `status-reconciler` and `tide`.

The patch revision bump is the operative part of the fix. As `prow-mirror`'s own comment explains, upstream pins its ko base images in `.ko.yaml` and refreshes that pin only every few months, so a Prow release ships outdated `expat`/`openssl`/`curl` **regardless of how recent the tag is**. The `apk upgrade` during mirroring is what patches them. Because `-ack.2` does not yet exist in ECR, the mirror's existence check will not skip it and all 15 mirrored images get rebuilt against current OS packages.

Note that the version bump alone would not have been sufficient — a newer upstream tag still carries the stale base. The revision bump is what forces the rebuild.

## Changes

- `prow/config/values.yaml` — `imageMirror.prowVersion`, `imageMirror.prowPatchRevision`
- `prow/jobs/values.yaml` — `prowVersion`, `toolsVersion`, `prowPatchRevision`
- `flux/prow/charts/prow-mirror/values.yaml` — same three
- `prow/config/Chart.yaml` — 0.4.24 → 0.4.25
- `flux/prow/crds/prowjob_customresourcedefinition.yaml` — refreshed from upstream

All three version copies move together, as `scripts/upgrade-prow.sh` requires.

## CRD upgrade

The refresh moves the CRD to controller-gen `v0.22.0`. Verified additive:

- 22 top-level `spec` properties before and after, none removed
- Single `v1` version, served and stored — no migration
- `preserveUnknownFields: false` retained, so the existing `ignoreDifferences` entry in `argocd/applications/values.yaml` stays valid
- New nested fields (`bindMountOptions`, podCertificate volume source, container restart rules, resize policy) are optional pod-spec additions from a newer Kubernetes API
- The apparent `mountPath` removal in the diff is `bindMountOptions` sorting ahead of it; the count is 3 both before and after

**Re-added the `argocd.argoproj.io/sync-options: ServerSideApply=true` annotation**, which `upgrade-prow.sh` strips when it overwrites the file from upstream. Without it Argo CD applies the CRD client-side and the API server rejects the `last-applied-configuration` annotation as too long. The manifest grew 667 KB → 704 KB, so the 262144-byte limit is further out of reach than before, and the comment's stated size was updated to match.

## Testing

- `helm template` on `prow/config` — all 9 components and 4 utility images compose to `v20260908-104d452f4-ack.2`
- `helm template` on `prow/jobs` — `PROW_VERSION`, `TOOLS_VERSION` correct, `PATCH_SUFFIX: "-ack.2"` renders as a string
- `helm template` on `prow-mirror` — targets both new upstream tags
- `kubectl kustomize flux/prow/crds` — builds clean, sync-options annotation present in output
- No references to the previous versions remain anywhere in the repo

## Follow-ups (not in this PR)

- A container is running `ack-prow-webhook:v1.0.30`, an image name that appears nowhere in this repo — we build `agent-plugin` per `prow/plugins/images_config.yaml`. Looks like an orphaned Deployment running a pre-rename artifact, and its packages are stale. Needs a cluster-side look rather than a repo change.
- `scripts/upgrade-prow.sh` has two rough edges worth fixing: `yq -i` reformats the values files (strips all blank lines), and the CRD `cp` silently drops the sync-options annotation.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
