### PR TITLE
Add build-cluster runtime infra for the agent workflow-runner

### DIFF
--- a/bootstrap/README.md
+++ b/bootstrap/README.md
@@ -44,6 +44,13 @@ aws secretsmanager create-secret \
   --name "ack/prow/api-model-kb" \
   --secret-string "<KNOWLEDGE_BASE_ID>"
 
+# Dedicated GitHub Personal Access Token for the agent workflow. Kept separate from
+# the shared github-pat-token above: the agent runs on the build cluster and its
+# workflow-runner IAM role can read ONLY this secret.
+aws secretsmanager create-secret \
+  --name "ack/prow/agent-github-pat-token" \
+  --secret-string "<AGENT_PAT_TOKEN>"
+
 ```
 
 The `ecr-pullthroughcache/ghcr-fluxcd` secret and its resource policy used to be created here.

--- a/flux/ack/charts/ack-build-infra/templates/addons.yaml
+++ b/flux/ack/charts/ack-build-infra/templates/addons.yaml
@@ -1,0 +1,38 @@
+# EKS Addons for the build cluster, reconciled by the control-plane ACK EKS
+# controller. clusterRef (not a literal clusterName) because the build cluster's
+# name/ARN is not knowable until ACK creates the Cluster CR named build-cluster;
+# the reference resolves once that CR is synced.
+#
+# The Secrets Store CSI driver is required so agent workflow job pods (cluster:
+# build) can mount their SecretProviderClass and have the dedicated GitHub PAT
+# synced into a Kubernetes Secret. syncSecret.enabled mirrors the control-plane
+# addon (ack-addons chart) so secretObjects produce real Secret objects.
+{{- $stackName := required "stackName is required" .Values.stackName }}
+---
+apiVersion: eks.services.k8s.aws/v1alpha1
+kind: Addon
+metadata:
+  name: build-cluster-secrets-store-csi
+  annotations:
+    kustomize.toolkit.fluxcd.io/prune: disabled
+    helm.sh/resource-policy: keep
+spec:
+  clusterRef:
+    from:
+      name: build-cluster
+  name: aws-secrets-store-csi-driver-provider
+  # Keep aligned with the build cluster's Kubernetes version (currently 1.35).
+  # Verify with:
+  #   aws eks describe-addon-versions \
+  #     --addon-name aws-secrets-store-csi-driver-provider \
+  #     --kubernetes-version 1.35 --region us-west-2 \
+  #     --query 'addons[0].addonVersions[].addonVersion'
+  addonVersion: v3.1.2-eksbuild.1
+  configurationValues: |-
+    {
+      "secrets-store-csi-driver": {
+        "syncSecret": {
+          "enabled": true
+        }
+      }
+    }

--- a/flux/ack/charts/ack-build-infra/templates/pod-identities/prow-pod-identities.yaml
+++ b/flux/ack/charts/ack-build-infra/templates/pod-identities/prow-pod-identities.yaml
@@ -6,11 +6,13 @@
 # account (the ack-pod-identity-roles chart), so we reuse
 # them by ARN — no new roles/ tree here.
 #
-# Only pre-submit-service-account is bound: the build cluster runs pre-submit jobs
-# exclusively (post-submit/periodic/mirror stay on the control-plane `default`
-# cluster), keeping the identity surface minimal for the untrusted PR code here.
-# Its cross-account test-role assume is authorized at the account level, not by
-# anything on the build-cluster side.
+# Two SAs are bound: pre-submit-service-account (untrusted PR code) and
+# workflow-runner (agent workflow jobs, cluster: build). post-submit/periodic/mirror
+# stay on the control-plane `default` cluster, keeping the identity surface minimal.
+# pre-submit's cross-account test-role assume is authorized at the account level, not
+# by anything on the build-cluster side. workflow-runner is bound to a dedicated,
+# tightly scoped role (prow-build-workflow-runner-role) that can read ONLY the
+# agent-specific GitHub PAT secret — see the ack-pod-identity-roles chart.
 ---
 apiVersion: eks.services.k8s.aws/v1alpha1
 kind: PodIdentityAssociation
@@ -26,3 +28,18 @@ spec:
   namespace: test-pods
   serviceAccount: pre-submit-service-account
   roleARN: arn:aws:iam::{{ $accountId }}:role/{{ $stackName }}-prow-presubmit-role
+---
+apiVersion: eks.services.k8s.aws/v1alpha1
+kind: PodIdentityAssociation
+metadata:
+  name: prow-build-workflow-runner-pod-identity
+  annotations:
+    kustomize.toolkit.fluxcd.io/prune: disabled
+    helm.sh/resource-policy: keep
+spec:
+  clusterRef:
+    from:
+      name: build-cluster
+  namespace: test-pods
+  serviceAccount: workflow-runner
+  roleARN: arn:aws:iam::{{ $accountId }}:role/{{ $stackName }}-prow-build-workflow-runner-role

--- a/flux/prow/charts/prow-build-cluster-resources/templates/namespace.yaml
+++ b/flux/prow/charts/prow-build-cluster-resources/templates/namespace.yaml
@@ -40,3 +40,14 @@ kind: ServiceAccount
 metadata:
   name: pre-submit-service-account
   namespace: test-pods
+---
+# workflow-runner runs the agent workflow job pods (cluster: build). Like
+# pre-submit-service-account it must exist here so the build-cluster
+# PodIdentityAssociation (ack-build-infra pod-identities) can bind it to its IAM
+# role; the pod also mounts the SecretProviderClass below, which the Secrets Store
+# CSI driver syncs using this SA's Pod Identity credentials.
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: workflow-runner
+  namespace: test-pods

--- a/flux/prow/charts/prow-build-cluster-resources/templates/secret-provider.yaml
+++ b/flux/prow/charts/prow-build-cluster-resources/templates/secret-provider.yaml
@@ -1,0 +1,36 @@
+# SecretProviderClass for agent workflow job pods on the build cluster.
+#
+# The Secrets Store CSI driver — installed on this cluster via the
+# build-cluster-secrets-store-csi Addon (ack-build-infra chart) — fetches the
+# dedicated agent GitHub PAT from AWS Secrets Manager using the workflow-runner SA's
+# Pod Identity credentials (usePodIdentity). secretObjects then syncs it into a
+# Kubernetes Secret (agent-github-pat-token) that the job pod consumes as
+# GITHUB_TOKEN via secretKeyRef.
+#
+# This is deliberately narrow: it exposes ONLY ack/prow/agent-github-pat-token, and
+# the workflow-runner role can read nothing else — isolating the build cluster from
+# the shared prowjob-github-pat-token and other ack/prow secrets on the control plane.
+#
+# ORDERING: this object's CRD (secrets-store.csi.x-k8s.io) does not exist until the
+# CSI driver Addon has installed on the build cluster. Argo CD is eventually
+# consistent here — it retries this Application until the Addon reconciles and the
+# CRD appears, then the SecretProviderClass syncs.
+apiVersion: secrets-store.csi.x-k8s.io/v1
+kind: SecretProviderClass
+metadata:
+  name: agent-secrets
+  namespace: test-pods
+spec:
+  provider: aws
+  parameters:
+    usePodIdentity: "true"
+    objects: |
+      - objectName: "ack/prow/agent-github-pat-token"
+        objectType: "secretsmanager"
+        objectAlias: "token"
+  secretObjects:
+  - secretName: agent-github-pat-token
+    type: Opaque
+    data:
+    - objectName: token
+      key: token

--- a/scripts/lib/aws.sh
+++ b/scripts/lib/aws.sh
@@ -42,7 +42,7 @@ daws() {
     # When static creds exist, skip web identity and AWS config mount to avoid
     # conflicts with pod identity configuration in nested containers
     aws_cli_static_creds_env=""
-    aws_config_mount="-v ~/.aws:/root/.aws:z"
+    aws_config_mount="-v $HOME/.aws:/root/.aws:z"
     if [ -n "${AWS_ACCESS_KEY_ID:-}" ]; then
         aws_cli_static_creds_env="--env AWS_ACCESS_KEY_ID --env AWS_SECRET_ACCESS_KEY --env AWS_SESSION_TOKEN"
         # Clear web identity env to prevent Docker from using pod identity


### PR DESCRIPTION
Issue #, if available:

Description of changes:

Creates the objects the add-resource agent's job pods need on the dedicated Prow build cluster, so a job scheduled with Cluster: "build" can obtain its IAM identity and pull its GitHub token. All additive; nothing consumes these until the plugin/rework PRs.

- workflow-runner ServiceAccount (build-cluster test-pods) — the identity the agent pod runs as.
- agent-secrets SecretProviderClass — exposes only ack/prow/agent-github-pat-token via the pod's Pod Identity, synced into a Kubernetes Secret the pod reads as GITHUB_TOKEN.
- aws-secrets-store-csi-driver-provider EKS Addon — the Secrets Store CSI driver on the build cluster that backs the SecretProviderClass.
- PodIdentityAssociation — binds build-cluster test-pods/workflow-runner to prow-build-workflow-runner-role (the scoped role from PR1).
- scripts/lib/aws.sh — fixes the nested-daws AWS config mount (~/.aws → $HOME/.aws) so tilde expansion works in the e2e container.
- bootstrap/README.md — documents the new ack/prow/agent-github-pat-token secret.

Files

- flux/prow/charts/prow-build-cluster-resources/templates/{namespace.yaml, secret-provider.yaml}
- flux/ack/charts/ack-build-infra/templates/{addons.yaml, pod-identities/prow-pod-identities.yaml}
- scripts/lib/aws.sh
- bootstrap/README.md

Safety

Additive and inert until PR3/PR4. The SecretProviderClass is only a spec — the CSI driver fetches the secret when a pod actually mounts agent-secrets The PodIdentityAssociation binds the role added in #1094 , already live in prod. No terraform required. The existing add-resource workflow is untouched.


Validation

After merge, confirm the ack-build-infra and prow-build-cluster-resources ArgoCD apps sync healthy (the CSI-driver CRD may need a retry or two before the SecretProviderClass applies), and that the SA, SecretProviderClass, CSI addon, and PodIdentityAssociation are present on the build cluster.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
