### PR TITLE
fix: enable Helm OCI support for the ack e2e chart install

### DIFF
--- a/scripts/run-ack-e2e-tests.sh
+++ b/scripts/run-ack-e2e-tests.sh
@@ -71,6 +71,8 @@ install_released_controller() {
     region=$(get_aws_region)
 
     info_msg "Installing released $AWS_SERVICE controller chart $chart_version ..."
+    # The test image ships Helm 3.7, which keeps OCI support behind this flag.
+    export HELM_EXPERIMENTAL_OCI=1
     aws ecr-public get-login-password --region us-east-1 |
         helm registry login --username AWS --password-stdin public.ecr.aws 1>/dev/null
 


### PR DESCRIPTION
Description of changes:
The integration-test image ships Helm 3.7, which refuses oci:// refs unless
HELM_EXPERIMENTAL_OCI is set, so the chart install failed right after the
version resolved. Set it the same way the soak and release scripts do.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
