### PR TITLE
Add build-cluster workflow-runner IAM role + agentE2eAccountId plumbing

### DIFF
--- a/argocd/applications/values.yaml
+++ b/argocd/applications/values.yaml
@@ -107,7 +107,7 @@ applications:
     path: flux/ack/charts/ack-pod-identity-roles
     targetNamespace: ack-system
     wave: 2
-    values: [accountId, publishAccountId, region, stackName]
+    values: [accountId, publishAccountId, region, stackName, agentE2eAccountId]
     automated: true
 
   ack-prow:

--- a/bootstrap/argocd-applications.tf
+++ b/bootstrap/argocd-applications.tf
@@ -35,6 +35,12 @@ locals {
     prowDomain        = var.prow_domain
     prowImagesRepoUri = local.prow_images_repo_uri
 
+    # Sandbox account whose agent-e2e-test-role the build-cluster add-resource agent
+    # assumes for e2e. Already a string (see variable), so it does not trip the
+    # 12-digit-account-id-as-float hazard the chartValues comment warns about. Empty in
+    # environments not running agent e2e, which omits the grant (prow-iam-roles.yaml).
+    agentE2eAccountId = var.agent_e2e_account_id
+
     # Needed by prow-build-cluster-connection: the Application it creates at
     # runtime has to name its own source.
     testInfraOrg    = var.test_infra_org

--- a/bootstrap/scripts/bootstrap-env.sh
+++ b/bootstrap/scripts/bootstrap-env.sh
@@ -99,7 +99,7 @@ prompt_all_vars() {
   echo "Configure environment variables:" >&2
   echo "" >&2
 
-  local test_infra_branch stage prow_domain kubernetes_org redhat_org controllers publish_account_id
+  local test_infra_branch stage prow_domain kubernetes_org redhat_org controllers publish_account_id agent_e2e_account_id
 
   # Helper to extract existing value from JSON, falling back to provided default
   _default() {
@@ -143,6 +143,9 @@ prompt_all_vars() {
   redhat_org=$(prompt "GitHub org for community-operators-prod fork" "$(_default redhat_org "$default_redhat_org")")
   controllers=$(prompt "ACK controllers for ECR repos (comma-separated)" "$(_default controllers "ecrpublic")")
   publish_account_id=$(prompt "AWS account ID for ECR Public publishing" "$(_default publish_account_id "${account_id}")")
+  # Optional sandbox account whose agent-e2e-test-role the build-cluster add-resource
+  # agent assumes for e2e. Blank (the default) omits the e2e IAM grants entirely.
+  agent_e2e_account_id=$(prompt "AWS account ID for agent e2e sandbox (blank to disable)" "$(_default agent_e2e_account_id "")")
 
   # Build JSON
   jq -n \
@@ -157,6 +160,7 @@ prompt_all_vars() {
     --arg redhat_org "$redhat_org" \
     --arg controllers "$controllers" \
     --arg publish_account_id "$publish_account_id" \
+    --arg agent_e2e_account_id "$agent_e2e_account_id" \
     '{
       region: $region,
       account_id: $account_id,
@@ -168,7 +172,8 @@ prompt_all_vars() {
       kubernetes_org: $kubernetes_org,
       redhat_org: $redhat_org,
       controllers: $controllers,
-      publish_account_id: $publish_account_id
+      publish_account_id: $publish_account_id,
+      agent_e2e_account_id: $agent_e2e_account_id
     }'
 }
 

--- a/bootstrap/variables.tf
+++ b/bootstrap/variables.tf
@@ -53,6 +53,20 @@ variable "publish_account_id" {
   type        = string
 }
 
+variable "agent_e2e_account_id" {
+  description = <<-EOT
+    AWS account ID of the dedicated sandbox that owns the agent-e2e-test-role, which the
+    build-cluster add-resource agent workflow assumes to run e2e against real AWS
+    resources. Distinct from the CI test accounts on purpose.
+
+    Empty (the default) omits the e2e sts:AssumeRole / ssm:GetParameter grants from the
+    build-cluster workflow-runner role entirely, so environments not running agent e2e are
+    unaffected. Set it only where agent e2e is enabled.
+  EOT
+  type        = string
+  default     = ""
+}
+
 variable "seed_ack_bootstrap_policy" {
   description = <<-EOT
     Seed the ACK capability role with the minimal BootstrapPermissions inline policy.

--- a/flux/ack/charts/ack-pod-identity-roles/templates/prow-iam-roles.yaml
+++ b/flux/ack/charts/ack-pod-identity-roles/templates/prow-iam-roles.yaml
@@ -3,6 +3,11 @@
 {{- $publishAccountId := required "publishAccountId is required" .Values.publishAccountId }}
 {{- $region := required "region is required" .Values.region }}
 {{- $stackName := required "stackName is required" .Values.stackName }}
+{{- /* Optional: the dedicated sandbox account whose agent-e2e-test-role the
+       build-cluster agent workflow assumes to run e2e. Empty (the
+       default) omits the e2e assume/SSM grants entirely, so environments that
+       do not run agent e2e are unaffected. */ -}}
+{{- $agentE2eAccountId := .Values.agentE2eAccountId | default "" }}
 ---
 # Deployment Role - used by Prow core components (deck, hook, etc.)
 apiVersion: iam.services.k8s.aws/v1alpha1
@@ -357,6 +362,132 @@ spec:
               "arn:aws:s3:::{{ $stackName }}-prow-logs-{{ $accountId }}",
               "arn:aws:s3:::{{ $stackName }}-prow-logs-{{ $accountId }}/*"
             ]
+          }
+        ]
+      }
+---
+# Build Cluster Workflow Runner Role - used by agent workflow job pods running on the
+# dedicated build cluster (cluster: build) to mount the SecretProviderClass via the
+# Secrets Store CSI driver. Deliberately isolated from the control-plane
+# prow-workflow-runner-role: it can read ONLY the agent-specific GitHub PAT secret
+# (ack/prow/agent-github-pat-token), never the shared prowjob token or any other
+# ack/prow secret. Bound to the build cluster's test-pods/workflow-runner SA by the
+# ack-build-infra pod-identities chart.
+apiVersion: iam.services.k8s.aws/v1alpha1
+kind: Role
+metadata:
+  name: prow-build-workflow-runner-role
+  annotations:
+    kustomize.toolkit.fluxcd.io/prune: disabled
+    helm.sh/resource-policy: keep
+spec:
+  name: {{ $stackName }}-prow-build-workflow-runner-role
+  assumeRolePolicyDocument: |
+    {
+      "Version": "2012-10-17",
+      "Statement": [
+        {
+          "Effect": "Allow",
+          "Principal": {
+            "Service": "pods.eks.amazonaws.com"
+          },
+          "Action": ["sts:AssumeRole", "sts:TagSession"]
+        }
+      ]
+    }
+  inlinePolicies:
+    SecretsAccess: |
+      {
+        "Version": "2012-10-17",
+        "Statement": [
+          {
+            "Effect": "Allow",
+            "Action": ["secretsmanager:GetSecretValue", "secretsmanager:DescribeSecret"],
+            "Resource": [
+              "arn:aws:secretsmanager:{{ $region }}:{{ $accountId }}:secret:ack/prow/agent-github-pat-token-*"
+            ]
+          }
+        ]
+      }
+{{- if $agentE2eAccountId }}
+    AssumeAgentE2ERole: |
+      {
+        "Version": "2012-10-17",
+        "Statement": [
+          {
+            "Effect": "Allow",
+            "Action": ["sts:AssumeRole", "sts:TagSession"],
+            "Resource": "arn:aws:iam::{{ $agentE2eAccountId }}:role/agent-e2e-test-role"
+          }
+        ]
+      }
+    SSMAgentE2ERole: |
+      {
+        "Version": "2012-10-17",
+        "Statement": [
+          {
+            "Effect": "Allow",
+            "Action": ["ssm:GetParameter"],
+            "Resource": "arn:aws:ssm:{{ $region }}:{{ $accountId }}:parameter/ack/prow/agent-e2e-role"
+          }
+        ]
+      }
+{{- end }}
+    BedrockInvoke: |
+      {
+        "Version": "2012-10-17",
+        "Statement": [
+          {
+            "Effect": "Allow",
+            "Action": [
+              "bedrock:InvokeModel",
+              "bedrock:InvokeModelWithResponseStream",
+              "bedrock:Converse",
+              "bedrock:ConverseStream"
+            ],
+            "Resource": [
+              "arn:aws:bedrock:*::foundation-model/anthropic.*",
+              "arn:aws:bedrock:*:{{ $accountId }}:inference-profile/*.anthropic.*"
+            ]
+          }
+        ]
+      }
+    S3Logs: |
+      {
+        "Version": "2012-10-17",
+        "Statement": [
+          {
+            "Effect": "Allow",
+            "Action": ["s3:Get*", "s3:List*", "s3:Put*", "s3:DeleteObject"],
+            "Resource": [
+              "arn:aws:s3:::{{ $stackName }}-prow-logs-{{ $accountId }}",
+              "arn:aws:s3:::{{ $stackName }}-prow-logs-{{ $accountId }}/*"
+            ]
+          }
+        ]
+      }
+    # Read-only ECR Public access so prow-job.sh can authenticate `docker login
+    # public.ecr.aws`, raising the pull-rate-limit ceiling for the base images the
+    # e2e controller build pulls. Mirrors the presubmit role's ECRPublicRead.
+    ECRPublicRead: |
+      {
+        "Version": "2012-10-17",
+        "Statement": [
+          {
+            "Effect": "Allow",
+            "Action": [
+              "ecr-public:GetAuthorizationToken",
+              "sts:GetServiceBearerToken",
+              "ecr-public:BatchCheckLayerAvailability",
+              "ecr-public:GetRepositoryPolicy",
+              "ecr-public:DescribeRepositories",
+              "ecr-public:DescribeRegistries",
+              "ecr-public:DescribeImages",
+              "ecr-public:DescribeImageTags",
+              "ecr-public:GetRepositoryCatalogData",
+              "ecr-public:GetRegistryCatalogData"
+            ],
+            "Resource": "*"
           }
         ]
       }

--- a/flux/ack/charts/ack-pod-identity-roles/values.yaml
+++ b/flux/ack/charts/ack-pod-identity-roles/values.yaml
@@ -6,3 +6,7 @@ accountId: ""
 publishAccountId: ""
 region: ""
 stackName: ""
+# Optional: the dedicated sandbox account whose agent-e2e-test-role the build-cluster
+# agent workflow assumes for e2e. Left empty so environments that do not run
+# agent e2e omit the assume/SSM grants entirely (see prow-iam-roles.yaml).
+agentE2eAccountId: ""


### PR DESCRIPTION
**What**

Introduces prow-build-workflow-runner-role, the tightly-scoped IAM role the add-resource agent's job pods use on the dedicated Prow build cluster, and threads a new optional agentE2eAccountId through Terraform → ArgoCD → the ack-pod-identity-roles chart.

The role grants only:
- read of ack/prow/agent-github-pat-token (the agent's dedicated GitHub PAT — nothing else),
- Bedrock model invoke (Anthropic models/inference profiles),
- S3 access to the prow-logs bucket,
- ECR-Public read (pull-rate ceiling for e2e base images).

When agentE2eAccountId is set, two gated statements are added: sts:AssumeRole on arn:aws:iam::<agentE2eAccountId>:role/agent-e2e-test-role and ssm:GetParameter on /ack/prow/agent-e2e-role. Empty (the default) omits them, so environments not running agent e2e are unaffected.

Files

- flux/ack/charts/ack-pod-identity-roles/templates/prow-iam-roles.yaml — new role + $agentE2eAccountId-gated e2e grants.
- flux/ack/charts/ack-pod-identity-roles/values.yaml — agentE2eAccountId: "".
- argocd/applications/values.yaml — add agentE2eAccountId to the chart's values: list.
- bootstrap/{variables.tf, argocd-applications.tf, scripts/bootstrap-env.sh} — declare agent_e2e_account_id (default ""), pass it into chartValues, prompt for it.

Safety

Purely additive and inert: the role is bound to nothing until the build-cluster infra PR (PodIdentityAssociation), and the e2e grants stay off until agentE2eAccountId is set. The existing add-resource workflow is untouched.

Terraform follow-up (non-git)

The chart value defaults empty, so merging this PR alone renders the role without the e2e grants. To activate them: set agent_e2e_account_id in the prod bootstrap tfvars and run terraform apply. That updates the Terraform-managed root ArgoCD Application's values; ArgoCD re-renders and auto-syncs ack-pod-identity-roles, and the ACK IAM controller applies the added statements to the live role — no prow-gen, image build, or manual sync needed.

Validation

Confirm the ArgoCD app syncs healthy and the role exists with only the base grants after merge; after the tfvars change + terraform apply, confirm the role picks up the two e2e statements. The chart can also be rendered locally both ways (account set vs empty) to check the grants toggle.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
