### PR TITLE
Upgrade agent-plugin: route workflows to the build cluster + extra_res + e2e

### DIFF
--- a/prow/plugins/agent-plugin/cmd/webhook-server/main.go
+++ b/prow/plugins/agent-plugin/cmd/webhook-server/main.go
@@ -107,17 +107,21 @@ func main() {
 		logrus.WithError(err).Fatal("Error getting GitHub client.")
 	}
 
-	// Load workflow configuration
-	workflowConfig, err := prowjob.LoadWorkflowConfig(o.workflowConfigPath)
+	// Workflow config lives in a mounted ConfigMap and can change while the
+	// plugin is running (e.g. an image-tag bump). Construct a loader that
+	// re-reads the file on mtime change, and prime it once at startup so a
+	// bad path or content fails fast rather than at first webhook.
+	workflowLoader := prowjob.NewWorkflowConfigLoader(o.workflowConfigPath)
+	initial, err := workflowLoader.Get()
 	if err != nil {
 		logrus.Fatalf("Failed to load workflows: %v", err)
 	}
 
-	logrus.Infof("Loaded %d workflows from %s", len(workflowConfig.GetWorkflowsMap()), o.workflowConfigPath)
+	logrus.Infof("Loaded %d workflows from %s", len(initial.GetWorkflowsMap()), o.workflowConfigPath)
 
-	prowJobGenerator := prowjob.NewGenerator(workflowConfig.GetWorkflowsMap())
+	prowJobGenerator := prowjob.NewGenerator(workflowLoader)
 	server, err := webhook.NewServer(
-		workflowConfig,
+		workflowLoader,
 		prowJobGenerator,
 		githubClient,
 		secret.GetTokenGenerator(o.webhookSecretFile),

--- a/prow/plugins/agent-plugin/pkg/prowjob/e2e_pod_test.go
+++ b/prow/plugins/agent-plugin/pkg/prowjob/e2e_pod_test.go
@@ -1,0 +1,127 @@
+// Copyright 2020 Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package prowjob
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	v1 "k8s.io/api/core/v1"
+)
+
+// TestLoadWorkflowConfigE2E verifies the `e2e` flag round-trips through the
+// loader (defaults false when absent).
+func TestLoadWorkflowConfigE2E(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "wf.yaml")
+	content := `
+workflows:
+  add-resource:
+    description: test
+    image: repo:tag
+    command: ["./prow-job.sh"]
+    timeout: "45m"
+    e2e: true
+  no-e2e:
+    description: test
+    image: repo:tag
+    command: ["./prow-job.sh"]
+    timeout: "45m"
+`
+	if err := os.WriteFile(p, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := LoadWorkflowConfig(p)
+	if err != nil {
+		t.Fatalf("LoadWorkflowConfig: %v", err)
+	}
+	if w, _ := cfg.GetWorkflowByName("add-resource"); !w.E2E {
+		t.Errorf("add-resource: want E2E=true")
+	}
+	if w, _ := cfg.GetWorkflowByName("no-e2e"); w.E2E {
+		t.Errorf("no-e2e: want E2E=false (default)")
+	}
+}
+
+// TestApplyE2EPodSettings verifies the inlined DinD/kind provisioning: the
+// container is privileged, gets the DinD/RUN_E2E env, and the pod carries the
+// docker + kind volumes with matching mounts.
+func TestApplyE2EPodSettings(t *testing.T) {
+	podSpec := &v1.PodSpec{
+		Containers: []v1.Container{{
+			Name: "workflow-runner",
+			Env:  []v1.EnvVar{{Name: "EXISTING", Value: "keep"}},
+		}},
+	}
+	applyE2EPodSettings(podSpec)
+
+	c := podSpec.Containers[0]
+	if c.SecurityContext == nil || c.SecurityContext.Privileged == nil || !*c.SecurityContext.Privileged {
+		t.Fatalf("container must be privileged for DinD; got %+v", c.SecurityContext)
+	}
+
+	env := map[string]string{}
+	for _, e := range c.Env {
+		env[e.Name] = e.Value
+	}
+	if env["EXISTING"] != "keep" {
+		t.Errorf("existing env must be preserved, got %v", env)
+	}
+	for _, want := range []string{"DOCKER_IN_DOCKER_ENABLED", "RUN_E2E"} {
+		if env[want] != "true" {
+			t.Errorf("env %s: want true, got %q", want, env[want])
+		}
+	}
+
+	// Every declared volume must have a matching mount and vice versa.
+	vols := map[string]bool{}
+	for _, v := range podSpec.Volumes {
+		vols[v.Name] = true
+	}
+	mounts := map[string]string{}
+	for _, m := range c.VolumeMounts {
+		mounts[m.Name] = m.MountPath
+	}
+	wantMounts := map[string]string{
+		"docker-graph": "/docker-graph",
+		"docker-root":  "/var/lib/docker",
+		"modules":      "/lib/modules",
+		"cgroup":       "/sys/fs/cgroup",
+	}
+	for name, path := range wantMounts {
+		if !vols[name] {
+			t.Errorf("missing volume %q", name)
+		}
+		if mounts[name] != path {
+			t.Errorf("mount %q: want %q, got %q", name, path, mounts[name])
+		}
+	}
+
+	// The kind host mounts must be real hostPaths (not emptyDirs).
+	for _, v := range podSpec.Volumes {
+		if v.Name == "modules" || v.Name == "cgroup" {
+			if v.HostPath == nil {
+				t.Errorf("volume %q must be a hostPath", v.Name)
+			}
+		}
+	}
+}
+
+// TestApplyE2EPodSettingsNilSafe guards the no-container edge case.
+func TestApplyE2EPodSettingsNilSafe(t *testing.T) {
+	applyE2EPodSettings(nil)
+	applyE2EPodSettings(&v1.PodSpec{}) // no containers; must not panic
+}

--- a/prow/plugins/agent-plugin/pkg/prowjob/extrarefs_test.go
+++ b/prow/plugins/agent-plugin/pkg/prowjob/extrarefs_test.go
@@ -1,0 +1,112 @@
+// Copyright 2020 Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package prowjob
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestLoadWorkflowConfigExtraRefs verifies the extra_refs YAML round-trips
+// through the loader (sigs.k8s.io/yaml uses the json tags).
+func TestLoadWorkflowConfigExtraRefs(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "wf.yaml")
+	content := `
+workflows:
+  add-resource:
+    description: test
+    image: repo:tag
+    command: ["./prow-job.sh"]
+    timeout: "45m"
+    extra_refs:
+      - org: aws-controllers-k8s
+        repo: code-generator
+        base_ref: main
+        env: CODEGEN_DIR
+      - org: aws-controllers-k8s
+        repo: runtime
+        base_ref: main
+      - org: aws-controllers-k8s
+        repo: ack-dev-skills
+        env: ACK_DEV_SKILLS_DIR
+`
+	if err := os.WriteFile(p, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := LoadWorkflowConfig(p)
+	if err != nil {
+		t.Fatalf("LoadWorkflowConfig: %v", err)
+	}
+	w, err := cfg.GetWorkflowByName("add-resource")
+	if err != nil {
+		t.Fatalf("GetWorkflowByName: %v", err)
+	}
+	if len(w.ExtraRefs) != 3 {
+		t.Fatalf("want 3 extra_refs, got %d", len(w.ExtraRefs))
+	}
+	if w.ExtraRefs[0].Repo != "code-generator" || w.ExtraRefs[0].Env != "CODEGEN_DIR" {
+		t.Errorf("ref[0] = %+v", w.ExtraRefs[0])
+	}
+	if w.ExtraRefs[1].Env != "" {
+		t.Errorf("ref[1] should have no env, got %q", w.ExtraRefs[1].Env)
+	}
+}
+
+// TestBuildExtraRefs verifies ref translation + path env injection, including
+// the base_ref/path_alias defaults and that only refs declaring Env emit a var.
+func TestBuildExtraRefs(t *testing.T) {
+	refs := []ExtraRef{
+		{Org: "aws-controllers-k8s", Repo: "code-generator", BaseRef: "main", Env: "CODEGEN_DIR"},
+		{Org: "aws-controllers-k8s", Repo: "runtime", BaseRef: "main"},
+		{Org: "aws-controllers-k8s", Repo: "ack-dev-skills", Env: "ACK_DEV_SKILLS_DIR"}, // base defaults
+	}
+	prowRefs, envs := buildExtraRefs(refs)
+
+	if len(prowRefs) != 3 {
+		t.Fatalf("want 3 refs, got %d", len(prowRefs))
+	}
+	if prowRefs[2].BaseRef != "main" {
+		t.Errorf("default base_ref: got %q want main", prowRefs[2].BaseRef)
+	}
+	if prowRefs[0].PathAlias != "github.com/aws-controllers-k8s/code-generator" {
+		t.Errorf("default path_alias: got %q", prowRefs[0].PathAlias)
+	}
+
+	if len(envs) != 2 {
+		t.Fatalf("want 2 env vars (only refs with Env), got %d", len(envs))
+	}
+	got := map[string]string{}
+	for _, e := range envs {
+		got[e.Name] = e.Value
+	}
+	want := map[string]string{
+		"CODEGEN_DIR":        "/home/prow/go/src/github.com/aws-controllers-k8s/code-generator",
+		"ACK_DEV_SKILLS_DIR": "/home/prow/go/src/github.com/aws-controllers-k8s/ack-dev-skills",
+	}
+	for k, v := range want {
+		if got[k] != v {
+			t.Errorf("env %s: got %q want %q", k, got[k], v)
+		}
+	}
+}
+
+func TestBuildExtraRefsEmpty(t *testing.T) {
+	r, e := buildExtraRefs(nil)
+	if r != nil || e != nil {
+		t.Errorf("want nil,nil for empty input; got refs=%v envs=%v", r, e)
+	}
+}

--- a/prow/plugins/agent-plugin/pkg/prowjob/generator.go
+++ b/prow/plugins/agent-plugin/pkg/prowjob/generator.go
@@ -42,14 +42,16 @@ type Generator interface {
 	) (*k8s.ProwJob, error)
 }
 
-// DefaultGenerator is the standard implementation of the Generator interface
+// DefaultGenerator is the standard implementation of the Generator interface.
+// It holds a WorkflowConfigLoader rather than a pre-parsed map so per-request
+// lookups pick up ConfigMap updates without a pod restart.
 type DefaultGenerator struct {
-	workflows map[string]*Workflow
+	loader *WorkflowConfigLoader
 }
 
-// NewGenerator creates a new ProwJob generator
-func NewGenerator(workflows map[string]*Workflow) Generator {
-	return &DefaultGenerator{workflows: workflows}
+// NewGenerator creates a new ProwJob generator backed by the given loader.
+func NewGenerator(loader *WorkflowConfigLoader) Generator {
+	return &DefaultGenerator{loader: loader}
 }
 
 // CreateWorkflowProwJob creates a ProwJob for a workflow execution
@@ -64,9 +66,12 @@ func (g *DefaultGenerator) CreateWorkflowProwJob(
 	s3Bucket string,
 ) (*k8s.ProwJob, error) {
 
-	workflow, exists := g.workflows[workflowName]
-	if !exists {
-		return nil, fmt.Errorf("workflow %s not found", workflowName)
+	// Look up the workflow through the loader on every call — this is what
+	// makes the plugin pick up an updated agent-workflow-config ConfigMap
+	// (e.g. a bumped image tag) without a pod restart.
+	workflow, err := g.loader.GetWorkflowByName(workflowName)
+	if err != nil {
+		return nil, err
 	}
 
 	envVars := []v1.EnvVar{
@@ -98,6 +103,13 @@ func (g *DefaultGenerator) CreateWorkflowProwJob(
 			},
 		})
 	}
+
+	// Translate the workflow's declared stable repo dependencies into Prow
+	// extra_refs (cloned by the clonerefs init container) and inject each ref's
+	// checkout path as an env var where requested, so the workflow reads the
+	// exact path the repo is cloned to.
+	extraRefs, refEnvVars := buildExtraRefs(workflow.ExtraRefs)
+	envVars = append(envVars, refEnvVars...)
 
 	// Add arguments as command-line flags
 	workflowArgs := make([]string, 0)
@@ -157,8 +169,15 @@ func (g *DefaultGenerator) CreateWorkflowProwJob(
 		Spec: k8s.ProwJobSpec{
 			Type:    k8s.PeriodicJob,
 			Agent:   k8s.KubernetesAgent,
-			Cluster: "default",
+			// Run on the dedicated build cluster for workload isolation from the
+			// Prow control plane. "build" is the kubeconfig context alias Prow
+			// registers for the build cluster (see jobs_config.yaml presubmit_cluster).
+			Cluster: "build",
 			Job:     fmt.Sprintf("agent-workflow-%s", workflowName),
+			// Stable repo dependencies (code-generator, runtime, ack-dev-skills,
+			// ...) cloned into the pod by the clonerefs init container. Empty when
+			// the workflow declares no extra_refs.
+			ExtraRefs: extraRefs,
 			// Add decoration config for S3 logs
 			DecorationConfig: &k8s.DecorationConfig{
 				Timeout:     &prowv1.Duration{Duration: timeoutDuration},
@@ -191,21 +210,27 @@ func (g *DefaultGenerator) CreateWorkflowProwJob(
 						Requests: v1.ResourceList{},
 						Limits:   v1.ResourceList{},
 					},
+					// Mount the SecretProviderClass so the Secrets Store CSI driver
+					// syncs the dedicated agent GitHub PAT (agent-github-pat-token)
+					// into a Kubernetes Secret using this pod's workflow-runner Pod
+					// Identity. GITHUB_TOKEN then reads that Secret via secretKeyRef.
 					VolumeMounts: []v1.VolumeMount{
 						{
-							Name:      "jobs-config",
-							MountPath: "/prow/jobs",
+							Name:      "agent-secrets",
+							MountPath: "/mnt/secrets-store",
 							ReadOnly:  true,
 						},
 					},
 				}},
 				Volumes: []v1.Volume{
 					{
-						Name: "jobs-config",
+						Name: "agent-secrets",
 						VolumeSource: v1.VolumeSource{
-							ConfigMap: &v1.ConfigMapVolumeSource{
-								LocalObjectReference: v1.LocalObjectReference{
-									Name: "jobs-config",
+							CSI: &v1.CSIVolumeSource{
+								Driver:   "secrets-store.csi.k8s.io",
+								ReadOnly: Bool(true),
+								VolumeAttributes: map[string]string{
+									"secretProviderClass": "agent-secrets",
 								},
 							},
 						},
@@ -213,6 +238,12 @@ func (g *DefaultGenerator) CreateWorkflowProwJob(
 				},
 			},
 		},
+	}
+
+	// For e2e-enabled workflows, provision the pod for kind-in-Docker-in-Docker.
+	// Provision the pod for kind-in-Docker-in-Docker when the workflow opts in.
+	if workflow.E2E {
+		applyE2EPodSettings(prowJob.Spec.PodSpec)
 	}
 
 	// Set resource limits if specified
@@ -241,4 +272,85 @@ func (g *DefaultGenerator) CreateWorkflowProwJob(
 	}
 
 	return prowJob, nil
+}
+
+// applyE2EPodSettings provisions the pod for kind-in-Docker-in-Docker. It is the
+// inline equivalent of the preset-dind-enabled and preset-kind-volume-mounts presets
+// (prow/config/templates/config-ConfigMap.yaml) plus the privileged securityContext
+// the integration-test jobs set inline. preset-test-config is not mirrored: roles/e2e.py
+// writes its own test_config.yaml. Safe to call on the single-container PodSpec
+// CreateWorkflowProwJob builds.
+func applyE2EPodSettings(podSpec *v1.PodSpec) {
+	if podSpec == nil || len(podSpec.Containers) == 0 {
+		return
+	}
+	c := &podSpec.Containers[0]
+
+	// Privileged is required for dockerd + kind node containers to run.
+	c.SecurityContext = &v1.SecurityContext{Privileged: Bool(true)}
+
+	// preset-dind-enabled: signal DinD to the harness and give dockerd its
+	// storage. docker-root (/var/lib/docker) is load-bearing for a modern
+	// dockerd; docker-graph is the legacy kubekins path, kept for fidelity.
+	c.Env = append(c.Env,
+		v1.EnvVar{Name: "DOCKER_IN_DOCKER_ENABLED", Value: "true"},
+		// Gate the e2e path in the workflow (roles/config.py reads this).
+		v1.EnvVar{Name: "RUN_E2E", Value: "true"},
+	)
+
+	hostPathDir := v1.HostPathDirectory
+	podSpec.Volumes = append(podSpec.Volumes,
+		v1.Volume{Name: "docker-graph", VolumeSource: v1.VolumeSource{EmptyDir: &v1.EmptyDirVolumeSource{}}},
+		v1.Volume{Name: "docker-root", VolumeSource: v1.VolumeSource{EmptyDir: &v1.EmptyDirVolumeSource{}}},
+		// preset-kind-volume-mounts: kind's nodes need the host's kernel modules
+		// and cgroup hierarchy.
+		v1.Volume{Name: "modules", VolumeSource: v1.VolumeSource{HostPath: &v1.HostPathVolumeSource{Path: "/lib/modules", Type: &hostPathDir}}},
+		v1.Volume{Name: "cgroup", VolumeSource: v1.VolumeSource{HostPath: &v1.HostPathVolumeSource{Path: "/sys/fs/cgroup", Type: &hostPathDir}}},
+	)
+	c.VolumeMounts = append(c.VolumeMounts,
+		v1.VolumeMount{Name: "docker-graph", MountPath: "/docker-graph"},
+		v1.VolumeMount{Name: "docker-root", MountPath: "/var/lib/docker"},
+		v1.VolumeMount{Name: "modules", MountPath: "/lib/modules", ReadOnly: true},
+		v1.VolumeMount{Name: "cgroup", MountPath: "/sys/fs/cgroup"},
+	)
+}
+
+// clonerefsSrcRoot is where Prow's clonerefs init container checks out refs
+// under the decorated pod's shared code volume (the upstream default GOPATH src
+// root). Extra-ref checkout paths are computed relative to it.
+const clonerefsSrcRoot = "/home/prow/go/src"
+
+// buildExtraRefs converts a workflow's declared stable repo dependencies into
+// Prow extra_refs and the env vars that expose each ref's checkout path. The
+// checkout path and the ref's PathAlias are derived from the same inputs, so the
+// path the workflow reads cannot drift from where clonerefs clones the repo.
+func buildExtraRefs(refs []ExtraRef) ([]prowv1.Refs, []v1.EnvVar) {
+	if len(refs) == 0 {
+		return nil, nil
+	}
+	prowRefs := make([]prowv1.Refs, 0, len(refs))
+	envVars := make([]v1.EnvVar, 0, len(refs))
+	for _, r := range refs {
+		baseRef := r.BaseRef
+		if baseRef == "" {
+			baseRef = "main"
+		}
+		pathAlias := r.PathAlias
+		if pathAlias == "" {
+			pathAlias = fmt.Sprintf("github.com/%s/%s", r.Org, r.Repo)
+		}
+		prowRefs = append(prowRefs, prowv1.Refs{
+			Org:       r.Org,
+			Repo:      r.Repo,
+			BaseRef:   baseRef,
+			PathAlias: pathAlias,
+		})
+		if r.Env != "" {
+			envVars = append(envVars, v1.EnvVar{
+				Name:  r.Env,
+				Value: fmt.Sprintf("%s/%s", clonerefsSrcRoot, pathAlias),
+			})
+		}
+	}
+	return prowRefs, envVars
 }

--- a/prow/plugins/agent-plugin/pkg/prowjob/workflow.go
+++ b/prow/plugins/agent-plugin/pkg/prowjob/workflow.go
@@ -39,11 +39,39 @@ type Workflow struct {
 	Environment            map[string]string        `yaml:"environment,omitempty" json:"environment,omitempty"`
 	EnvironmentFromSecrets map[string]*SecretKeyRef `yaml:"environmentFromSecrets,omitempty" json:"environmentFromSecrets,omitempty"`
 	Resources              *ResourceLimits          `yaml:"resources,omitempty" json:"resources,omitempty"`
+	// ExtraRefs are stable repo dependencies (e.g. code-generator, runtime,
+	// ack-dev-skills) mounted into the workflow pod by Prow's clonerefs init
+	// container. The dynamic service controller is NOT listed here — prow-job.sh
+	// forks and clones it per run. See ExtraRef.
+	ExtraRefs []ExtraRef `yaml:"extra_refs,omitempty" json:"extra_refs,omitempty"`
+	// E2E, when true, has the generator provision the pod for kind-in-Docker-in-Docker:
+	// privileged securityContext, DinD/kind volumes, and RUN_E2E. These mirror the
+	// preset-dind-enabled / preset-kind-volume-mounts presets but must be inlined —
+	// preset merging runs only in Prow's config loader, which submitting ProwJob CRs
+	// directly bypasses.
+	E2E bool `yaml:"e2e,omitempty" json:"e2e,omitempty"`
 }
 
 type SecretKeyRef struct {
 	Name string `yaml:"name" json:"name"`
 	Key  string `yaml:"key" json:"key"`
+}
+
+// ExtraRef declares a stable git repository dependency to clone into the
+// workflow pod as a Prow extra_ref (via the clonerefs init container).
+type ExtraRef struct {
+	Org  string `yaml:"org" json:"org"`
+	Repo string `yaml:"repo" json:"repo"`
+	// BaseRef is the branch/tag/sha to check out. Defaults to "main".
+	BaseRef string `yaml:"base_ref,omitempty" json:"base_ref,omitempty"`
+	// PathAlias overrides the checkout subpath under the clone root. Defaults to
+	// "github.com/<org>/<repo>".
+	PathAlias string `yaml:"path_alias,omitempty" json:"path_alias,omitempty"`
+	// Env, if set, names an environment variable injected into the workflow
+	// container with this ref's absolute checkout path. This keeps the path the
+	// workflow reads (e.g. CODEGEN_DIR) in sync with where clonerefs checks the
+	// repo out — both are derived from the same org/repo/path_alias.
+	Env string `yaml:"env,omitempty" json:"env,omitempty"`
 }
 
 // ResourceLimits defines resource constraints for workflows
@@ -111,4 +139,42 @@ func (wc *WorkflowConfig) GetWorkflowByName(name string) (*Workflow, error) {
 // GetWorkflowsMap returns the map of workflows
 func (wc *WorkflowConfig) GetWorkflowsMap() map[string]*Workflow {
 	return wc.Workflows
+}
+
+// WorkflowConfigLoader reads and parses the workflow config from disk on every
+// Get(), so the plugin picks up ConfigMap updates without a pod restart:
+// kubelet swaps the mounted file atomically via a symlink, and the next Get()
+// reads the new content.
+//
+// It deliberately does NOT cache a previously-parsed config. Serving a stale
+// config on a read/parse error would hide a broken ConfigMap — the plugin would
+// keep generating jobs from old config while the new one silently failed to
+// load. Instead every error is surfaced so a bad config fails the /agent
+// command loudly. Reads are cheap: /agent commands are infrequent and the file
+// is small.
+type WorkflowConfigLoader struct {
+	path string
+}
+
+// NewWorkflowConfigLoader returns a loader for the given path. It does not read
+// the file; callers should invoke Get() once at startup to fail fast on a bad
+// path or content.
+func NewWorkflowConfigLoader(path string) *WorkflowConfigLoader {
+	return &WorkflowConfigLoader{path: path}
+}
+
+// Get reads and parses the workflow config from disk. Any read/parse/validation
+// error is returned so a broken ConfigMap is not masked by a stale config.
+func (l *WorkflowConfigLoader) Get() (*WorkflowConfig, error) {
+	return LoadWorkflowConfig(l.path)
+}
+
+// GetWorkflowByName reads the current config from disk and looks up a workflow
+// by name.
+func (l *WorkflowConfigLoader) GetWorkflowByName(name string) (*Workflow, error) {
+	cfg, err := l.Get()
+	if err != nil {
+		return nil, err
+	}
+	return cfg.GetWorkflowByName(name)
 }

--- a/prow/plugins/agent-plugin/pkg/webhook/server.go
+++ b/prow/plugins/agent-plugin/pkg/webhook/server.go
@@ -37,7 +37,7 @@ type githubClient interface {
 // Server handles webhook requests
 type Server struct {
 	tokenGenerator   func() []byte
-	workflowConfig   *prowjobpkg.WorkflowConfig
+	workflowConfig   *prowjobpkg.WorkflowConfigLoader
 	prowJobGenerator prowjobpkg.Generator
 	githubClient     githubClient
 	k8sClient        kubernetes.Interface
@@ -49,7 +49,7 @@ type Server struct {
 
 // NewServer creates a new webhook server
 func NewServer(
-	workflowConfig *prowjobpkg.WorkflowConfig,
+	workflowConfig *prowjobpkg.WorkflowConfigLoader,
 	prowJobGenerator prowjobpkg.Generator,
 	githubClient githubClient,
 	tokenGenerator func() []byte,

--- a/prow/plugins/images_config.yaml
+++ b/prow/plugins/images_config.yaml
@@ -1,3 +1,3 @@
 image_repo: ${PROW_IMAGES_REPO_URI}
 images:
-    agent-plugin: agent-plugin-0.0.7
+    agent-plugin: agent-plugin-0.0.11


### PR DESCRIPTION
Issue #, if available:

Description of changes:
Upgrades the agent-plugin webhook so the ProwJobs it synthesizes run on the dedicated build cluster with the identity, repo checkouts, and DinD/kind setup the add-resource agent needs. The plugin's CreateWorkflowProwJob generator now:

- schedules agent workflows on the build cluster (Cluster: "build") as the workflow-runner ServiceAccount, mounting the agent-secrets CSI SecretProviderClass so GITHUB_TOKEN comes from agent-github-pat-token;
- loads workflow config through a WorkflowConfigLoader that re-reads the ConfigMap each request, so catalog/image bumps apply without a plugin pod restart;
- translates a workflow's declared extra_refs into Prow extra_refs and injects each ref's checkout-path env var (CODEGEN_DIR / ACK_DEV_SKILLS_DIR / TEST_INFRA_DIR);
- provisions the pod for kind-in-Docker-in-Docker (privileged + DinD/kind volumes + RUN_E2E=true) when a workflow sets e2e: true.

Bumps prow/plugins/images_config.yaml agent-plugin 0.0.7 → 0.0.11.

Files

- prow/plugins/agent-plugin/pkg/prowjob/{generator.go, workflow.go} — cluster/CSI/extra_refs/e2e logic + ExtraRef/E2E/WorkflowConfigLoader types.
- prow/plugins/agent-plugin/cmd/webhook-server/main.go, pkg/webhook/server.go — wire the loader.
- prow/plugins/agent-plugin/pkg/prowjob/{e2e_pod_test.go, extrarefs_test.go} — new unit tests.
- prow/plugins/images_config.yaml — agent-plugin 0.0.7 → 0.0.11.

Image build (two-phase — intentionally no deployment change here)

Per the repo's image flow, this PR bumps only images_config.yaml. On merge, the build-prow-images postsubmit builds/pushes agent-plugin-0.0.11 from this source, and a follow-up bot PR regenerates prow/plugins/deployments/agent-plugin/deployment.yaml to the new tag. Committing the deployment tag here would make ArgoCD try to pull an image that doesn't exist yet.

Depends on / sequencing

- Requires PR2 (build-cluster workflow-runner SA, agent-secrets SecretProviderClass, CSI addon, PodIdentityAssociation) — the generator unconditionally targets Cluster: build with that SA and CSI mount.
- After merge, /agent add-resource is expected to break until the rework PR lands the matching catalog + add-resource image: the new plugin reads the still-old catalog (default cluster, old secret name). This is the accepted, kept-short migration gap.

Validation

go build, go vet, and go test ./pkg/prowjob/... (including the new e2e_pod_test.go / extrarefs_test.go) pass. After merge, confirm the build-prow-images postsubmit builds agent-plugin-0.0.11, the bot deployment-bump PR merges, and the prow-plugins app syncs healthy with the plugin pod running 0.0.11.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
